### PR TITLE
feature: socle de design (jetons, layout global, composants de base)

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,10 +1,8 @@
 # Accessibilité
 
-<!-- TODO : compléter avec les audits réalisés. -->
-
 ## Objectif
 
-Conformité **WCAG 2.1 AA** sur les parcours principaux.
+Conformité **WCAG 2.1 AA** / RGAA sur les parcours principaux.
 
 > Ces règles **priment sur les défauts d'un template UI importé** : un thème du
 > commerce qui désactive des règles a11y ou pose des `div` cliquables doit être
@@ -15,7 +13,8 @@ Conformité **WCAG 2.1 AA** sur les parcours principaux.
 - HTML **sémantique** d'abord (`nav`, `main`, `button`…) ; ARIA seulement en complément.
 - **Navigation clavier** complète : focus visible, ordre logique, pas de piège de focus.
 - **Formulaires** : chaque champ a un `label` associé ; erreurs annoncées (`aria-live`).
-- **Contrastes** : ratio ≥ 4.5:1 pour le texte courant.
+- **Contrastes** : ratio ≥ 4.5:1 pour le texte courant, ≥ 3:1 pour les composants
+  d'interface (bordures d'éléments interactifs, anneau de focus).
 - **Images** : `alt` pertinent (ou vide si décorative).
 
 ## Checklist par composant
@@ -24,14 +23,147 @@ Conformité **WCAG 2.1 AA** sur les parcours principaux.
 - [ ] Accessible et actionnable au **clavier** (Tab, Entrée/Espace) ; focus visible.
 - [ ] Champs de formulaire reliés à un `label` (`htmlFor`/`id`) ; erreur en `aria-live`.
 - [ ] Icône seule → `aria-label` ; image décorative → `alt=""`.
-- [ ] Contraste texte/fond ≥ 4.5:1 (≥ 3:1 pour le grand texte).
+- [ ] Contraste texte/fond ≥ 4.5:1 (≥ 3:1 pour le grand texte et les bordures utiles).
 - [ ] État dynamique (chargement, ouverture) annoncé (`aria-busy`, `aria-expanded`).
