### PR TITLE
bug: libelles des offres derives du contenu editorial

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,13 @@ certifications vivent dans des structures typées (`front/src/interfaces/`, une 
 par fichier, préfixe `I`) que les composants consomment. Ajouter une certification ou
 une offre ne doit pas demander de toucher au rendu.
 
+Corollaire tenu partout : **un texte éditorial affiché deux fois n'est écrit qu'une
+fois**. Aucune configuration ne redéclare un libellé dont `src/content/` est déjà
+porteur — elle le dérive. La navigation en est le cas d'école : ses entrées d'offres
+sont construites depuis `content/offres/` (titre et clé), et seules les entrées sans
+source éditoriale, `Parcours` et `Contact`, sont écrites dans
+`@shared/config/navigation.ts`.
+
 **Le contrat de contact vit dans `shared/`** : `shared/interfaces/` pour l'entité,
 `shared/schemas/` pour le schéma Zod. Le front valide avant l'envoi, le back revalide à
 la frontière — **le même schéma**, jamais dupliqué.
@@ -105,6 +112,7 @@ la frontière — **le même schéma**, jamais dupliqué.
 | **Pas de base de données** | CMS headless (Strapi), Notion API | Le contenu change quelques fois par an et n'a qu'un seul auteur. Le versionner dans le dépôt le rend relisible en revue de PR et supprime une dépendance d'exploitation. À réévaluer si la publication devient fréquente. |
 | **Contenu typé en TypeScript** | Fichiers Markdown / MDX | Les entités (offre, expérience, certification) ont une forme stricte que le typage fait respecter — un lien de certification manquant devient une erreur de compilation, pas une page publiée avec un lien mort. |
 | **Preuves référencées, jamais recopiées** | Reprendre le texte des preuves dans le contenu de chaque page | Une page qui met en avant une preuve la désigne par `{ offre, axe }` (`IReferencePreuve`) ; `services/preuves.service.ts` la résout contre `content/offres/`. Le texte reste écrit à un seul endroit, celui qui a été relu contre les règles de véracité. Une référence cassée, ou pointant un axe sans preuve publiable, lève une erreur **au build** — le site ne peut pas afficher une affirmation non prouvée. |
