### PR TITLE
autre: outillage de tests front (jsdom, modules CSS) et fichiers generes ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,11 @@ cypress/videos/
 # Claude Code — settings personnels (settings.json partagé, local non)
 .claude/settings.local.json
 .claude/worktrees/
+
+# Consignes d'agent générées par « next dev » (option agentRules de Next.js,
+# active par défaut) : Next écrit AGENTS.md et CLAUDE.md à la racine du front
+# pour y pointer sa propre documentation. Ils ne sont jamais versionnés — un
+# second CLAUDE.md dans le dépôt entrerait en concurrence avec les règles du
+# projet, portées par le seul CLAUDE.md racine.
+/front/AGENTS.md
+/front/CLAUDE.md

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,6 +20,31 @@ Les tests **conditionnent la fusion** d'une PR vers `dev` (voir le
 lancée — runner Node natif (`node:test` + `fetch`), dans `tests/acceptance/` et
 `tests/acceptance/uat/<catégorie>/`.
 
+## Environnement de test front — jsdom, TSX et modules CSS
+
+Les tests front des niveaux **unitaire** et **intégration** rendent de vrais composants
+React avec React Testing Library : ils ont besoin d'un DOM et tournent donc en
+environnement **`jsdom`** (`front/jest.config.mjs`). Le **back reste en environnement
+`node`** — sa configuration (`back/jest.config.mjs`) est indépendante et inchangée.
+
+La compilation du TypeScript/JSX et la résolution des imports non-JS sont déléguées à
+**`next/jest`**, livré avec Next.js — **aucune dépendance supplémentaire** :
+
+| Ce qu'importe le composant | Ce que voit le test |
+|---|---|
+| `.ts` / `.tsx` | compilé par **SWC**, le compilateur du build Next, avec les alias de `tsconfig.json` (`@/…`) |
+| `styles from './card.module.css'` | un **proxy d'objet** : `styles.card` vaut la chaîne `'card'` — la classe appliquée reste donc assertable |
+| CSS global, images, `next/font`, `server-only` | neutralisés : ce ne sont pas des comportements observables en Jest |
+
+Cette résolution vient **de la configuration**, jamais d'une doublure écrite à la main :
+le dépôt ne contient ni `jest.mock`, ni dossier `__mocks__`, ni fichier de doublure. Un
+module CSS est un **actif de style**, pas un module métier — la règle « pas de mocks »
+ci-dessous porte sur la **logique métier**, qui n'est jamais remplacée.
+
+**Contrepartie assumée** : SWC transpile **sans vérifier les types**. Le type-checking
+des tests reste couvert par TypeScript lui-même — `npx tsc --noEmit` dans `front/`, et
+`next build` en CI, dont le périmètre inclut `front/tests/**`.
+
 ## Cycle : le test d'abord, écrit par le développeur
 
 L'ordre n'est pas négociable — il est appliqué par le hook
@@ -78,7 +103,10 @@ vers un mock.
 - **Supertest** ou un **vrai serveur** (`listen(0)`) pour le niveau système ;
 - une **base de test dédiée** (jamais celle de dev/prod), rechargée depuis les fixtures ;
 - `jest.fn()` / `jest.spyOn` pour **observer** un appel (callback, événement) sans