+- [ ] L'information n'est jamais portée par la **seule** couleur (WCAG 1.4.1).
+
+---
+
+## Contrastes mesurés — socle de design
+
+Les ratios ci-dessous ne sont pas déclaratifs : ils sont **recalculés à partir du fichier
+de jetons lui-même** (`front/src/@shared/styles/tokens.css`), selon la formule de
+luminance relative de WCAG 2.1. L'inventaire des combinaisons réellement produites par
+les composants vit dans `front/src/@shared/config/contrast-pairs.ts`, et les fonctions de
+calcul dans `front/src/@shared/utils/`.
+
+Toutes les combinaisons sont vérifiées **dans les deux thèmes**. Seuils appliqués :
+**4.5:1** pour le texte (WCAG 1.4.3), **3:1** pour les composants d'interface
+(WCAG 1.4.11).
+
+### Thème clair
+
+| Avant-plan | Arrière-plan | Ratio | Seuil | Usage |
+|---|---|---|---|---|
+| `--color-text` `#16181c` | `--color-background` `#fcfcfa` | **17.30:1** | 4.5 | texte courant sur le fond de page |
+| `--color-text` | `--color-surface` `#ffffff` | **17.77:1** | 4.5 | texte courant dans une carte |
+| `--color-text` | `--color-surface-muted` `#f1f0eb` | **15.58:1** | 4.5 | texte courant sur fond atténué |
+| `--color-text` | `--color-accent-soft` `#e3eef6` | **15.09:1** | 4.5 | texte courant sur pastille accent |
+| `--color-text-muted` `#54585f` | `--color-background` | **6.96:1** | 4.5 | texte secondaire sur le fond de page |
+| `--color-text-muted` | `--color-surface` | **7.15:1** | 4.5 | texte secondaire dans une carte |
+| `--color-text-muted` | `--color-surface-muted` | **6.26:1** | 4.5 | texte secondaire sur fond atténué |
+| `--color-accent` `#0b4f79` | `--color-background` | **8.49:1** | 4.5 | lien et navigation |
+| `--color-accent` | `--color-surface` | **8.72:1** | 4.5 | lien dans une carte |
+| `--color-accent` | `--color-surface-muted` | **7.64:1** | 4.5 | lien sur fond atténué |
+| `--color-accent` | `--color-accent-soft` | **7.40:1** | 4.5 | texte accent sur pastille |
+| `--color-accent-hover` `#083a5a` | `--color-background` | **11.59:1** | 4.5 | lien survolé |
+| `--color-accent-contrast` `#ffffff` | `--color-accent` | **8.72:1** | 4.5 | libellé d'un lien d'action plein |
+| `--color-accent-contrast` | `--color-accent-hover` | **11.91:1** | 4.5 | libellé d'un lien d'action survolé |
+| `--color-border-strong` `#8b8780` | `--color-background` | **3.48:1** | 3 | bordure d'action secondaire |
+| `--color-border-strong` | `--color-surface` | **3.57:1** | 3 | bordure interactive dans une carte |
+| `--color-border-strong` | `--color-surface-muted` | **3.13:1** | 3 | bordure interactive sur fond atténué |
+| `--color-focus` `#0b4f79` | `--color-background` | **8.49:1** | 3 | anneau de focus |
+| `--color-focus` | `--color-surface` | **8.72:1** | 3 | anneau de focus dans une carte |
+| `--color-focus` | `--color-surface-muted` | **7.64:1** | 3 | anneau de focus sur fond atténué |
+| `--color-accent` | `--color-background` | **8.49:1** | 3 | fond d'un lien d'action plein |
+
+### Thème sombre
+
+| Avant-plan | Arrière-plan | Ratio | Seuil | Usage |
+|---|---|---|---|---|
+| `--color-text` `#e9ebee` | `--color-background` `#0e1013` | **15.95:1** | 4.5 | texte courant sur le fond de page |
+| `--color-text` | `--color-surface` `#171a1f` | **14.60:1** | 4.5 | texte courant dans une carte |
+| `--color-text` | `--color-surface-muted` `#1f2329` | **13.21:1** | 4.5 | texte courant sur fond atténué |
+| `--color-text` | `--color-accent-soft` `#152430` | **13.25:1** | 4.5 | texte courant sur pastille accent |
+| `--color-text-muted` `#a7aeb8` | `--color-background` | **8.52:1** | 4.5 | texte secondaire sur le fond de page |
+| `--color-text-muted` | `--color-surface` | **7.80:1** | 4.5 | texte secondaire dans une carte |
+| `--color-text-muted` | `--color-surface-muted` | **7.06:1** | 4.5 | texte secondaire sur fond atténué |
+| `--color-accent` `#7fc1f0` | `--color-background` | **9.79:1** | 4.5 | lien et navigation |
+| `--color-accent` | `--color-surface` | **8.96:1** | 4.5 | lien dans une carte |
+| `--color-accent` | `--color-surface-muted` | **8.11:1** | 4.5 | lien sur fond atténué |
+| `--color-accent` | `--color-accent-soft` | **8.13:1** | 4.5 | texte accent sur pastille |
+| `--color-accent-hover` `#a8d5f7` | `--color-background` | **12.27:1** | 4.5 | lien survolé |
+| `--color-accent-contrast` `#07131c` | `--color-accent` | **9.64:1** | 4.5 | libellé d'un lien d'action plein |
+| `--color-accent-contrast` | `--color-accent-hover` | **12.09:1** | 4.5 | libellé d'un lien d'action survolé |
+| `--color-border-strong` `#6b7380` | `--color-background` | **3.98:1** | 3 | bordure d'action secondaire |
+| `--color-border-strong` | `--color-surface` | **3.65:1** | 3 | bordure interactive dans une carte |
+| `--color-border-strong` | `--color-surface-muted` | **3.30:1** | 3 | bordure interactive sur fond atténué |
+| `--color-focus` `#7fc1f0` | `--color-background` | **9.79:1** | 3 | anneau de focus |
+| `--color-focus` | `--color-surface` | **8.96:1** | 3 | anneau de focus dans une carte |
+| `--color-focus` | `--color-surface-muted` | **8.11:1** | 3 | anneau de focus sur fond atténué |
+| `--color-accent` | `--color-background` | **9.79:1** | 3 | fond d'un lien d'action plein |
+
+**Combinaison la plus juste** : `--color-border-strong` sur `--color-surface-muted` en
+thème clair, à **3.13:1** pour un seuil de 3. C'est la marge la plus faible du socle :
+toute modification de `--color-border-strong` ou de `--color-surface-muted` doit être
+revérifiée.
+
+`--color-border` (séparations décoratives) n'est volontairement pas soumis à un seuil :
+il ne porte aucune information et ne délimite aucun élément interactif. Le jour où une
+bordure devient nécessaire à la compréhension d'un contrôle, c'est
+`--color-border-strong` qu'il faut employer.
+
+## Navigation clavier — socle de design
+
+Vérifié sur le layout global (en-tête, contenu, pied de page) dans Chrome, en thème clair
+et en thème sombre.
+
+| Point | État | Détail |
+|-------|------|--------|
+| Lien d'évitement | OK | Premier élément focusable du document, avant l'en-tête. `href="#contenu"`, cible existante. |
+| Restitution du lien d'évitement | OK | Toujours rendu (`display: block`, `visibility: visible`) : seulement déplacé hors du champ visuel par une transformation, donc jamais retiré de l'ordre de tabulation. Il revient dans le viewport au focus (mesuré : de `top: -70px` à `top: 8px`). |
+| Déplacement réel du focus | OK | `main` porte `id="contenu"` et `tabIndex={-1}` : le saut déplace le focus, pas seulement le défilement. `tabIndex={-1}` n'ajoute pas de tabulation supplémentaire. |
+| Indicateur de focus | OK | Règle `:focus-visible` globale, `3px solid var(--color-focus)` avec 2 px de décalage. Jamais neutralisée nulle part dans le socle. |
+| Ordre de tabulation | OK | Ordre du DOM : lien d'évitement, identité, cinq entrées de navigation, puis le contenu, puis le pied de page. Aucun `tabindex` positif. |
+| Piège de focus | Sans objet | Aucun menu déroulant, aucune modale, aucun élément d'interface à état dans le socle. |
+| Régions | OK | Exactement un `header`, un `main`, un `footer` par page. |
+| Navigations nommées | OK | Deux `nav` distinctes, nommées « Navigation principale » et « Navigation de pied de page » — obligatoire dès qu'il y en a plusieurs. |
+| Page courante | OK | `aria-current="page"` posé par `NavLink`, doublé d'un soulignement épaissi : l'information n'est pas portée par la seule couleur (WCAG 1.4.1). |
+| Cible tactile | OK | 44 px de hauteur utile pour `ActionLink`, au-delà du minimum de 24 px de WCAG 2.5.8. |
+| Lien externe | OK | `ActionLink` avec `external` ajoute `rel="noopener noreferrer"` et une mention « (nouvelle fenêtre) » restituée aux lecteurs d'écran. |
+
+## Rendu de 320 px à 1920 px
+
+Mesuré dans Chrome (headless, pilotage CDP) sur dix largeurs — 320, 360, 390, 414, 600,
+768, 1024, 1280, 1440 et 1920 px — dans les **deux thèmes**.
+
+Résultat : **aucun défilement horizontal** (`documentElement.scrollWidth` égal à la
+largeur du viewport dans les 40 mesures), et aucun élément débordant du viewport.
+
+Trois garde-fous portent ce résultat, aucun ne consistant à masquer le débordement
+(`overflow-x: hidden` n'est employé nulle part) :
+
+- `overflow-wrap: break-word` sur `body` : une URL ou une adresse e-mail longue se coupe
+  au lieu d'élargir le document.
+- `min-width: 0` sur les conteneurs flex et grid : sans cela un enfant large impose sa
+  largeur au parent.
+- `max-width: 100%` sur tous les médias.
+
+Le thème suit `prefers-color-scheme` : fond mesuré à `rgb(252, 252, 250)` en clair et
+`rgb(14, 16, 19)` en sombre, sans intervention. L'attribut `data-theme` sur `:root`
+permet de forcer l'un ou l'autre si un sélecteur de thème est ajouté plus tard.
 
 ## Vérification
 
-- Lint accessibilité (règles a11y de Biome).
+- Lint accessibilité (règles a11y de Biome) — `make lint`.
+- Recalcul des contrastes depuis `tokens.css` (voir la section ci-dessus).
 - Audit manuel clavier + lecteur d'écran sur les parcours critiques.
+- Tests d'acceptation non fonctionnels : `tests/acceptance/uat/`.
 
 | Parcours | Audit | État |
 |----------|-------|------|
-| _TODO_ | | |
+| Layout global (en-tête, contenu, pied de page) | Contrastes recalculés, clavier, 320→1920 px, deux thèmes | Vérifié |
+| Page d'accueil | — | À faire (autre lot) |
+| Pages de services | — | À faire (autre lot) |
+| Parcours | — | À faire (autre lot) |
+| Formulaire de contact | — | À faire (autre lot) ; couleurs d'état à définir et à mesurer |
+
+## Restes à faire
+
+- **Lecteur d'écran** : le socle a été vérifié par mesure et par inspection du DOM, pas
+  encore avec VoiceOver ou NVDA. À faire avant la première mise en ligne.
+- **Couleurs d'état** (succès, alerte, erreur) : non définies, car aucun écran n'en
+  produit encore. À ajouter avec le formulaire de contact, et à soumettre au même
+  contrôle de contraste.
+- **Zoom 200 % et zoom texte seul** (WCAG 1.4.4 / 1.4.10) : non mesurés. La mise en page
+  étant fluide et exprimée en `rem`, le risque est faible, mais cela reste à vérifier.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,54 +1,196 @@
 # Design & UI
 
-<!-- TODO : compléter avec la charte du projet (bibliothèque UI, tokens réels). -->
+Socle visuel du site : jetons, layout global et composants de base. Tout ce qui est
+décrit ici vit dans `front/src/@shared/`.
+
+Le site est la démonstration de ce qu'il vend. Accessibilité et performance ne sont pas
+des finitions : elles sont dans les choix du socle, et les contrastes réellement mesurés
+sont consignés dans [`accessibility.md`](./accessibility.md).
 
 ## Principes
 
-- **Cohérence** : composants réutilisables, tokens de design centralisés
-  (couleurs, espacements, typographie).
-- **Responsive** : mobile-first, breakpoints documentés.
-- **Thème** : clair/sombre si pertinent.
-
-## Bibliothèque UI
-
-Choisir **une** bibliothèque et s'y tenir (ne pas mélanger plusieurs systèmes) :
-
-| Choix | Notes |
-|-------|-------|
-| _TODO (ex. shadcn/ui, PrimeReact, MUI…)_ | |
+- **Une seule source de vérité.** Toutes les valeurs visuelles sont des propriétés
+  personnalisées CSS déclarées dans `@shared/styles/tokens.css`. Aucun composant
+  n'écrit une couleur, un espacement ou une taille de police en dur.
+- **Fluide plutôt que par paliers.** Tailles de police et espacements majeurs
+  interpolent avec `clamp()` de 320 px à 1920 px. Il n'y a donc pas de « saut » de
+  typographie à une largeur donnée, et rien à re-régler pour une largeur intermédiaire.
+- **Le HTML d'abord.** Le socle n'embarque aucune bibliothèque d'interface et presque
+  aucun JavaScript : la navigation, le lien d'évitement et les cartes sont du HTML
+  sémantique stylé. Ce qui n'existe pas ne peut ni peser, ni casser l'accessibilité.
+- **Pur par défaut.** Un composant ne lit que ses props. Le seul composant qui dépend
+  d'autre chose est isolé dans `_notPure/` (voir plus bas).
 
 ## Stratégie de style
 
-Une **seule** stratégie par projet, cohérente avec [`frontend-practices.md`](./frontend-practices.md) :
+**CSS Modules colocalisés + propriétés personnalisées CSS.** Une seule stratégie, pas de
+mélange (conformément à [`frontend-practices.md`](./frontend-practices.md)).
 
-| Stratégie | Quand | Convention |
-|-----------|-------|------------|
-| **CSS Modules** | style scopé, sans lib CSS-in-JS | `Composant/index.module.css` co-localisé, classes en **BEM** |
-| **styled / emotion** | design system type MUI | thème centralisé, pas de style en dur |
-| **Utilitaire (Tailwind…)** | prototypage rapide, design tokens intégrés | classes utilitaires, `@apply` pour les motifs récurrents |
+| Choix | Alternatives écartées | Justification |
+|-------|----------------------|---------------|
+| CSS Modules | CSS-in-JS (styled, emotion) | Aucun runtime de style expédié au navigateur, aucun coût d'hydratation. Next.js extrait le CSS à la compilation. |
+| Propriétés personnalisées CSS pour les jetons | jetons en TypeScript | Le thème sombre devient une simple redéclaration de variables, sans re-rendu React ni duplication des composants. |
+| Aucune bibliothèque d'interface | shadcn/ui, MUI, Tailwind | Le socle tient en quatre composants et un layout. Importer un système entier pour cela coûterait en poids, en dépendances à suivre et en défauts d'accessibilité à corriger. À réévaluer si le catalogue grossit franchement. |
+| Pile de polices système | Google Fonts, polices auto-hébergées | Zéro requête réseau, zéro décalage de mise en page au chargement, et aucun appel à un service tiers — ce dernier point est aussi une contrainte RGPD du `README.md`. |
 
-Règles communes : style **co-localisé** avec le composant, **mobile-first**, valeurs
-issues des **tokens** ci-dessous (jamais de couleur/espacement en dur).
+Nommage des classes : une classe par rôle, en `camelCase` (contrainte des modules CSS
+consommés en TypeScript), fichier nommé d'après le composant
+(`Card/index.tsx` + `Card/card.module.css`).
 
-## Breakpoints
+## Jetons
 
-| Nom | Largeur min | Usage |
-|-----|-------------|-------|
-| `sm` | 640px | mobile paysage |
-| `md` | 768px | tablette |
-| `lg` | 1024px | desktop |
-| `xl` | 1280px | large desktop |
+Source : `front/src/@shared/styles/tokens.css`.
 
-<!-- Ajuster aux breakpoints réels de la bibliothèque UI retenue. -->
+### Couleurs
 
-## Tokens
+Douze jetons, déclarés à l'identique dans les deux thèmes. Les valeurs de contraste
+mesurées sont dans [`accessibility.md`](./accessibility.md).
 
-| Token | Valeur (exemple) | Usage |
-|-------|------------------|-------|
-| `color-primary` | `#2563eb` | actions principales, liens |
-| `color-danger` | `#dc2626` | erreurs, suppression |
-| `space-unit` | `8px` | base des espacements (multiples : 8/16/24…) |
-| `radius-base` | `6px` | arrondis de cartes/boutons |
-| `font-body` | `system-ui, sans-serif` | texte courant |
+| Jeton | Clair | Sombre | Usage |
+|-------|-------|--------|-------|
+| `--color-background` | `#fcfcfa` | `#0e1013` | fond de page |
+| `--color-surface` | `#ffffff` | `#171a1f` | cartes, éléments posés sur le fond |
+| `--color-surface-muted` | `#f1f0eb` | `#1f2329` | sections alternées, pied de page |
+| `--color-text` | `#16181c` | `#e9ebee` | texte courant |
+| `--color-text-muted` | `#54585f` | `#a7aeb8` | texte secondaire |
+| `--color-border` | `#dcdad3` | `#2c313a` | séparations décoratives |
+| `--color-border-strong` | `#8b8780` | `#6b7380` | bordure d'un élément interactif (seuil 3:1) |
+| `--color-accent` | `#0b4f79` | `#7fc1f0` | liens, actions, focus |
+| `--color-accent-hover` | `#083a5a` | `#a8d5f7` | survol |
+| `--color-accent-contrast` | `#ffffff` | `#07131c` | texte posé sur l'accent |
+| `--color-accent-soft` | `#e3eef6` | `#152430` | pastilles, fonds d'accent discrets |
+| `--color-focus` | `#0b4f79` | `#7fc1f0` | anneau de focus |
 
-<!-- Remplacer par les tokens réels du projet. -->
+**Palette retenue** : un bleu d'encre profond sur un blanc légèrement chaud. Une seule
+teinte d'accent, pas de couleur secondaire décorative — un site qui vend de l'ingénierie
+n'a pas besoin d'une palette, il a besoin d'être lisible et calme. Le fond clair est
+volontairement cassé (`#fcfcfa` plutôt que du blanc pur) pour réduire l'éblouissement,
+et le fond sombre n'est pas noir (`#0e1013`) pour limiter le halo autour du texte clair.
+
+Aucune couleur d'état (succès, alerte, erreur) n'est définie : le socle n'a pas encore
+d'écran qui en produise. Elles seront ajoutées avec le formulaire de contact, et devront
+passer par le même contrôle de contraste.
+
+### Typographie
+
+Pile système (`--font-sans`, `--font-mono`). Échelle fluide, interpolée de 320 px à
+1920 px.
+
+| Jeton | 320 px | 1920 px | Usage |
+|-------|--------|---------|-------|
+| `--font-size-xs` | 13 px | 13 px | mentions légales, pastilles |
+| `--font-size-sm` | 14 px | 14 px | navigation, texte de pied de page |
+| `--font-size-base` | 16 px | 18 px | texte courant |
+| `--font-size-md` | 18 px | 21 px | chapô de section |
+| `--font-size-lg` | 20 px | 24 px | `h4`, titre de carte |
+| `--font-size-xl` | 24 px | 32 px | `h3` |
+| `--font-size-2xl` | 30 px | 46 px | `h2` |
+| `--font-size-3xl` | 34 px | 58 px | `h1` |
+
+Les deux plus petites tailles sont fixes : les faire rétrécir en dessous de 13 px nuirait
+à la lisibilité sans rien gagner.
+
+Hauteurs de ligne : `--line-height-tight` (1.15, titres), `--line-height-snug` (1.3),
+`--line-height-normal` (1.6, texte courant). Graisses : 400 / 500 / 700.
+
+### Espacement
+
+Échelle géométrique fondée sur 0.25 rem : `--space-3xs` (4 px), `--space-2xs` (8),
+`--space-xs` (12), `--space-sm` (16), `--space-md` (24), `--space-lg` (32),
+`--space-xl` (48), `--space-2xl` (64), `--space-3xl` (96).
+
+Deux espacements fluides portent la mise en page :
+
+| Jeton | 320 px | 1920 px | Usage |
+|-------|--------|---------|-------|
+| `--space-gutter` | 16 px | 40 px | gouttière latérale du conteneur |
+| `--space-section` | 48 px | 96 px | respiration verticale d'une section |
+
+### Rayons, ombres, layout
+
+`--radius-sm` 4 px, `--radius-md` 8 px, `--radius-lg` 14 px, `--radius-pill`.
+
+`--shadow-sm` et `--shadow-md` sont doux en thème clair et nettement plus sombres en
+thème sombre, où une ombre diffuse ne se voit plus : c'est alors `--color-border` qui
+porte l'essentiel de la séparation entre surfaces.
+
+Largeurs utiles : `--layout-width-narrow` 44 rem (texte suivi),
+`--layout-width-default` 68 rem, `--layout-width-wide` 80 rem (en-tête, grilles).
+
+### Focus et mouvement
+
+`--focus-ring-width` 3 px, `--focus-ring-offset` 2 px, appliqués par une règle
+`:focus-visible` globale jamais neutralisée.
+
+`--transition-fast` 120 ms, `--transition-base` 200 ms. Sous
+`prefers-reduced-motion: reduce`, ces deux jetons passent à `0s` : toutes les animations
+du site étant construites dessus, cela suffit à les supprimer, sans sélecteur universel
+ni `!important`.
+
+## Points de rupture
+
+Le socle n'utilise **aucune media query de largeur**. La mise en page s'adapte par des
+mécanismes intrinsèques :
+
+| Mécanisme | Où | Effet |
+|-----------|-----|-------|
+| `clamp()` | typographie, gouttière, sections | interpolation continue de 320 à 1920 px |
+| `flex-wrap` | en-tête | la navigation passe sous l'identité quand la place manque |
+| `grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr))` | pied de page, grilles de cartes | le nombre de colonnes se déduit de la place disponible |
+
+Conséquence : il n'y a pas de largeur « non testée » entre deux paliers, et rien à
+ajouter pour une taille d'écran nouvelle. Les jetons `sm/md/lg/xl` du gabarit initial ont
+été retirés parce qu'ils n'étaient pas utilisés — une valeur non employée qui figure dans
+la doc finit toujours par être employée à tort.
+
+## Composants de base
+
+Chacun dans son dossier PascalCase, `index.tsx` + module CSS colocalisé.
+
+| Composant | Rôle | Points notables |
+|-----------|------|-----------------|
+| `Container` | borne la largeur, applique la gouttière | seul endroit qui décide d'une largeur maximale ; `width` = `narrow` / `default` / `wide` |
+| `ActionLink` | lien mis en avant comme un bouton | rend toujours un `a` — les appels à l'action du site sont des navigations ; `variant` = `primary` / `secondary` ; `external` ajoute `rel="noopener noreferrer"` et une mention « nouvelle fenêtre » pour les lecteurs d'écran |
+| `Card` | surface autonome titrée | volontairement non cliquable en entier : la zone d'action est explicite (`footer`), ce qui évite de superposer un lien invisible au texte |
+| `Section` | bloc de page titré | `id` obligatoire : il nomme la région via `aria-labelledby` et sert d'ancre ; `tone="muted"` pour alterner les fonds |
+| `SkipLink` | lien d'évitement | premier élément focusable du document |
+| `SiteHeader` | en-tête global | identité + navigation principale |
+| `SiteFooter` | pied de page global | promesse, navigation secondaire, appel à contact |
+
+`Card` et `Section` acceptent un niveau de titre explicite (`headingLevel`) : la
+hiérarchie des titres appartient à la page, pas au composant.
+
+### Pureté et `_notPure/`
+
+Tous les composants ci-dessus sont purs : leur rendu ne dépend que de leurs props, et ils
+s'exécutent côté serveur.
+
+Une seule exception, `SiteHeader/_notPure/NavLink/`. Ce composant lit la route courante
+(`usePathname`) pour poser `aria-current="page"` sur l'entrée active. Il dépend donc du
+contexte d'exécution et doit être rendu côté client. Le coût est assumé pour une raison
+précise : sans cet attribut, un lecteur d'écran ne distingue pas la page affichée des
+autres entrées du menu. La page courante n'est d'ailleurs jamais signalée par la seule
+couleur — un soulignement épaissi porte la même information.
+
+## Navigation
+
+La navigation principale est une liste de liens qui se replie sur plusieurs lignes en
+dessous d'environ 640 px, **pas** un menu déroulant. Cinq entrées tiennent sans cela, et
+ce choix supprime d'un coup l'état d'ouverture, le piège de focus, la gestion de la
+touche Échap et le JavaScript associé. L'en-tête n'est pas non plus collant : sur un
+téléphone, il mange sinon une part notable de la hauteur utile.
+
+Les entrées sont déclarées une seule fois dans `@shared/config/navigation.ts` et
+consommées par l'en-tête comme par le pied de page : les deux ne peuvent pas diverger.
+
+## Ajouter un jeton ou un composant
+
+1. Le jeton se déclare dans `tokens.css`, **dans les deux thèmes** — les deux blocs
+   doivent porter exactement le même jeu de jetons de couleur.
+2. Si le jeton introduit une nouvelle combinaison texte/fond ou bordure/fond, l'ajouter
+   à `@shared/config/contrast-pairs.ts`. C'est cet inventaire qui rend le contrôle de
+   contraste automatisable plutôt que déclaratif.
+3. Le composant va dans son dossier PascalCase avec son module CSS ; s'il lit autre chose
+   que ses props, il va dans `_notPure/`.
+4. Aucune valeur en dur : si le jeton nécessaire n'existe pas, c'est lui qu'il faut
+   ajouter, pas la valeur.

--- a/front/src/@shared/components/ActionLink/action-link.module.css
+++ b/front/src/@shared/components/ActionLink/action-link.module.css
@@ -1,0 +1,59 @@
+/* Lien d'action — la seule mise en avant cliquable du socle. */
+
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+
+  /* 44 px de hauteur utile : cible tactile confortable, au-delà du minimum
+   * WCAG 2.5.8 (24 px). */
+  min-height: 2.75rem;
+  padding: var(--space-2xs) var(--space-md);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-snug);
+  text-align: center;
+  text-decoration: none;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.primary {
+  background-color: var(--color-accent);
+  color: var(--color-accent-contrast);
+}
+
+.primary:hover {
+  background-color: var(--color-accent-hover);
+  color: var(--color-accent-contrast);
+}
+
+.secondary {
+  border-color: var(--color-border-strong);
+  background-color: transparent;
+  color: var(--color-accent);
+}
+
+.secondary:hover {
+  background-color: var(--color-accent-soft);
+  color: var(--color-accent-hover);
+}
+
+/* Complément lu par les lecteurs d'écran, invisible à l'œil. Jamais
+ * `display: none` ni `visibility: hidden` : le texte doit rester restitué. */
+.assistiveHint {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/front/src/@shared/components/ActionLink/index.tsx
+++ b/front/src/@shared/components/ActionLink/index.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import styles from './action-link.module.css'
+
+/** `primary` pour l'action attendue d'une page, `secondary` pour une alternative. */
+export type ActionLinkVariant = 'primary' | 'secondary'
+
+interface IActionLinkProps {
+  href: string
+  children: ReactNode
+  variant?: ActionLinkVariant
+  /** Ouvre dans un nouvel onglet et annonce l'ouverture aux lecteurs d'écran. */
+  external?: boolean
+  className?: string
+}
+
+/**
+ * Lien mis en avant visuellement comme un bouton. Le site étant une vitrine
+ * entièrement prérendue, ses appels à l'action sont des NAVIGATIONS : c'est un
+ * `a` qui est rendu, jamais un `button` — un `button` sans gestionnaire ne serait
+ * ni annoncé correctement, ni ouvrable dans un nouvel onglet.
+ *
+ * Les vraies commandes (envoi du formulaire de contact) relèveront d'un `button`
+ * dédié, qui réutilisera ces mêmes jetons.
+ */
+export function ActionLink({
+  href,
+  children,
+  variant = 'primary',
+  external = false,
+  className,
+}: IActionLinkProps) {
+  const classNames = [styles.action, styles[variant], className].filter(Boolean).join(' ')
+
+  if (external) {
+    return (
+      <a
+        className={classNames}
+        href={href}
+        rel="noopener noreferrer"
+        target="_blank"
+        data-variant={variant}
+      >
+        {children}
+        <span className={styles.assistiveHint}> (nouvelle fenêtre)</span>
+      </a>
+    )
+  }
+
+  return (
+    <Link className={classNames} href={href} data-variant={variant}>
+      {children}
+    </Link>
+  )
+}

--- a/front/src/@shared/components/Card/card.module.css
+++ b/front/src/@shared/components/Card/card.module.css
@@ -1,0 +1,47 @@
+/* Carte — surface autonome posée sur le fond de page. */
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  min-width: 0;
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.eyebrow {
+  align-self: flex-start;
+  padding: var(--space-3xs) var(--space-2xs);
+  border-radius: var(--radius-pill);
+  background-color: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.title {
+  font-size: var(--font-size-lg);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  color: var(--color-text-muted);
+}
+
+.footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+
+  /* Colle le pied de carte en bas quelles que soient les hauteurs voisines :
+   * dans une grille, les cartes restent alignées. */
+  margin-top: auto;
+  padding-top: var(--space-2xs);
+}

--- a/front/src/@shared/components/Card/index.tsx
+++ b/front/src/@shared/components/Card/index.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+import styles from './card.module.css'
+
+const HEADING_TAGS = { 2: 'h2', 3: 'h3', 4: 'h4' } as const
+
+/** Niveau de titre de la carte — à choisir selon la hiérarchie de la page. */
+export type CardHeadingLevel = 2 | 3 | 4
+
+interface ICardProps {
+  children: ReactNode
+  title?: string
+  /** Par défaut `3` : une carte vit normalement dans une `Section` titrée en `h2`. */
+  headingLevel?: CardHeadingLevel
+  /** Court libellé de catégorie affiché au-dessus du titre. */
+  eyebrow?: string
+  /** Zone d'actions, alignée en bas de carte. */
+  footer?: ReactNode
+  className?: string
+}
+
+/**
+ * Surface autonome regroupant un titre et son contenu. Volontairement NON
+ * cliquable dans son ensemble : la zone d'action est explicite (`footer`), ce qui
+ * évite de superposer un lien invisible au texte et de rendre celui-ci
+ * insélectionnable.
+ */
+export function Card({
+  children,
+  title,
+  headingLevel = 3,
+  eyebrow,
+  footer,
+  className,
+}: ICardProps) {
+  const Heading = HEADING_TAGS[headingLevel]
+  const classNames = [styles.card, className].filter(Boolean).join(' ')
+
+  return (
+    <article className={classNames}>
+      {eyebrow ? <p className={styles.eyebrow}>{eyebrow}</p> : null}
+      {title ? <Heading className={styles.title}>{title}</Heading> : null}
+      <div className={styles.body}>{children}</div>
+      {footer ? <div className={styles.footer}>{footer}</div> : null}
+    </article>
+  )
+}

--- a/front/src/@shared/components/Container/container.module.css
+++ b/front/src/@shared/components/Container/container.module.css
@@ -1,0 +1,24 @@
+/* Conteneur de largeur maximale — gouttière fluide, jamais de débordement. */
+
+.container {
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: var(--space-gutter);
+
+  /* Autorise le conteneur à rétrécir dans un parent flex ou grid : sans cela,
+   * un enfant large (tableau, bloc de code) imposerait sa largeur au document
+   * et provoquerait un défilement horizontal. */
+  min-width: 0;
+}
+
+.narrow {
+  max-width: var(--layout-width-narrow);
+}
+
+.default {
+  max-width: var(--layout-width-default);
+}
+
+.wide {
+  max-width: var(--layout-width-wide);
+}

--- a/front/src/@shared/components/Container/index.tsx
+++ b/front/src/@shared/components/Container/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+import styles from './container.module.css'
+
+/** Largeurs de lecture disponibles, définies par les jetons `--layout-width-*`. */
+export type ContainerWidth = 'narrow' | 'default' | 'wide'
+
+interface IContainerProps {
+  children: ReactNode
+  /**
+   * `narrow` pour du texte suivi (longueur de ligne confortable), `default` pour
+   * les sections courantes, `wide` pour l'en-tête et les grilles de cartes.
+   */
+  width?: ContainerWidth
+  className?: string
+}
+
+/**
+ * Centre son contenu, borne sa largeur et applique la gouttière latérale.
+ * C'est le seul endroit du socle qui décide de la largeur utile : aucun autre
+ * composant ne redéfinit `max-width` sur l'axe de la page.
+ */
+export function Container({ children, width = 'default', className }: IContainerProps) {
+  const classNames = [styles.container, styles[width], className].filter(Boolean).join(' ')
+
+  return <div className={classNames}>{children}</div>
+}

--- a/front/src/@shared/components/Section/index.tsx
+++ b/front/src/@shared/components/Section/index.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { Container, type ContainerWidth } from '../Container'
+import styles from './section.module.css'
+
+const HEADING_TAGS = { 2: 'h2', 3: 'h3' } as const
+
+export type SectionHeadingLevel = 2 | 3
+export type SectionTone = 'default' | 'muted'
+
+interface ISectionProps {
+  /**
+   * Ancre de la section. Obligatoire : elle sert d'identifiant au titre
+   * (`<id>-titre`), ce qui donne son nom accessible à la région, et de cible aux
+   * liens internes de la page.
+   */
+  id: string
+  title: string
+  children: ReactNode
+  headingLevel?: SectionHeadingLevel
+  /** Phrase d'introduction affichée sous le titre. */
+  lead?: string
+  width?: ContainerWidth
+  tone?: SectionTone
+}
+
+/**
+ * Bloc de page titré. Rend une région nommée par son propre titre
+ * (`aria-labelledby`) : la liste des régions restituée par un lecteur d'écran
+ * reprend donc le plan visible de la page, sans libellé à maintenir en double.
+ */
+export function Section({
+  id,
+  title,
+  children,
+  headingLevel = 2,
+  lead,
+  width = 'default',
+  tone = 'default',
+}: ISectionProps) {
+  const Heading = HEADING_TAGS[headingLevel]
+  const headingId = `${id}-titre`
+  const classNames = [styles.section, tone === 'muted' ? styles.muted : undefined]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <section aria-labelledby={headingId} className={classNames} id={id}>
+      <Container width={width}>
+        <div className={styles.header}>
+          <Heading id={headingId}>{title}</Heading>
+          {lead ? <p className={styles.lead}>{lead}</p> : null}
+        </div>
+        {children}
+      </Container>
+    </section>
+  )
+}