+| **Navigation dérivée du contenu éditorial** | Libellés et liens écrits en dur dans `@shared/config/navigation.ts` | Les entrées d'offres de l'en-tête et du pied de page sont construites depuis `content/offres/` : le libellé est le `titre` de l'offre, le lien découle de sa `cle` via `@shared/config/routes.ts`, l'ordre est celui du contenu. La liste en dur avait divergé dès la première livraison — la navigation annonçait « Data et IA » quand la carte juste en dessous annonçait « Data & IA » (issue #11) — parce que deux sources décrivaient la même donnée et qu'aucun contrôle ne pouvait les comparer. Dérivée, la divergence n'est plus improbable : elle est impossible, et une quatrième offre apparaît dans la navigation sans que `navigation.ts` soit touché. Coût assumé : `@shared/` dépend de `src/content/`, dépendance déjà admise pour les données structurées. Les entrées sans source éditoriale (`Parcours`, `Contact`) restent, elles, déclarées à la main — elles n'ont rien d'où être dérivées. |
 | **Sitemap dérivé des routes réelles** | Liste de routes maintenue à la main ; bibliothèque tierce | `@shared/seo/routes.server.ts` lit l'arborescence de `src/app/` au build : la seule façon d'entrer dans le sitemap est d'exister comme route. Une liste manuelle serait juste le jour de son écriture et fausse au premier ajout de page — et un sitemap faux est pire qu'absent, il envoie les moteurs sur des 404 sans qu'aucun test ni aucun lint ne s'en aperçoive. Coût assumé : une lecture du système de fichiers au build, et les routes dynamiques restent à déclarer explicitement. |
 | **Métadonnées construites par un module partagé** | Chaque page écrit ses balises | Une page déclare un titre, une description et un chemin ; canonique, Open Graph et carte Twitter en découlent. Les entrées sont bornées par Zod (60 / 160 caractères) et les pages étant prérendues, un dépassement casse le **build**. Le défaut SEO devient une erreur de compilation au lieu d'une régression invisible. |
 | **Schéma de contact dans `shared/`** | Un schéma par côté | Front et back valident le **même** contrat Zod. Une divergence de validation entre les deux serait un bug invisible jusqu'au premier message perdu. |

--- a/front/src/@shared/config/navigation.ts
+++ b/front/src/@shared/config/navigation.ts
@@ -1,4 +1,9 @@
+// navigation.ts — jeromemarichez2026
+// Navigation principale du site. Les libellés des offres ne sont PAS écrits ici :
+// ils sont dérivés de `src/content/offres/`, seule source éditoriale.
+import { offres } from '@/content/offres'
 import type { INavigationLink } from '../interfaces/inavigation-link'
+import { cheminOffre } from './routes'
 
 /**
  * Identifiant du conteneur de contenu principal. Sert de cible au lien
@@ -8,16 +13,36 @@ import type { INavigationLink } from '../interfaces/inavigation-link'
 export const MAIN_CONTENT_ID = 'contenu'
 
 /**
- * Navigation principale du site : les trois offres, le parcours, le contact.
- * Ordre volontaire — les offres d'abord (ce qui est vendu), le parcours ensuite
- * (ce qui le rend crédible), le contact en dernier (l'action attendue).
- * Les routes correspondantes sont créées par d'autres lots ; les libellés, eux,
- * sont figés ici pour que l'en-tête et le pied de page ne divergent jamais.
+ * Entrées des offres, DÉRIVÉES du contenu : le libellé est le titre de l'offre, le
+ * lien est construit sur sa clé, et l'ordre est celui déclaré dans `content/offres/`.
+ *
+ * Rien n'est recopié ici, donc plus rien ne peut diverger. La version précédente
+ * réécrivait les trois libellés à la main et avait dérivé dès la première livraison :
+ * l'en-tête annonçait « Data et IA » quand la carte juste en dessous annonçait
+ * « Data & IA » (issue #11). Ajouter une quatrième offre au contenu l'ajoute
+ * désormais à la navigation sans toucher à ce fichier.
  */
-export const siteNavigation: readonly INavigationLink[] = [
-  { href: '/services/ingenierie-web', label: 'Ingénierie web' },
-  { href: '/services/data-ia', label: 'Data et IA' },
-  { href: '/services/seo-sea', label: 'SEO et SEA' },
+const liensOffres: readonly INavigationLink[] = offres.map((offre) => ({
+  href: cheminOffre(offre.cle),
+  label: offre.titre,
+}))
+
+/**
+ * Entrées sans source éditoriale : ni « Parcours » ni « Contact » ne correspondent à
+ * une offre. Leur libellé n'existe nulle part ailleurs, il se déclare donc ici — et
+ * c'est le seul texte que ce fichier ait encore le droit de porter.
+ */
+const liensHorsOffres: readonly INavigationLink[] = [
   { href: '/parcours', label: 'Parcours' },
   { href: '/contact', label: 'Contact' },
 ]
+
+/**
+ * Navigation principale du site : les trois offres, le parcours, le contact.
+ * Ordre volontaire — les offres d'abord (ce qui est vendu), le parcours ensuite
+ * (ce qui le rend crédible), le contact en dernier (l'action attendue).
+ *
+ * L'en-tête et le pied de page consomment cette même liste : ils ne peuvent diverger
+ * ni l'un de l'autre, ni du contenu dont elle est tirée.
+ */
+export const siteNavigation: readonly INavigationLink[] = [...liensOffres, ...liensHorsOffres]

--- a/front/src/@shared/config/routes.ts
+++ b/front/src/@shared/config/routes.ts
@@ -1,0 +1,17 @@
+// routes.ts — jeromemarichez2026
+// Forme des URL internes construites à partir du contenu éditorial.
+// Un seul module connaît le gabarit d'une route d'offre : la navigation et les cartes
+// de la page d'accueil le demandent au lieu de le réécrire chacune de leur côté.
+import type { CleOffre } from '@/interfaces/types'
+
+/**
+ * Page d'une offre de service.
+ *
+ * Le segment d'URL est la clé de l'offre elle-même — `CleOffre` est justement décrite
+ * comme « clé stable, identifiant et segment d'URL » (`src/interfaces/types.ts`). Le
+ * libellé, lui, n'entre jamais dans une URL : il est éditorial et peut être réécrit,
+ * la clé non.
+ */
+export function cheminOffre(cle: CleOffre): string {
+  return `/services/${cle}`
+}

--- a/front/src/views/accueil/sections/Offres/index.tsx
+++ b/front/src/views/accueil/sections/Offres/index.tsx
@@ -1,6 +1,7 @@
 import { ActionLink } from '@/@shared/components/ActionLink'
 import { Card } from '@/@shared/components/Card'
 import { Section } from '@/@shared/components/Section'
+import { cheminOffre } from '@/@shared/config/routes'
 import type { IAccueil } from '@/interfaces/accueil'
 import type { IOffre } from '@/interfaces/offre'
 import styles from './offres.module.css'
@@ -26,7 +27,7 @@ export function Offres({ contenu, offres }: IOffresProps) {
           <li className={styles.item} key={offre.cle}>
             <Card
               footer={
-                <ActionLink href={`/services/${offre.cle}`} variant="secondary">
+                <ActionLink href={cheminOffre(offre.cle)} variant="secondary">
                   {`${contenu.libelleLien} ${offre.titre}`}
                 </ActionLink>
               }


### PR DESCRIPTION
Closes #11

## Le défaut

Les libellés des trois offres étaient écrits **deux fois** : une fois dans
`content/offres/` (la donnée éditoriale), une fois en dur dans
`@shared/config/navigation.ts`. Les deux copies avaient divergé dès la première
livraison, et la page d'accueil le montrait à l'œil nu — l'en-tête annonçait
« Data et IA » quand la carte juste en dessous annonçait « Data & IA ».

| | avant, navigation | avant, cartes | après, partout |
|---|---|---|---|
| | Ingénierie web | Ingénierie Web | **Ingénierie Web** |
| | Data et IA | Data & IA | **Data & IA** |
| | SEO et SEA | SEO / SEA | **SEO / SEA** |

## Le mécanisme retenu

`navigation.ts` ne déclare plus aucun libellé d'offre : il **dérive** ses entrées
de `content/offres/`.

```ts
const liensOffres: readonly INavigationLink[] = offres.map((offre) => ({
  href: cheminOffre(offre.cle),
  label: offre.titre,
}))
```

- **Le libellé** est le `titre` de l'offre — plus rien à recopier, donc plus rien
  qui puisse diverger.
- **Le lien** vient de la `cle`, via `cheminOffre()` : `CleOffre` est décrite dans
  `interfaces/types.ts` comme « clé stable, identifiant **et segment d'URL** »,
  c'est donc elle qui fait foi. Le libellé, lui, n'entre jamais dans une URL — il
  est éditorial et peut être réécrit.
- **L'ordre** est celui du tableau `offres` de `content/offres/index.ts`.
- **`Parcours` et `Contact` restent déclarés à la main** : ils ne correspondent à
  aucune offre, leur libellé n'existe nulle part ailleurs, ils n'ont donc rien
  d'où être dérivés. C'est le seul texte que le fichier ait encore le droit de
  porter.

**En-tête et pied de page n'ont eu besoin d'aucune modification** : tous deux
consomment déjà `siteNavigation`. Corriger la source les corrige ensemble — c'était
précisément l'argument de la liste unique, il tient toujours, il pointait
simplement vers une source de mauvaise qualité.

### Un ajout au-delà du strict énoncé

Le gabarit `/services/<cle>` était écrit à deux endroits (la navigation et la carte
de l'accueil). C'est la même classe de défaut un cran plus bas : le jour où le
segment devient `/offres/`, une des deux copies est oubliée. Il vit désormais dans
`@shared/config/routes.ts`, et les deux appelants le demandent au lieu de le
réécrire. `views/accueil/sections/Offres/index.tsx` est modifié pour cette seule
raison — aucun libellé, aucun contenu n'y est touché.

## Preuve par exécution : une quatrième offre apparaît sans toucher à `navigation.ts`

Vérification ponctuelle **non versionnée**, faite sur le code de cette PR puis
entièrement défaite (`git status` vide, `git clean` sur le fichier ajouté).

Fichiers touchés pour l'expérience — tous dans la couche **contenu / modèle**,
aucun dans la navigation :

1. `content/offres/offre-factice.ts` (créé) — l'offre témoin ;
2. `content/offres/index.ts` — ajout au tableau `offres` ;
3. `interfaces/types.ts` et `schemas/offre.schema.ts` — `CleOffre` et le schéma Zod
   ferment volontairement la liste des clés (`z.literal([...])`), il faut donc y
   déclarer la nouvelle clé. **C'est une garde de véracité, pas un défaut** : elle
   force une offre à être déclarée avant d'exister. Elle se paie en deux lignes,
   dans la couche donnée, jamais dans la navigation.

`git diff --name-only HEAD -- front/src/@shared/config/navigation.ts` → **vide**.

Sortie réelle du serveur (`npm run build && npx next start`, liens `/services/`
extraits du HTML servi) — les trois blocs sont, dans l'ordre, l'en-tête, les cartes
et le pied de page :

```
href="/services/ingenierie-web">Ingénierie Web
href="/services/data-ia">Data &amp; IA
href="/services/seo-sea">SEO / SEA
href="/services/offre-factice">Offre Factice / Temoin      <-- en-tête

href="/services/ingenierie-web">Voir l’offre Ingénierie Web
href="/services/data-ia">Voir l’offre Data &amp; IA
href="/services/seo-sea">Voir l’offre SEO / SEA
href="/services/offre-factice">Voir l’offre Offre Factice / Temoin   <-- cartes

href="/services/ingenierie-web">Ingénierie Web
href="/services/data-ia">Data &amp; IA
href="/services/seo-sea">SEO / SEA
href="/services/offre-factice">Offre Factice / Temoin      <-- pied de page
```

L'offre témoin apparaît aux **trois** endroits, avec le libellé et l'URL tirés de
sa seule déclaration.

### Le sitemap est resté indépendant

Vérifié pendant la même expérience : avec quatre offres en navigation,
`/sitemap.xml` ne contenait toujours que `/`, la seule route réellement servie.
Il dérive de l'arborescence de `src/app/`, pas de la navigation — ce lot ne le
modifie pas et ne crée aucun lien entre les deux.

## Vérification visuelle

Site construit et servi (`npx next start`), page `/` chargée. Les liens du
`<nav>` d'en-tête, les titres des `<Card>` et les liens du pied de page affichent
désormais les **trois mêmes chaînes**, caractère pour caractère, y compris
l'esperluette de « Data & IA » et les espaces autour du « / » de « SEO / SEA ».
Le décalage visible sur l'accueil a disparu.

## Contrôles

- `make lint` — vert (Biome + limite 300 lignes ; les 2 « infos » Biome sur le
  schéma de `biome.json` préexistent à cette branche et ne sont pas des erreurs).
- `make test` — vert.
- `make build` — vert, front et back.
- Fichier le plus long touché : `navigation.ts`, 46 lignes.

## Tests

Aucun test n'est écrit dans cette PR : le `CLAUDE.md` réserve leur écriture à
Jérôme MARICHEZ. Trois tests sont **proposés** (intention + contenu complet) dans
le rapport de session, dont celui qui échouerait si les deux sources
redivergeaient — il compare `siteNavigation` à `offres` plutôt qu'à des chaînes
attendues, faute de quoi il redeviendrait lui-même une troisième copie des
libellés.

## Documentation

`docs/architecture.md` : le corollaire « un texte éditorial affiché deux fois n'est
écrit qu'une fois » est ajouté sous le principe « le contenu éditorial est de la
donnée, pas du JSX », et l'arbitrage est justifié dans le tableau des choix
techniques, à côté de « Sitemap dérivé des routes réelles » et « Preuves
référencées, jamais recopiées » — même famille de décision.