-  remplacer un module métier.
+  remplacer un module métier ;
+- la **résolution des actifs non-JS** (modules CSS, images, polices) par `next/jest` —
+  un mapper de configuration fourni par le framework, qui ne remplace **aucun module
+  métier** (voir « Environnement de test front » ci-dessus).
 
 Le hook se désarme par `ALLOW_TEST_DOUBLES=1` — décision de Jérôme MARICHEZ, à justifier.
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -21,6 +21,25 @@ Toutes les opérations passent par `make` (voir `Makefile`) : agnostique, docume
 make lint
 ```
 
+## Chaîne de test front — Jest, jsdom, next/jest
+
+`front/jest.config.mjs` tourne en environnement **`jsdom`** (les tests rendent des
+composants React) et délègue la transformation à **`next/jest`**, fourni avec Next.js :
+TypeScript/JSX compilé par **SWC**, alias `@/…` de `tsconfig.json`, et résolution des
+imports `*.module.css` par un proxy d'objet. **Aucune dépendance ajoutée**, aucune
+doublure de module écrite à la main. `back/jest.config.mjs` reste en environnement
+**`node`** avec `ts-jest`. Détail : [`testing.md`](./testing.md).
+
+## Fichiers générés — ce qui n'entre pas dans le dépôt
+
+`next dev` génère `front/AGENTS.md` et `front/CLAUDE.md` (option `agentRules` de
+Next.js, active par défaut) pour orienter un agent de code vers la documentation de la
+version installée. Ces fichiers sont **ignorés par git** : un second `CLAUDE.md` dans le
+dépôt entrerait en concurrence avec les règles du projet, portées par le seul
+`CLAUDE.md` racine. Pour supprimer la génération elle-même plutôt que l'ignorer, il
+faudrait poser `agentRules: false` dans `next.config.mjs` — non retenu, la documentation
+versionnée avec Next étant utile en local.
+
 ## Hooks Claude Code (`.claude/`)
 
 | Hook | Événement | Rôle |

--- a/front/jest.config.mjs
+++ b/front/jest.config.mjs
@@ -1,19 +1,32 @@
-// Configuration Jest — jeromemarichez2026
+// Configuration Jest — front jeromemarichez2026
 // Unitaire : tests/unitaire/**  —  Intégration : tests/integration/**
-// TODO : adapter transform/preset au scaffolding réel (ts-jest, next/jest ou babel).
+//
+// Les tests front rendent des composants React (React Testing Library) : ils ont
+// besoin d'un DOM, d'où « jsdom » et non « node » (le back, lui, reste en node).
+//
+// La transformation passe par next/jest, fourni avec Next.js — aucune dépendance
+// supplémentaire. Il compile TypeScript/JSX avec SWC (le compilateur du build),
+// lit les alias de tsconfig.json, et surtout RÉSOUT les imports « *.module.css »
+// vers son proxy d'objet : « styles.card » renvoie la chaîne « card ». La
+// résolution vient donc de la configuration, jamais d'une doublure de module
+// écrite à la main. Référence : docs/testing.md.
+import nextJest from 'next/jest.js'
+
+const createJestConfig = nextJest({ dir: './' })
 
 /** @type {import('jest').Config} */
-export default {
-  testEnvironment: 'node', // 'jsdom' côté front (composants React)
+const config = {
+  testEnvironment: 'jsdom',
   roots: ['<rootDir>/tests'],
   testMatch: [
     '**/tests/unitaire/**/*.(test|spec).ts?(x)',
     '**/tests/integration/**/*.(test|spec).ts?(x)',
     '**/tests/systeme/**/*.test.ts',
   ],
-  transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }] },
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
   coverageThreshold: {
     global: { branches: 80, functions: 80, lines: 80, statements: 80 },
   },
 }
+
+export default createJestConfig(config)

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -25,7 +25,6 @@
         "cypress": "^15.0.0",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
-        "ts-jest": "^29.4.0",
         "typescript": "^5.9.0"
       }
     },
@@ -4326,19 +4325,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -5859,38 +5845,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/handlebars/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -8128,13 +8082,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -8357,13 +8304,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -8572,13 +8512,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10051,72 +9984,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/ts-jest": {
-      "version": "29.4.12",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
-      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "^0.2.6",
-        "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.9",
-        "json5": "^2.2.3",
-        "lodash.memoize": "^4.1.2",
-        "make-error": "^1.3.6",
-        "semver": "^7.8.5",
-        "type-fest": "^4.41.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0 || ^30.0.0",
-        "@jest/types": "^29.0.0 || ^30.0.0",
-        "babel-jest": "^29.0.0 || ^30.0.0",
-        "jest": "^29.0.0 || ^30.0.0",
-        "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <7"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/transform": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jest-util": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10228,20 +10095,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/underscore": {
@@ -10496,13 +10349,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/front/package.json
+++ b/front/package.json
@@ -19,15 +19,14 @@
     "@biomejs/biome": "^2.0.0",
     "@stryker-mutator/core": "^9.0.0",
     "@stryker-mutator/jest-runner": "^9.0.0",
-    "cypress": "^15.0.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "cypress": "^15.0.0",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
-    "ts-jest": "^29.4.0",
     "typescript": "^5.9.0"
   }
 }


### PR DESCRIPTION
## Contexte

Deux problemes d'outillage constates a la livraison du socle de design (PR #4), tous deux hors de son perimetre.

Closes #5

## 1. Les composants React sont testables

`front/jest.config.mjs` tournait en `testEnvironment: 'node'` et ne resolvait pas les imports `*.module.css` : aucun composant ne pouvait etre rendu, alors que le `CLAUDE.md` annonce Jest + React Testing Library aux niveaux unitaire et integration cote front.

- **Environnement `jsdom`** cote front. Le **back reste en `node`** : `back/jest.config.mjs` n'est pas touche.
- **Transformation deleguee a `next/jest`**, livre avec Next.js. Il compile TypeScript/JSX avec **SWC** (le compilateur du build), lit les alias `@/…` de `tsconfig.json`, et resout les imports `*.module.css` vers un **proxy d'objet** : `styles.card` vaut la chaine `'card'`, donc la classe appliquee reste assertable.
- La resolution vient **de la configuration**, jamais d'une doublure de module ecrite a la main : ni `jest.mock`, ni dossier `__mocks__`, ni fichier de doublure dans le depot. Un module CSS est un actif de style, pas un module metier — la regle « pas de mocks » est **inchangee** et le hook `check-test-doubles.sh` n'est ni desarme ni contourne.

### Contrepartie assumee

SWC transpile **sans verifier les types**. Le type-checking des tests reste couvert par TypeScript : `npx tsc --noEmit` dans `front/` inclut bien `front/tests/unitaire/exemple.spec.ts` (verifie via `tsc --listFilesOnly`), et `next build` type-verifie le meme perimetre en CI (`Running TypeScript ... Finished TypeScript in 999ms`). Si tu veux ce garde-fou aussi sur les PR vers `dev`, il faudrait une cible `make typecheck` cablee dans `ci-dev-lint.yml` : je n'ai pas touche aux workflows.

## 2. Fichiers generes par `next dev` ignores

`next dev` genere `front/AGENTS.md` et `front/CLAUDE.md` a la racine du front — option `agentRules` de Next.js, **active par defaut**, qui pointe un agent de code vers la documentation de la version installee. Un second `CLAUDE.md` dans le depot entrerait en concurrence avec les regles du projet.

`.gitignore` les couvre desormais, avec le commentaire expliquant l'origine et le risque. Les chemins sont **ancres a la racine** (`/front/AGENTS.md`), ce qui laisse le `CLAUDE.md` racine suivi par git :

```
$ git check-ignore -v front/AGENTS.md front/CLAUDE.md
.gitignore:36:/front/AGENTS.md	front/AGENTS.md
.gitignore:37:/front/CLAUDE.md	front/CLAUDE.md