--- a/front/src/@shared/components/Section/section.module.css
+++ b/front/src/@shared/components/Section/section.module.css
@@ -1,0 +1,22 @@
+/* Section titrée — unité de rythme vertical de toutes les pages. */
+
+.section {
+  padding-block: var(--space-section);
+}
+
+.muted {
+  background-color: var(--color-surface-muted);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  margin-bottom: var(--space-lg);
+}
+
+.lead {
+  max-width: var(--layout-width-narrow);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+}

--- a/front/src/@shared/components/SiteFooter/index.tsx
+++ b/front/src/@shared/components/SiteFooter/index.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+import { siteNavigation } from '../../config/navigation'
+import { ActionLink } from '../ActionLink'
+import { Container } from '../Container'
+import styles from './site-footer.module.css'
+
+/**
+ * Pied de page appliqué à toutes les routes.
+ *
+ * Aucune date n'y est calculée : un « © 2026 » se périme, et lire l'horloge
+ * rendrait le composant impur pour un gain nul sur un site prérendu.
+ */
+export function SiteFooter() {
+  return (
+    <footer className={styles.footer}>
+      <Container width="wide">
+        <div className={styles.grid}>
+          <div className={styles.identity}>
+            <p className={styles.name}>Jérôme Marichez</p>
+            <p className={styles.tagline}>
+              Ingénieur logiciel à Lille. Un seul interlocuteur pour vos projets digitaux, sans
+              sous-traitance.
+            </p>
+            <ActionLink href="/contact" variant="secondary">
+              Me contacter
+            </ActionLink>
+          </div>
+
+          <nav aria-label="Navigation de pied de page">
+            <ul className={styles.list}>
+              {siteNavigation.map((link) => (
+                <li key={link.href}>
+                  <Link className={styles.link} href={link.href}>
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+
+        <p className={styles.legal}>© Jérôme Marichez</p>
+      </Container>
+    </footer>
+  )
+}

--- a/front/src/@shared/components/SiteFooter/site-footer.module.css
+++ b/front/src/@shared/components/SiteFooter/site-footer.module.css
@@ -1,0 +1,62 @@
+/* Pied de page — rappel de la promesse, navigation secondaire, appel à contact. */
+
+.footer {
+  margin-top: var(--space-section);
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-surface-muted);
+  padding-block: var(--space-xl);
+}
+
+/* Une seule colonne jusqu'à 640 px, deux au-delà : la grille se réorganise sans
+ * point de rupture en dur, la colonne d'identité gardant 18rem au minimum. */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-lg);
+}
+
+.identity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-xs);
+}
+
+.name {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.tagline {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.link {
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  text-decoration: none;
+}
+
+.link:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
+.legal {
+  margin-top: var(--space-lg);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}

--- a/front/src/@shared/components/SiteHeader/_notPure/NavLink/index.tsx
+++ b/front/src/@shared/components/SiteHeader/_notPure/NavLink/index.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { INavigationLink } from '../../../../interfaces/inavigation-link'
+import styles from './nav-link.module.css'
+
+/**
+ * NON PUR — d'où sa place dans `_notPure/`.
+ *
+ * Ce composant lit une donnée qui ne vient pas de ses props : la route courante,
+ * fournie par le routeur (`usePathname`). Il en dépend donc du contexte
+ * d'exécution et doit être rendu côté client.
+ *
+ * Ce coût est assumé pour une seule raison : sans `aria-current="page"`, un
+ * lecteur d'écran ne distingue pas la page affichée des autres entrées du menu
+ * (WCAG 2.4.8). C'est le seul composant du socle dans ce cas.
+ */
+export function NavLink({ href, label }: INavigationLink) {
+  const pathname = usePathname()
+  const isCurrentPage = pathname === href || pathname.startsWith(`${href}/`)
+
+  return (
+    <Link aria-current={isCurrentPage ? 'page' : undefined} className={styles.link} href={href}>
+      {label}
+    </Link>
+  )
+}

--- a/front/src/@shared/components/SiteHeader/_notPure/NavLink/nav-link.module.css
+++ b/front/src/@shared/components/SiteHeader/_notPure/NavLink/nav-link.module.css
@@ -1,0 +1,26 @@
+/* Lien de la navigation principale. */
+
+.link {
+  display: inline-block;
+  min-height: 1.5rem;
+  padding: var(--space-3xs) var(--space-2xs);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  text-decoration: none;
+}
+
+.link:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
+/* La page courante n'est jamais signalée par la seule couleur : le soulignement
+ * porte l'information pour qui ne perçoit pas la nuance (WCAG 1.4.1). */
+.link[aria-current="page"] {
+  color: var(--color-accent);
+  font-weight: var(--font-weight-medium);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.3em;
+}

--- a/front/src/@shared/components/SiteHeader/index.tsx
+++ b/front/src/@shared/components/SiteHeader/index.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import { siteNavigation } from '../../config/navigation'
+import { Container } from '../Container'
+import { NavLink } from './_notPure/NavLink'
+import styles from './site-header.module.css'
+
+/**
+ * En-tête appliqué à toutes les routes : identité à gauche, navigation
+ * principale à droite.
+ *
+ * La navigation est une simple liste de liens qui se replie sur plusieurs
+ * lignes en dessous de 640 px, au lieu d'un menu déroulant. Ce choix supprime
+ * d'un coup l'état d'ouverture, le piège de focus, la gestion de la touche
+ * Échap et le JavaScript associé : cinq liens tiennent sans cela.
+ */
+export function SiteHeader() {
+  return (
+    <header className={styles.header}>
+      <Container className={styles.inner} width="wide">
+        <Link className={styles.brand} href="/">
+          <span className={styles.brandName}>Jérôme Marichez</span>
+          <span className={styles.brandRole}>Ingénieur logiciel, Lille</span>
+        </Link>
+
+        <nav aria-label="Navigation principale" className={styles.nav}>
+          <ul className={styles.list}>
+            {siteNavigation.map((link) => (
+              <li key={link.href}>
+                <NavLink href={link.href} label={link.label} />
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </Container>
+    </header>
+  )
+}

--- a/front/src/@shared/components/SiteHeader/site-header.module.css
+++ b/front/src/@shared/components/SiteHeader/site-header.module.css
@@ -1,0 +1,52 @@
+/* En-tête du site — identité et navigation principale. */
+
+.header {
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-background);
+}
+
+.inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2xs) var(--space-md);
+  padding-block: var(--space-xs);
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.brandName {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.brandRole {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.brand:hover .brandName {
+  color: var(--color-accent-hover);
+}
+
+.nav {
+  min-width: 0;
+}
+
+/* Liste de liens qui se replie sur plusieurs lignes : pas de menu déroulant,
+ * donc aucun piège de focus, aucun état à gérer et aucun JavaScript. */
+.list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3xs) var(--space-sm);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}

--- a/front/src/@shared/components/SkipLink/index.tsx
+++ b/front/src/@shared/components/SkipLink/index.tsx
@@ -1,0 +1,23 @@
+import styles from './skip-link.module.css'
+
+interface ISkipLinkProps {
+  /** Identifiant de l'élément à atteindre ; celui-ci doit être focusable. */
+  targetId: string
+  children?: string
+}
+
+/**
+ * Premier élément focusable de la page : permet d'atteindre le contenu principal
+ * sans parcourir toute la navigation au clavier (WCAG 2.4.1).
+ *
+ * Il reste dans le flux et dans l'ordre de tabulation en permanence — il est
+ * seulement déplacé hors du champ visuel par une transformation, et revient à sa
+ * place dès qu'il reçoit le focus.
+ */
+export function SkipLink({ targetId, children = 'Aller au contenu principal' }: ISkipLinkProps) {
+  return (
+    <a className={styles.skipLink} href={`#${targetId}`}>
+      {children}
+    </a>
+  )
+}

--- a/front/src/@shared/components/SkipLink/skip-link.module.css
+++ b/front/src/@shared/components/SkipLink/skip-link.module.css
@@ -1,0 +1,25 @@
+/* Lien d'évitement — premier élément focusable du document. */
+
+.skipLink {
+  position: fixed;
+  top: var(--space-2xs);
+  left: var(--space-2xs);
+  z-index: var(--z-skip-link);
+  padding: var(--space-2xs) var(--space-sm);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface);
+  color: var(--color-accent);
+  font-weight: var(--font-weight-medium);
+  text-decoration: none;
+
+  /* Hors champ visuel mais TOUJOURS rendu et focusable : ni `display: none`,
+   * ni `visibility: hidden`, qui le retireraient de l'ordre de tabulation. */
+  transform: translateY(calc(-100% - var(--space-lg)));
+  transition: transform var(--transition-fast);
+}
+
+.skipLink:focus-visible,
+.skipLink:focus {
+  transform: translateY(0);
+}

--- a/front/src/@shared/config/contrast-pairs.ts
+++ b/front/src/@shared/config/contrast-pairs.ts
@@ -1,0 +1,152 @@
+import type { IContrastRequirement } from '../interfaces/icontrast-requirement'
+
+/**
+ * Inventaire des combinaisons texte / fond et bordure / fond réellement produites
+ * par les composants du socle. Chaque entrée est une promesse vérifiable : les
+ * valeurs sont lues dans `@shared/styles/tokens.css` et le ratio est recalculé,
+ * pour les deux thèmes.
+ *
+ * Ajouter une combinaison ici dès qu'un composant en introduit une nouvelle —
+ * c'est ce qui empêche une régression de contraste de passer en revue.
+ */
+export const CONTRAST_REQUIREMENTS: readonly IContrastRequirement[] = [
+  // ------------------------------------------------ Texte (WCAG 1.4.3, 4.5:1)
+  {
+    foreground: 'color-text',
+    background: 'color-background',
+    minimumRatio: 4.5,
+    usage: 'texte courant sur le fond de page',
+  },
+  {
+    foreground: 'color-text',
+    background: 'color-surface',
+    minimumRatio: 4.5,
+    usage: 'texte courant dans une carte',
+  },
+  {
+    foreground: 'color-text',
+    background: 'color-surface-muted',
+    minimumRatio: 4.5,
+    usage: 'texte courant sur fond atténué (pied de page)',
+  },
+  {
+    foreground: 'color-text',
+    background: 'color-accent-soft',
+    minimumRatio: 4.5,
+    usage: 'texte courant sur pastille accent',
+  },
+  {
+    foreground: 'color-text-muted',
+    background: 'color-background',
+    minimumRatio: 4.5,
+    usage: 'texte secondaire sur le fond de page',
+  },
+  {
+    foreground: 'color-text-muted',
+    background: 'color-surface',
+    minimumRatio: 4.5,
+    usage: 'texte secondaire dans une carte',
+  },
+  {
+    foreground: 'color-text-muted',
+    background: 'color-surface-muted',
+    minimumRatio: 4.5,
+    usage: 'texte secondaire sur fond atténué',
+  },
+  {
+    foreground: 'color-accent',
+    background: 'color-background',
+    minimumRatio: 4.5,
+    usage: 'lien et navigation sur le fond de page',
+  },
+  {
+    foreground: 'color-accent',
+    background: 'color-surface',
+    minimumRatio: 4.5,
+    usage: 'lien dans une carte',
+  },
+  {
+    foreground: 'color-accent',
+    background: 'color-surface-muted',
+    minimumRatio: 4.5,
+    usage: 'lien sur fond atténué',
+  },
+  {
+    foreground: 'color-accent',
+    background: 'color-accent-soft',
+    minimumRatio: 4.5,
+    usage: 'texte accent sur pastille accent',
+  },
+  {
+    foreground: 'color-accent-hover',
+    background: 'color-background',
+    minimumRatio: 4.5,
+    usage: 'lien survolé sur le fond de page',
+  },
+  {
+    foreground: 'color-accent-contrast',
+    background: 'color-accent',
+    minimumRatio: 4.5,
+    usage: "libellé d'un lien d'action plein",
+  },
+  {
+    foreground: 'color-accent-contrast',
+    background: 'color-accent-hover',
+    minimumRatio: 4.5,
+    usage: "libellé d'un lien d'action plein survolé",
+  },
+
+  // ------------------------------- Composants d'interface (WCAG 1.4.11, 3:1)
+  {
+    foreground: 'color-border-strong',
+    background: 'color-background',
+    minimumRatio: 3,
+    usage: "bordure d'un lien d'action secondaire sur le fond",
+  },
+  {
+    foreground: 'color-border-strong',
+    background: 'color-surface',
+    minimumRatio: 3,
+    usage: "bordure d'un élément interactif dans une carte",
+  },
+  {
+    foreground: 'color-border-strong',
+    background: 'color-surface-muted',
+    minimumRatio: 3,
+    usage: "bordure d'un élément interactif sur fond atténué",
+  },
+  {
+    foreground: 'color-focus',
+    background: 'color-background',
+    minimumRatio: 3,
+    usage: 'anneau de focus sur le fond de page',
+  },
+  {
+    foreground: 'color-focus',
+    background: 'color-surface',
+    minimumRatio: 3,
+    usage: 'anneau de focus dans une carte',
+  },
+  {
+    foreground: 'color-focus',
+    background: 'color-surface-muted',
+    minimumRatio: 3,
+    usage: 'anneau de focus sur fond atténué',
+  },
+  {
+    foreground: 'color-accent',
+    background: 'color-background',
+    minimumRatio: 3,
+    usage: "fond d'un lien d'action plein sur le fond de page",
+  },
+]
+
+/**
+ * Sélecteurs des deux thèmes dans `@shared/styles/tokens.css`. Les guillemets
+ * doubles sont ceux que produit le formateur Biome : ils doivent correspondre
+ * au fichier au caractère près, la lecture des jetons étant purement textuelle.
+ */
+export const THEME_SELECTORS = {
+  clair: ':root',
+  sombre: ':root[data-theme="dark"]',
+} as const

--- a/front/src/@shared/config/navigation.ts
+++ b/front/src/@shared/config/navigation.ts
@@ -1,0 +1,23 @@
+import type { INavigationLink } from '../interfaces/inavigation-link'
+
+/**
+ * Identifiant du conteneur de contenu principal. Sert de cible au lien
+ * d'évitement de l'en-tête ; le `main` correspondant est rendu focusable pour
+ * que le saut déplace réellement le focus, et pas seulement le défilement.
+ */
+export const MAIN_CONTENT_ID = 'contenu'
+
+/**
+ * Navigation principale du site : les trois offres, le parcours, le contact.
+ * Ordre volontaire — les offres d'abord (ce qui est vendu), le parcours ensuite
+ * (ce qui le rend crédible), le contact en dernier (l'action attendue).
+ * Les routes correspondantes sont créées par d'autres lots ; les libellés, eux,
+ * sont figés ici pour que l'en-tête et le pied de page ne divergent jamais.
+ */
+export const siteNavigation: readonly INavigationLink[] = [
+  { href: '/services/ingenierie-web', label: 'Ingénierie web' },
+  { href: '/services/data-ia', label: 'Data et IA' },
+  { href: '/services/seo-sea', label: 'SEO et SEA' },
+  { href: '/parcours', label: 'Parcours' },
+  { href: '/contact', label: 'Contact' },
+]

--- a/front/src/@shared/interfaces/icontrast-requirement.ts
+++ b/front/src/@shared/interfaces/icontrast-requirement.ts
@@ -1,0 +1,14 @@
+/**
+ * Exigence de contraste portant sur une combinaison de jetons de couleur.
+ * Les champs `foreground` et `background` désignent des NOMS de jetons
+ * (sans les deux tirets), jamais des valeurs : les valeurs restent définies
+ * une seule fois, dans `@shared/styles/tokens.css`.
+ */
+export interface IContrastRequirement {
+  readonly foreground: string
+  readonly background: string
+  /** 4.5 pour du texte courant (WCAG 1.4.3), 3 pour un composant d'interface (1.4.11). */
+  readonly minimumRatio: number
+  /** Où cette combinaison apparaît réellement dans le socle. */
+  readonly usage: string
+}

--- a/front/src/@shared/interfaces/inavigation-link.ts
+++ b/front/src/@shared/interfaces/inavigation-link.ts
@@ -1,0 +1,9 @@
+/**
+ * Lien de navigation du site (en-tête et pied de page).
+ * `label` est le libellé lu par l'utilisateur et par les technologies d'assistance :
+ * il doit rester explicite hors contexte (critère WCAG 2.4.4).
+ */
+export interface INavigationLink {
+  readonly href: string
+  readonly label: string
+}

--- a/front/src/@shared/styles/globals.css
+++ b/front/src/@shared/styles/globals.css
@@ -1,0 +1,149 @@
+/* globals.css — jeromemarichez2026
+ * Seule feuille de style globale du site : remise à zéro minimale, styles des
+ * éléments HTML de base et squelette du layout. Tout le reste est colocalisé
+ * dans le module CSS de son composant. Les valeurs viennent de tokens.css.
+ */
+
+@import "./tokens.css";
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+html {
+  /* Empêche l'agrandissement automatique du texte en paysage sur iOS. */
+  -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100svh;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+
+  /* Garantit qu'aucun mot long (URL, adresse e-mail) ne pousse la largeur du
+   * document au-delà du viewport à 320 px. C'est la seule protection contre le
+   * défilement horizontal : on ne masque jamais l'overflow. */
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  flex: 1 1 auto;
+
+  /* Cible du lien d'évitement : laisse respirer le haut du contenu au moment du
+   * saut de focus. */
+  scroll-margin-top: var(--space-md);
+}
+
+/* Aucun média ne dépasse son conteneur, quelle que soit la largeur du viewport. */
+img,
+svg,
+video,
+canvas,
+iframe {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--letter-spacing-tight);
+  text-wrap: balance;
+}
+
+h1 {
+  font-size: var(--font-size-3xl);
+}
+
+h2 {
+  font-size: var(--font-size-2xl);
+}
+
+h3 {
+  font-size: var(--font-size-xl);
+}
+
+h4 {
+  font-size: var(--font-size-lg);
+}
+
+p,
+li {
+  text-wrap: pretty;
+}
+
+/* Longueur de ligne confortable pour le texte courant (environ 70 caractères). */
+p {
+  max-width: 70ch;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+  transition: color var(--transition-fast);
+}
+
+a:hover {
+  color: var(--color-accent-hover);
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+ul,
+ol {
+  padding-left: var(--space-md);
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--color-border);
+}
+
+/* Un seul indicateur de focus pour tout le site, jamais supprimé. */
+:focus-visible {
+  outline: var(--focus-ring-width) solid var(--color-focus);
+  outline-offset: var(--focus-ring-offset);
+}
+
+::selection {
+  background-color: var(--color-accent-soft);
+  color: var(--color-text);
+}
+
+/* Mouvement réduit. Toutes les animations du site passent par les jetons
+ * `--transition-*` : les neutraliser à la source suffit, sans sélecteur universel
+ * ni `!important`. C'est un bénéfice direct de la règle « aucune valeur en dur ». */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-fast: 0s;
+    --transition-base: 0s;
+  }
+
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/front/src/@shared/styles/tokens.css
+++ b/front/src/@shared/styles/tokens.css
@@ -1,0 +1,147 @@
+/* tokens.css — jeromemarichez2026
+ * SOURCE DE VÉRITÉ UNIQUE des jetons de design. Aucune couleur, aucun espacement,
+ * aucune taille de police ne doit être écrit en dur ailleurs : tout composant lit
+ * ces propriétés personnalisées.
+ *
+ * Thèmes : le bloc `:root` porte le thème clair, le bloc `:root[data-theme='dark']`
+ * porte le thème sombre. La media query `prefers-color-scheme: dark` applique le
+ * thème sombre par défaut, sauf si `data-theme` force explicitement l'autre sens.
+ * Les deux blocs déclarent EXACTEMENT les mêmes jetons de couleur : c'est ce qui
+ * rend la vérification de contraste automatisable (docs/accessibility.md).
+ *
+ * Contrastes mesurés : docs/accessibility.md.
+ */
+
+:root {
+  color-scheme: light;
+
+  /* ---------------------------------------------------------- Palette claire */
+  --color-background: #fcfcfa;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f1f0eb;
+  --color-text: #16181c;
+  --color-text-muted: #54585f;
+  --color-border: #dcdad3;
+  --color-border-strong: #8b8780;
+  --color-accent: #0b4f79;
+  --color-accent-hover: #083a5a;
+  --color-accent-contrast: #ffffff;
+  --color-accent-soft: #e3eef6;
+  --color-focus: #0b4f79;
+
+  /* ------------------------------------------------------------- Typographie */
+  /* Pile système : aucune requête réseau, aucun décalage de mise en page au
+   * chargement, aucun appel à un service tiers (contrainte RGPD du README). */
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", roboto, "Helvetica Neue", arial, sans-serif;
+  --font-mono: ui-monospace, sfmono-regular, "SF Mono", menlo, consolas, monospace;
+
+  /* Échelle fluide : chaque taille interpole linéairement de 320 px à 1920 px.
+   * Une seule échelle couvre toute la plage, sans point de rupture typographique. */
+  --font-size-xs: 0.8125rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: clamp(1rem, 0.975rem + 0.125vw, 1.125rem);
+  --font-size-md: clamp(1.125rem, 1.0875rem + 0.1875vw, 1.3125rem);
+  --font-size-lg: clamp(1.25rem, 1.2rem + 0.25vw, 1.5rem);
+  --font-size-xl: clamp(1.5rem, 1.4rem + 0.5vw, 2rem);
+  --font-size-2xl: clamp(1.875rem, 1.675rem + 1vw, 2.875rem);
+  --font-size-3xl: clamp(2.125rem, 1.825rem + 1.5vw, 3.625rem);
+
+  --line-height-tight: 1.15;
+  --line-height-snug: 1.3;
+  --line-height-normal: 1.6;
+
+  --letter-spacing-tight: -0.02em;
+  --letter-spacing-wide: 0.06em;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+
+  /* --------------------------------------------------------------- Espacement */
+  /* Échelle géométrique fondée sur 0.25rem (4 px), rythme vertical de 8 px. */
+  --space-3xs: 0.25rem;
+  --space-2xs: 0.5rem;
+  --space-xs: 0.75rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --space-2xl: 4rem;
+  --space-3xl: 6rem;
+
+  /* Espacements fluides : gouttière latérale et respiration verticale des sections. */
+  --space-gutter: clamp(1rem, 0.7rem + 1.5vw, 2.5rem);
+  --space-section: clamp(3rem, 2.4rem + 3vw, 6rem);
+
+  /* ------------------------------------------------------------------ Rayons */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.875rem;
+  --radius-pill: 999rem;
+
+  /* ------------------------------------------------------------------ Ombres */
+  --shadow-sm: 0 1px 2px rgb(22 24 28 / 6%), 0 1px 3px rgb(22 24 28 / 8%);
+  --shadow-md: 0 2px 4px rgb(22 24 28 / 5%), 0 8px 24px rgb(22 24 28 / 9%);
+
+  /* ------------------------------------------------------------------ Layout */
+  --layout-width-narrow: 44rem;
+  --layout-width-default: 68rem;
+  --layout-width-wide: 80rem;
+
+  /* -------------------------------------------------------------------- Focus */
+  --focus-ring-width: 3px;
+  --focus-ring-offset: 2px;
+
+  /* ------------------------------------------------------------------- Autres */
+  --transition-fast: 120ms ease;
+  --transition-base: 200ms ease;
+  --z-header: 10;
+  --z-skip-link: 100;
+}
+
+/* Thème sombre — mêmes jetons, valeurs recalculées pour tenir AA sur fond sombre. */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-background: #0e1013;
+  --color-surface: #171a1f;
+  --color-surface-muted: #1f2329;
+  --color-text: #e9ebee;
+  --color-text-muted: #a7aeb8;
+  --color-border: #2c313a;
+  --color-border-strong: #6b7380;
+  --color-accent: #7fc1f0;
+  --color-accent-hover: #a8d5f7;
+  --color-accent-contrast: #07131c;
+  --color-accent-soft: #152430;
+  --color-focus: #7fc1f0;
+
+  /* Sur fond sombre une ombre diffuse ne se voit plus : on l'assombrit et on
+   * s'appuie davantage sur --color-border pour séparer les surfaces. */
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 40%);
+  --shadow-md: 0 2px 4px rgb(0 0 0 / 35%), 0 10px 28px rgb(0 0 0 / 50%);
+}
+
+/* Préférence système : thème sombre par défaut, sauf `data-theme='light'` explicite. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --color-background: #0e1013;
+    --color-surface: #171a1f;
+    --color-surface-muted: #1f2329;
+    --color-text: #e9ebee;
+    --color-text-muted: #a7aeb8;
+    --color-border: #2c313a;
+    --color-border-strong: #6b7380;
+    --color-accent: #7fc1f0;
+    --color-accent-hover: #a8d5f7;
+    --color-accent-contrast: #07131c;
+    --color-accent-soft: #152430;
+    --color-focus: #7fc1f0;
+
+    --shadow-sm: 0 1px 2px rgb(0 0 0 / 40%);
+    --shadow-md: 0 2px 4px rgb(0 0 0 / 35%), 0 10px 28px rgb(0 0 0 / 50%);
+  }
+}

--- a/front/src/@shared/utils/color.ts
+++ b/front/src/@shared/utils/color.ts
@@ -1,0 +1,59 @@
+/**
+ * Calcul de contraste WCAG 2.1 (§1.4.3 texte, §1.4.11 composants d'interface).
+ * Fonctions pures, sans état : elles servent à vérifier que les jetons de
+ * couleur du socle tiennent le niveau AA, plutôt que de l'affirmer.
+ * Référence : https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+
+const HEX_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i
+
+/** Convertit une couleur hexadécimale (`#abc` ou `#aabbcc`) en canaux 0-255. */
+export function parseHexColor(hex: string): readonly [number, number, number] {
+  const value = hex.trim()
+  if (!HEX_PATTERN.test(value)) {
+    throw new Error(`Couleur hexadécimale invalide : « ${hex} »`)
+  }
+
+  const digits = value.slice(1)
+  const expanded =
+    digits.length === 3
+      ? digits
+          .split('')
+          .map((digit) => digit + digit)
+          .join('')
+      : digits
+
+  return [
+    Number.parseInt(expanded.slice(0, 2), 16),
+    Number.parseInt(expanded.slice(2, 4), 16),
+    Number.parseInt(expanded.slice(4, 6), 16),
+  ]
+}
+
+/** Linéarisation d'un canal sRGB 0-255 vers l'espace linéaire 0-1. */
+function linearizeChannel(channel: number): number {
+  const ratio = channel / 255
+  return ratio <= 0.03928 ? ratio / 12.92 : ((ratio + 0.055) / 1.055) ** 2.4
+}
+
+/** Luminance relative d'une couleur hexadécimale, entre 0 (noir) et 1 (blanc). */
+export function relativeLuminance(hex: string): number {
+  const [red, green, blue] = parseHexColor(hex)
+  return (
+    0.2126 * linearizeChannel(red) +
+    0.7152 * linearizeChannel(green) +
+    0.0722 * linearizeChannel(blue)
+  )
+}
+
+/**
+ * Ratio de contraste entre deux couleurs, de 1:1 (identiques) à 21:1
+ * (noir sur blanc). L'ordre des arguments n'a pas d'importance.
+ */
+export function contrastRatio(foreground: string, background: string): number {
+  const first = relativeLuminance(foreground)
+  const second = relativeLuminance(background)
+  const lighter = Math.max(first, second)
+  const darker = Math.min(first, second)
+  return (lighter + 0.05) / (darker + 0.05)
+}

--- a/front/src/@shared/utils/css-custom-properties.ts
+++ b/front/src/@shared/utils/css-custom-properties.ts
@@ -1,0 +1,70 @@
+/**
+ * Lecture des propriétés personnalisées CSS d'un bloc de règles, à partir du
+ * texte d'une feuille de style. Fonctions pures : elles permettent de vérifier
+ * les jetons de `@shared/styles/tokens.css` sans navigateur ni exécution du CSS.
+ *
+ * Volontairement limité à ce dont le socle a besoin — un bloc, ses déclarations
+ * `--nom: valeur` — plutôt que d'embarquer un analyseur CSS complet.
+ */
+
+const DECLARATION_PATTERN = /(--[a-z0-9-]+)\s*:\s*([^;}]+)/gi
+
+/**
+ * Extrait le contenu textuel du bloc `{ … }` qui suit immédiatement `selector`.
+ * Le sélecteur doit être suivi (aux espaces près) d'une accolade ouvrante, ce qui
+ * évite de confondre `:root` avec `:root[data-theme='dark']`.
+ */
+export function extractRuleBlock(css: string, selector: string): string {
+  let searchFrom = 0
+
+  while (searchFrom < css.length) {
+    const start = css.indexOf(selector, searchFrom)
+    if (start === -1) break
+
+    let cursor = start + selector.length
+    while (cursor < css.length && /\s/.test(css.charAt(cursor))) cursor += 1
+
+    if (css.charAt(cursor) === '{') {
+      return readBalancedBlock(css, cursor)
+    }
+    searchFrom = start + selector.length
+  }
+
+  throw new Error(`Bloc CSS introuvable pour le sélecteur « ${selector} »`)
+}
+
+/** Lit le contenu d'un bloc en équilibrant les accolades, à partir du `{` ouvrant. */
+function readBalancedBlock(css: string, openingBrace: number): string {
+  let depth = 0
+
+  for (let cursor = openingBrace; cursor < css.length; cursor += 1) {
+    const character = css.charAt(cursor)
+    if (character === '{') depth += 1
+    if (character === '}') {
+      depth -= 1
+      if (depth === 0) return css.slice(openingBrace + 1, cursor)
+    }
+  }
+
+  throw new Error('Bloc CSS non terminé : accolade fermante manquante')
+}
+
+/**
+ * Renvoie les propriétés personnalisées déclarées par `selector`, sous la forme
+ * `nom` (sans les deux tirets) vers valeur nettoyée. Les commentaires du bloc
+ * sont ignorés.
+ */
+export function extractCustomProperties(
+  css: string,
+  selector: string,
+): ReadonlyMap<string, string> {
+  const block = extractRuleBlock(css, selector).replace(/\/\*[\s\S]*?\*\//g, '')
+  const properties = new Map<string, string>()
+
+  for (const [, name, value] of block.matchAll(DECLARATION_PATTERN)) {
+    if (name === undefined || value === undefined) continue
+    properties.set(name.slice(2), value.trim())
+  }
+
+  return properties
+}

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,6 +1,13 @@
 // src/app/layout.tsx — jeromemarichez2026
 // pages/app ne fait QUE le routage : les sections d'écran vivent dans src/views/.
+// Ce layout se contente d'assembler le socle de @shared et de l'appliquer à
+// toutes les routes.
 import type { ReactNode } from 'react'
+import { SiteFooter } from '@/@shared/components/SiteFooter'
+import { SiteHeader } from '@/@shared/components/SiteHeader'
+import { SkipLink } from '@/@shared/components/SkipLink'
+import { MAIN_CONTENT_ID } from '@/@shared/config/navigation'
+import '@/@shared/styles/globals.css'
 
 export const metadata = {
   title: 'Jérôme Marichez — Ingénieur logiciel à Lille',
@@ -11,7 +18,18 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="fr">
-      <body>{children}</body>
+      <body>
+        {/* Premier élément focusable du document, avant l'en-tête. */}
+        <SkipLink targetId={MAIN_CONTENT_ID} />
+        <SiteHeader />
+        {/* `tabIndex={-1}` rend la cible focusable sans l'ajouter à l'ordre de
+            tabulation : le lien d'évitement déplace ainsi le focus, et pas
+            seulement le défilement. */}
+        <main id={MAIN_CONTENT_ID} tabIndex={-1}>
+          {children}
+        </main>
+        <SiteFooter />
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
Closes #1

## Ce que fait cette PR

Pose le socle visuel du site, dans `front/src/@shared/` et `front/src/app/layout.tsx`.
Aucune page n'est créée : tout ce qui est ici sera consommé par les lots suivants.

### Jetons de design

`@shared/styles/tokens.css` est la **source de vérité unique** : palette (12 jetons),
échelle typographique fluide, échelle d'espacement, rayons, ombres, largeurs de layout,
focus et durées de transition. Aucun composant n'écrit une valeur en dur.

Les deux thèmes déclarent exactement le même jeu de jetons de couleur — c'est ce qui rend
la vérification de contraste automatisable plutôt que déclarative.

### Thèmes clair et sombre

`prefers-color-scheme` respecté, avec une échappatoire `data-theme` sur `:root` si un
sélecteur de thème est ajouté plus tard. Vérifié par mesure : fond `rgb(252, 252, 250)`
en clair, `rgb(14, 16, 19)` en sombre, sans intervention.

### Layout global

Lien d'évitement, en-tête, `main` focusable (`id="contenu"` + `tabIndex={-1}`), pied de
page — appliqués à toutes les routes.

### Composants de base

`Container`, `ActionLink`, `Card`, `Section`, `SkipLink`, `SiteHeader`, `SiteFooter` —
chacun dans son dossier PascalCase avec son module CSS colocalisé.

Tous purs, à une exception près : `SiteHeader/_notPure/NavLink/` lit la route courante
(`usePathname`) pour poser `aria-current="page"`. C'est le seul composant du socle qui
dépend d'autre chose que de ses props, et il est isolé comme le veut la règle.

## Décisions et justifications

| Décision | Pourquoi |
|---|---|
| CSS Modules + propriétés personnalisées, aucune bibliothèque d'interface | Le socle tient en quelques composants. Importer un système entier coûterait en poids, en dépendances à suivre et en défauts d'accessibilité à corriger. Aucun runtime de style expédié au navigateur. |
| Pile de polices système | Zéro requête réseau, zéro décalage de mise en page, aucun appel tiers — ce dernier point est aussi une contrainte RGPD du `README.md`. |
| Aucune media query de largeur | `clamp()`, `flex-wrap` et `grid auto-fit` couvrent 320 à 1920 px en continu. Pas de largeur « non testée » entre deux paliers. Les jetons `sm/md/lg/xl` du gabarit ont été retirés parce qu'ils n'étaient pas utilisés. |
| Navigation repliable, pas de menu déroulant | Cinq entrées tiennent sans état d'ouverture, sans piège de focus, sans gestion d'Échap et sans JavaScript. |
| En-tête non collant | Sur un téléphone il mangerait une part notable de la hauteur utile, pour un gain faible. |
| `Card` non cliquable en entier | Éviter de superposer un lien invisible au texte, ce qui le rendrait insélectionnable. La zone d'action est explicite. |
| `ActionLink` rend toujours un `a` | Les appels à l'action d'une vitrine prérendue sont des navigations. Le futur bouton d'envoi du formulaire de contact réutilisera les mêmes jetons. |
| `prefers-reduced-motion` traité par les jetons | Les jetons `--transition-*` passent à `0s`. Toutes les animations étant construites dessus, cela suffit — sans sélecteur universel ni `!important` (que la règle Biome `noImportantStyles` refuse à juste titre). |
| Pas de `<meta name="theme-color">` | Il aurait fallu répéter deux valeurs de couleur hors de `tokens.css`, ce qui casse la source de vérité unique pour un gain cosmétique. |

## Vérifications réellement faites

**Contrastes** — recalculés à partir de `tokens.css` lui-même (formule de luminance
relative WCAG 2.1), pas affirmés : **21 combinaisons par thème, 42 au total, toutes
au-dessus du seuil** (4.5:1 pour le texte, 3:1 pour les composants d'interface).

Marge la plus faible : `--color-border-strong` sur `--color-surface-muted` en thème
clair, à **3.13:1** pour un seuil de 3. Signalée dans `docs/accessibility.md`.

Deux jetons ont dû être corrigés en cours de route : `--color-border-strong` échouait le
seuil de 3:1 dans les deux thèmes (2.44:1 en clair, 2.83:1 en sombre). Les valeurs ont
été assombries/éclaircies jusqu'à passer — le seuil n'a pas été abaissé.

**Rendu 320 → 1920 px** — mesuré dans Chrome headless (pilotage CDP) sur dix largeurs
(320, 360, 390, 414, 600, 768, 1024, 1280, 1440, 1920), dans les deux thèmes, sur deux
pages : **aucun défilement horizontal** dans les 40 mesures.

Aucun `overflow-x: hidden` n'est employé : le résultat tient à `overflow-wrap: break-word`
sur `body`, `min-width: 0` sur les conteneurs flex/grid et `max-width: 100%` sur les
médias. Masquer le débordement aurait caché le problème au lieu de le régler.

**Clavier** — le lien d'évitement est le premier élément focusable du document, reste
dans l'ordre de tabulation en permanence (seulement déplacé hors champ par une
transformation) et revient dans le viewport au focus (mesuré : `top: -70px` vers
`top: 8px`). Sa cible existe et est focusable. Un seul `header`/`main`/`footer` par page,
deux `nav` nommées distinctement, aucun `tabindex` positif.

**Chaîne** — `make lint` (Biome + limite 300 lignes) et `make test` passent ; `next build`
prérend les routes en statique.

## Documentation

- `docs/design.md` : jetons réels, principes, justification des choix écartés, procédure
  pour ajouter un jeton ou un composant.
- `docs/accessibility.md` : les 42 ratios mesurés, le relevé de navigation clavier, le
  résultat des mesures responsive, et une section « restes à faire » explicite.

## Tests

Conformément au `CLAUDE.md`, **je n'ai écrit aucun test**. J'en propose quatre, avec leur
intention et leur contenu complet, dans le rapport transmis à Jérôme MARICHEZ :

1. **Unitaire** — `front/tests/unitaire/contrastes-jetons.spec.ts` : chaque combinaison
   déclarée dans `contrast-pairs.ts` tient son seuil, dans les deux thèmes, à partir du
   vrai `tokens.css`. C'est le critère d'acceptation « contraste AA » rendu exécutable.
2. **Unitaire** — `front/tests/unitaire/proprietes-personnalisees-css.spec.ts` : le
   lecteur de jetons distingue bien `:root` de `:root[data-theme="dark"]`, ignore les
   commentaires et échoue bruyamment sur un sélecteur absent. Sans ce test, le premier
   pourrait passer à vide.
3. **Unitaire** — `front/tests/unitaire/parite-themes.spec.ts` : les deux thèmes
   déclarent le même jeu de jetons `--color-*`. Attrape la régression la plus probable :
   ajouter une couleur au thème clair et oublier le sombre.
4. **E2E** — `front/tests/e2e/socle-accessibilite.cy.ts` : lien d'évitement, ordre
   clavier et absence de défilement horizontal à 320 px. Ces comportements dépendent de
   la mise en page réelle, que jsdom ne calcule pas — le niveau e2e est le bon.

## Points signalés

- Les liens de navigation pointent vers des routes qui n'existent pas encore
  (`/services/*`, `/parcours`, `/contact`) : attendu, elles font l'objet d'autres lots.
- `front/src/app/page.tsx` n'a pas été touché : hors périmètre de cette issue.
- Aucune dépendance ajoutée.
- `next dev` génère `front/AGENTS.md` et `front/CLAUDE.md`. Ces fichiers ne sont pas
  commités ; les ajouter au `.gitignore` éviterait qu'un second `CLAUDE.md` se retrouve
  dans le dépôt par inadvertance. Non fait ici, hors périmètre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Lkzawdu7WwjAQxgKY2ar