$ git check-ignore -v CLAUDE.md
(aucune sortie — le CLAUDE.md racine n'est pas ignore, c'est voulu)

$ git ls-files front/AGENTS.md front/CLAUDE.md
(aucune sortie — aucun des deux n'est dans l'index)
```

L'alternative aurait ete de **supprimer la generation** (`agentRules: false` dans `next.config.mjs`) : non retenue, la documentation versionnee avec Next etant utile en local. A trancher si tu preferes l'inverse.

## Preuve que le rendu fonctionne, sans fichier de test

L'ecriture des tests est reservee a Jerome MARICHEZ : **aucun fichier de test n'est ecrit, modifie ni commite** dans cette PR (`git diff --name-only origin/dev..HEAD` ne contient aucun `*.spec.*`, `*.test.*`, ni rien sous `tests/`).

La demonstration a donc ete faite par une **execution ponctuelle non versionnee** : un fichier temporaire pose dans `front/`, execute, puis retire du depot avant tout commit. Il rendait `Card`, `ActionLink` (qui passe par `next/link`), `Section` et `SkipLink` avec React Testing Library. Sortie reelle de Jest sur la configuration finale (rapport JSON, Jest 30 reecrivant son rapport texte en place) :

```
$ npx jest --roots . --testMatch '**/preuve-rendu-jsdom.tsx' --no-cache --json
code de sortie jest = 0

environnement : jsdom (front/jest.config.mjs)
fichier       : preuve-rendu-jsdom.tsx
suites        : 1/1 passees
tests         : 4/4 passes, 0 en echec
succes global : true

  [passed] rend une Card et l interroge par son role accessible  (31 ms)
  [passed] resout les imports *.module.css (proxy next/jest, pas une doublure)  (1 ms)
  [passed] rend un ActionLink (next/link) avec ses attributs  (3 ms)
  [passed] rend une Section nommee par son titre et un SkipLink  (3 ms)
```

Ce que chaque cas etablit : le rendu React et l'interrogation par role accessible fonctionnent ; `styles.card` vaut bien `'card'` et l'attribut `class` rendu est `card` (les modules CSS sont donc reellement resolus) ; `next/link` se rend en jsdom sans contexte de routeur ; la composition `Section` > `Container` > `SkipLink` tient, avec `aria-labelledby` correct.

Les tests durables qui figeront cet acquis sont **proposes dans le rapport de session** — a toi de les poser.

## Dependances

**Aucune dependance ajoutee.** `@testing-library/react`, `@testing-library/dom` (peer) et `jest-environment-jsdom` etaient deja installes, et `next/jest` est fourni par `next`.

**Une dependance retiree** : `ts-jest` cote front, ou plus rien ne l'utilise depuis le passage a `next/jest` (-154 lignes de `package-lock.json`). Elle reste la ou elle sert, cote **back**, dont la configuration est inchangee. `npm` a par ailleurs reordonne `cypress` alphabetiquement dans `front/package.json` en reecrivant le fichier.

Les binaires SWC des plateformes CI sont bien dans le lock (`@next/swc-linux-x64-gnu` et les 7 autres variantes).

## Verifications locales

| Commande | Resultat |
|---|---|
| `make lint` | code 0 — 65 fichiers, 2 `infos` **preexistantes** sur `biome.json` (migration de config, fichier hors perimetre) ; `Aucun fichier source ne depasse 300 lignes` |
| `make test` | code 0 — front unitaire 2/2, back unitaire 2/2, integration : aucun test |
| `make build` | code 0 — front `Compiled successfully`, `Running TypeScript` OK, 3 pages statiques ; back `tsc` OK |
| `npx tsc --noEmit` (front) | 0 erreur |

Le test d'exemple existant (`front/tests/unitaire/exemple.spec.ts`) passe sans modification sous le nouveau pipeline.

Aucun `--no-verify`, `[skip ci]`, `continue-on-error` ni `|| true`. `biome.json`, les workflows, le `CLAUDE.md` et les seuils (couverture 80, Stryker) sont inchanges.
