### PR TITLE
feature: coordonnees de contact et correction des certifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,30 @@ ni approximée.
 | Claude with Google Cloud's Vertex AI | 2026 | *à fournir* |
 | ISTQB **Foundation** (niveau Avancé **non** obtenu) | 2026 | *à fournir* |
 | Google Analytics Individual Qualification (GAIQ) | 2021 | *à fournir* |
-| Google Ads | 2021 *(à confirmer : 2022 sur un CV)* | *à fournir* |
-| Microsoft Ads *(à confirmer)* | — | *à fournir* |
+| Google Ads | *aucune année affichée* | *à fournir* |
 | WeLoveDev — Top 5 % React | 2023 | *à fournir* |
-| EF SET — Anglais B2 (CECRL) | — | *à fournir* |
+
+Trois arbitrages de Jérôme MARICHEZ (2026-08-08), rendus après recoupement des trois CV
+de référence, et tenus par le contenu typé (`front/src/content/certifications.ts`) :
+
+- **Google Ads reste sans année.** Les CV se contredisent — 2021 sur l'Ingénieur Full
+  Stack et l'AI Engineer, 2022 sur le Tracking Specialist. Une année approchée ne
+  s'écrit pas : la donnée porte `annee: null` et rien n'est affiché.
+- **Microsoft Ads est retiré.** Il figurait ici avec la mention « à confirmer » et
+  n'apparaît sur aucun des trois CV : non établi, donc non publié. Il ne se réintroduit
+  qu'avec un justificatif.
+- **EF SET n'est pas une certification** et ne figure plus dans ce tableau. Les trois CV
+  le classent sous « Langues » : c'est le test qui a **évalué** un niveau d'anglais, pas
+  un titre professionnel obtenu.
+
+## 🗣️ Langues
+
+| Langue | Niveau | Référentiel | Évalué par |
+|--------|--------|-------------|------------|
+| Anglais | B2 | CECRL | EF SET |
+
+Portée par `identite.langues` et émise dans `knowsLanguage` du JSON-LD — jamais dans
+`hasCredential`, qui est réservé aux diplômes et aux certifications.
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -29,12 +29,17 @@ Point d'entrée unique du contenu : `front/src/content/index.ts`.
 | `IExperience` | Une expérience professionnelle du parcours. | Pointe vers 1..n `IOffre` via `offresLiees` (clés `CleOffre`). |
 | `IFormation` | Un diplôme obtenu. | Aucune. |
 | `ICertification` | Une certification et son justificatif officiel. | Porte un `Justificatif` (union discriminée). |
+| `IIdentite` | L'identité professionnelle publique : nom, titre, ville, promesse, profils. Alimente les métadonnées et le JSON-LD. | Porte un `IContact` et 0..n `ILangue`. |
+| `IContact` | Les coordonnées directes : e-mail et téléphone. | Appartient à `IIdentite`. |
+| `ILangue` | Une compétence linguistique : niveau, référentiel, organisme évaluateur. | Appartient à `IIdentite`. |
 
 ```mermaid
 erDiagram
     IOFFRE      ||--|{ IAXEOFFRE     : "contient"
     IEXPERIENCE }o--|{ IOFFRE        : "appuie (offresLiees)"
     ICERTIFICATION ||--|| JUSTIFICATIF : "porte"
+    IIDENTITE   ||--|| ICONTACT      : "porte"
+    IIDENTITE   ||--o{ ILANGUE       : "pratique"
     IFORMATION  {
         string cle
         string intitule
@@ -87,17 +92,45 @@ La variante `a-fournir` **ne porte aucune propriété `url`**. Conséquences :
   (`TS2353`), et le `z.strictObject` la rejetterait aussi **au chargement** ;
 - une URL `disponible` doit être absolue et en **HTTPS** (`z.url().startsWith('https://')`).
 
-**À ce jour, aucune URL de justificatif n'est connue : les six certifications sont
+**À ce jour, aucune URL de justificatif n'est connue : les cinq certifications sont
 toutes en `a-fournir`.** Elles ne pourront afficher un lien qu'une fois les URLs
 officielles transmises par Jérôme MARICHEZ.
 
 ### 2. Pas de chiffre approché
 
 - `ICertification.annee` est `number | null`. `null` signifie « année **non établie** » —
-  jamais une valeur approchée. Deux certifications sont dans ce cas aujourd'hui
-  (Google Ads, daté différemment selon les CV ; EF SET, daté nulle part).
+  jamais une valeur approchée. Une seule certification est dans ce cas aujourd'hui :
+  Google Ads, datée 2021 sur deux CV et 2022 sur le troisième — arbitrage du 2026-08-08,
+  aucune année n'est affichée.
 - `IAxeOffre.preuve` est `string | null`. `null` signifie « aucune preuve publiable » :
   la ligne éditoriale impose de reformuler ou de supprimer plutôt que d'inventer.
+
+### 3. Une coordonnée, une seule écriture
+
+`IContact` est le **point unique** des coordonnées : e-mail et téléphone n'existent nulle
+part ailleurs dans le code — ni dans un composant, ni dans un `mailto:`, ni dans le
+JSON-LD.
+
+| Donnée | Forme stockée | Validation | Forme dérivée |
+|--------|---------------|------------|---------------|
+| E-mail | adresse telle quelle | `z.email()` | — |
+| Téléphone | format national `0X XX XX XX XX` | `TELEPHONE_NATIONAL_FR` | E.164 (`+33…`) par `utils/telephone.ts` |
+
+*(Les valeurs elles-mêmes ne sont pas recopiées ici : elles vivent dans
+`front/src/content/identite.ts`, et nulle part ailleurs.)*
+
+Le format international **n'est pas saisi une seconde fois** : `telephoneVersE164()` le
+dérive du numéro national, et le motif qui valide la donnée est celui-là même qui
+autorise la conversion. Deux écritures d'un même numéro finiraient par diverger, et la
+seconde — celle que seules les machines lisent — divergerait en silence.
+
+### 4. Une langue n'est pas une certification
+
+`ILangue` existe pour que la distinction soit **structurelle** et non éditoriale : les CV
+de référence classent « Anglais, B2 (EF SET, CECRL) » sous *Langues*. EF SET est le test
+qui évalue le niveau, pas un titre obtenu. La compétence part donc dans `knowsLanguage`
+du JSON-LD, jamais dans `hasCredential` — où elle aurait gonflé la liste des
+certifications d'une ligne indue.
 
 ## Validation au chargement
 

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -114,15 +114,25 @@ comme au texte visible**, alors même qu'il n'est lu que par des machines.
 
 Le graphe est construit à partir du contenu typé de `front/src/content/`, jamais de texte
 en dur. Ne sont **pas** émis, faute d'être établis : note ou avis (`aggregateRating`,
-`review`), fourchette de prix (`priceRange`), coordonnées (`telephone`, `email`), rue
-(`streetAddress`), zone desservie (`areaServed`).
+`review`), fourchette de prix (`priceRange`), rue (`streetAddress`), zone desservie
+(`areaServed`), horaires (`openingHours`).
 
-Deux garde-fous sont portés par le **typage** et non par la vigilance :
+`email` et `telephone` **sont** émis sur le nœud `Person` depuis le 2026-08-08 :
+coordonnées de Jérôme MARICHEZ, déjà publiques sur ses CV, publication demandée
+explicitement. Le téléphone part en **E.164** (`+33771651588`) — seule forme composable
+hors de France — dérivée du format national stocké dans le contenu par
+`front/src/utils/telephone.ts`. Aucun numéro n'est réécrit dans le module SEO.
+
+Trois garde-fous sont portés par le **typage** et non par la vigilance :
 
 - une certification dont le justificatif est `a-fournir` est émise **sans lien** —
   l'union discriminée `Justificatif` rend l'accès à `url` non compilable ;
 - `sameAs` n'est émis que si un profil public a été **vérifié**. Un `sameAs` erroné
-  rattache l'identité du site à un tiers.
+  rattache l'identité du site à un tiers. Deux profils y figurent aujourd'hui : le compte
+  GitHub et le profil LinkedIn ;
+- une **langue** part dans `knowsLanguage`, jamais dans `hasCredential` : `ILangue` et
+  `ICertification` sont deux entités distinctes, un niveau de langue ne peut donc pas
+  être publié comme une certification.
 
 ## Vérifier
 
@@ -142,6 +152,19 @@ curl -s http://localhost:3117/ \
   | grep -o '<script type="application/ld+json">[^<]*' \
   | sed 's/.*json">//' | node -e 'JSON.parse(require("fs").readFileSync(0,"utf8"))' \
   && echo "JSON-LD valide"
+```
+
+Et le contenu du nœud `Person` se relit **depuis la page servie**, pas depuis la source —
+c'est le seul endroit où l'on voit ce que les moteurs voient :
+
+```bash
+curl -s http://localhost:3117/ \
+  | grep -o '<script type="application/ld+json">[^<]*' | sed 's/.*json">//' \
+  | node -e '
+      const g = JSON.parse(require("fs").readFileSync(0, "utf8"))
+      const p = g["@graph"].find((n) => n["@type"] === "Person")
+      console.log(p.sameAs, p.email, p.telephone)
+    '
 ```
 
 Le graphe se contrôle ensuite avec le [validateur de résultats enrichis de

--- a/front/src/@shared/seo/structured-data.ts
+++ b/front/src/@shared/seo/structured-data.ts
@@ -6,10 +6,15 @@
 // Aucun texte en dur, et surtout aucune donnée que le site ne peut pas prouver — les
 // règles de véracité du CLAUDE.md s'appliquent au JSON-LD exactement comme au texte
 // visible, alors même qu'il n'est lu que par des machines. Ne sont donc PAS émis :
-// note ou avis (`aggregateRating`, `review`), fourchette de prix (`priceRange`),
-// coordonnées (`telephone`, `email`), rue (`streetAddress`), zone desservie
-// (`areaServed`) — rien de tout cela n'est établi.
+// note ou avis (`aggregateRating`, `review`), fourchette de prix (`priceRange`), rue
+// (`streetAddress`), zone desservie (`areaServed`), horaires (`openingHours`) — rien de
+// tout cela n'est établi.
+//
+// `email` et `telephone` SONT émis depuis le 2026-08-08 : ce sont les coordonnées de
+// Jérôme MARICHEZ, déjà publiques sur ses CV, dont il a explicitement demandé la
+// publication. Elles proviennent du contenu typé, jamais d'une chaîne écrite ici.
 import { certifications, formations, identite, offres } from '@/content'
+import { telephoneVersE164 } from '@/utils/telephone'
 import type { JsonLdGraph, JsonLdNode } from '../interfaces/types'
 import { absoluteUrl, siteUrl } from './site'
 
@@ -60,6 +65,25 @@ function certificationsObtenues(): readonly JsonLdNode[] {
   }))
 }
 
+/**
+ * Langues pratiquées.
+ *
+ * `knowsLanguage` est la propriété prévue par schema.org — et la bonne place pour EF SET,
+ * qui évalue un niveau d'anglais et n'est pas un titre professionnel : le mettre dans
+ * `hasCredential` reviendrait à annoncer une certification de plus.
+ *
+ * Le niveau CECRL (« B2 ») n'est pas émis : schema.org ne définit aucune propriété pour
+ * l'exprimer sur un nœud `Language`, et l'inventer produirait une clé qu'aucun
+ * consommateur ne lit. Il reste porté par le contenu typé, pour le texte visible.
+ */
+function languesPratiquees(): readonly JsonLdNode[] {
+  return identite.langues.map((langue) => ({
+    '@type': 'Language',
+    name: langue.nom,
+    alternateName: langue.code,
+  }))
+}
+
 /** Le catalogue des trois offres, décrites par leur accroche éditoriale. */
 function catalogueOffres(): JsonLdNode {
   return {
@@ -91,7 +115,13 @@ function personne(): JsonLdNode {
     description: identite.promesse,
     url: absoluteUrl('/'),
     address: adressePublique,
+    email: identite.contact.email,
+    // schema.org attend un numéro composable tel quel, donc en E.164 : la forme lisible
+    // « 07 71 65 15 88 » n'est pas interprétable hors de France. La conversion est
+    // dérivée du contenu typé, aucun numéro n'est réécrit ici.
+    telephone: telephoneVersE164(identite.contact.telephone),
     knowsAbout: domainesCouverts(),
+    knowsLanguage: languesPratiquees(),
     hasCredential: [...diplomes(), ...certificationsObtenues()],
     // `sameAs` n'est émis que si au moins un profil public a été vérifié.
     ...(identite.profilsPublics.length > 0 ? { sameAs: identite.profilsPublics } : {}),

--- a/front/src/content/certifications.ts
+++ b/front/src/content/certifications.ts
@@ -9,10 +9,15 @@
 //   en `a-fournir`. Une URL ne s'invente ni ne s'approxime — elle doit être transmise
 //   par Jérôme MARICHEZ. Le typage empêche tout rendu de lien tant que c'est le cas.
 // - `annee: null` = année non établie. Google Ads est daté 2021 sur deux CV et 2022 sur
-//   le CV Tracking Specialist : la contradiction n'est pas tranchée ici. EF SET n'est
-//   daté sur aucune source.
-// - « Microsoft Ads » figure au README avec la mention « à confirmer » et n'apparaît sur
-//   aucun CV : il n'est donc PAS saisi. À ajouter seulement après confirmation.
+//   le CV Tracking Specialist : arbitrage de Jérôme MARICHEZ du 2026-08-08, la
+//   contradiction n'est pas tranchée et AUCUNE année n'est affichée.
+// - « Microsoft Ads » n'est pas établi : absent des trois CV de référence. Il n'est pas
+//   saisi ici, et sa mention « à confirmer » a été retirée du README.md le 2026-08-08.
+// - « EF SET — Anglais B2 » n'est PAS une certification et ne figure plus ici : les trois
+//   CV le classent sous « Langues » (« Anglais, B2 (EF SET, CECRL) »), EF SET étant le
+//   test qui évalue le niveau et non un titre professionnel obtenu. La compétence est
+//   portée par `identite.langues` et part dans `knowsLanguage` du JSON-LD, pas dans
+//   `hasCredential`. Arbitrage de Jérôme MARICHEZ du 2026-08-08.
 import type { ICertification } from '../interfaces/certification'
 import { certificationSchema } from '../schemas/certification.schema'
 
@@ -51,14 +56,6 @@ const donnees = [
     organisme: 'Google',
     // 2021 sur les CV Ingénieur Full Stack et AI Engineer, 2022 sur le CV Tracking
     // Specialist. Non tranché : à confirmer par Jérôme MARICHEZ.
-    annee: null,
-    justificatif: { statut: 'a-fournir' },
-  },
-  {
-    cle: 'ef-set-anglais-b2',
-    intitule: 'EF SET — Anglais B2 (CECRL)',
-    organisme: 'EF SET',
-    // Aucune année sur les CV ni au README.
     annee: null,
     justificatif: { statut: 'a-fournir' },
   },

--- a/front/src/content/identite.ts
+++ b/front/src/content/identite.ts
@@ -5,14 +5,24 @@
 // Véracité — points tenus ici :
 // - « Ingénieur logiciel » et « Lille » sont repris du README.md, sans extension. Aucun
 //   titre plus vendeur (« expert », « consultant senior ») n'est introduit ici.
-// - AUCUNE coordonnée : ni adresse postale, ni téléphone, ni e-mail. La ville est la
-//   seule granularité géographique établie et publique ; une adresse ne s'invente pas
-//   (règles de véracité du CLAUDE.md, contrainte RGPD du README.md).
+// - Les COORDONNÉES (e-mail, téléphone) ont été arbitrées et validées explicitement par
+//   Jérôme MARICHEZ le 2026-08-08, après recoupement de ses trois CV de référence. Elles
+//   sont les siennes et déjà publiques. En revanche, toujours AUCUNE adresse postale :
+//   la ville reste la seule granularité géographique établie, et une rue ne s'invente pas
+//   (règles de véracité du CLAUDE.md, contrainte RGPD du README.md). Pas davantage
+//   d'horaires, de délai de réponse ni de fourchette tarifaire : rien de tout cela n'est
+//   établi.
 // - `profilsPublics` ne contient que des URL VÉRIFIÉES. github.com/Jerome-Marichez est
 //   le compte propriétaire du dépôt de ce site (Jerome-Marichez/jeromemarichez2026,
-//   public, intitulé « Jérôme MARICHEZ ») : l'identité est donc établie, pas supposée.
-//   LinkedIn, Malt et les autres profils restent absents tant que Jérôme MARICHEZ ne les
-//   a pas fournis — un `sameAs` erroné rattache l'identité du site à un tiers.
+//   public, intitulé « Jérôme MARICHEZ ») ; l'URL LinkedIn a été fournie par Jérôme
+//   MARICHEZ le 2026-08-08. Malt, Twitter et les autres profils restent absents tant
+//   qu'ils n'ont pas été fournis — un `sameAs` erroné rattache l'identité du site à un
+//   tiers, ce qui est pire que l'absence de `sameAs`.
+// - `langues` reprend la rubrique « Langues » des trois CV : « Anglais, B2 (EF SET,
+//   CECRL) ». EF SET y est le TEST qui a évalué le niveau, pas une certification
+//   professionnelle — il ne figure donc plus dans `certifications.ts`. Aucune autre
+//   langue n'est déclarée : le français maternel n'est écrit sur aucune des sources
+//   retenues, et il ne s'ajoute pas par déduction.
 import type { IIdentite } from '../interfaces/identite'
 import { identiteSchema } from '../schemas/identite.schema'
 
@@ -25,7 +35,25 @@ const donnees = {
     'Un seul interlocuteur humain pour vos projets digitaux, aucune sous-traitance : celui qui cadre est celui qui code, mesure et exploite.',
   descriptionSite:
     'Ingénierie web, data & IA, SEO/SEA. Un seul interlocuteur pour vos projets digitaux, sans sous-traitance.',
-  profilsPublics: ['https://github.com/Jerome-Marichez'],
+  contact: {
+    email: 'jeromemarichez@ik.me',
+    // Format national ; l'E.164 (`+33771651588`) en est dérivé par `utils/telephone.ts`.
+    telephone: '07 71 65 15 88',
+  },
+  langues: [
+    {
+      cle: 'anglais',
+      nom: 'Anglais',
+      code: 'en',
+      niveau: 'B2',
+      referentiel: 'CECRL',
+      evaluePar: 'EF SET',
+    },
+  ],
+  profilsPublics: [
+    'https://github.com/Jerome-Marichez',
+    'https://www.linkedin.com/in/jerome-marichez-31948712b',
+  ],
 } satisfies IIdentite
 
 /** Validée au chargement : une donnée non conforme échoue au build, pas en production. */

--- a/front/src/interfaces/contact.ts
+++ b/front/src/interfaces/contact.ts
@@ -1,0 +1,31 @@
+// contact.ts — jeromemarichez2026
+// Entité éditoriale : les coordonnées directes de Jérôme MARICHEZ.
+//
+// Ces coordonnées sont celles de Jérôme lui-même, déjà diffusées sur ses trois CV de
+// référence, et leur publication a été demandée explicitement le 2026-08-08. Aucune
+// donnée de tiers n'entre ici, et rien ne s'y ajoute sans arbitrage : ni adresse
+// postale, ni horaires, ni délai de réponse, ni fourchette tarifaire — autant
+// d'informations qu'un site de prestation est tenté d'afficher et qui, faute d'être
+// établies, seraient inventées.
+
+/**
+ * Coordonnées directes, uniques et publiques.
+ *
+ * Elles vivent ici, dans le contenu typé, et **nulle part ailleurs** : ni dans un
+ * composant, ni dans un `mailto:` écrit à la main, ni dans le JSON-LD. Une coordonnée
+ * dupliquée dans le rendu est une coordonnée qui devient fausse le jour où elle change,
+ * sans qu'aucun test ne s'en aperçoive.
+ */
+export interface IContact {
+  /** Adresse e-mail publique. Validée comme e-mail par le schéma, pas comme chaîne. */
+  readonly email: string
+  /**
+   * Téléphone au **format national français**, groupé par paires : `0X XX XX XX XX`.
+   *
+   * C'est la forme lisible par un humain, et la seule stockée. Le format international
+   * E.164 attendu par schema.org et par un lien `tel:` en est **dérivé**
+   * (`utils/telephone.ts`) plutôt que saisi une seconde fois : deux écritures du même
+   * numéro finissent toujours par diverger.
+   */
+  readonly telephone: string
+}

--- a/front/src/interfaces/identite.ts
+++ b/front/src/interfaces/identite.ts
@@ -6,9 +6,15 @@
 // non par du texte en dur semé dans le layout et les composants. Le nom, l'intitulé et
 // la ville se disent au même endroit que le reste du contenu éditorial.
 //
-// Elle ne porte QUE des informations professionnelles publiques : aucune coordonnée
-// personnelle, aucune adresse postale, aucun numéro. Contraintes RGPD du `README.md` et
-// règles de véracité du `CLAUDE.md`.
+// Elle ne porte QUE des informations professionnelles publiques. Les coordonnées
+// directes (e-mail, téléphone) y figurent depuis l'arbitrage de Jérôme MARICHEZ du
+// 2026-08-08 : ce sont les siennes, elles sont déjà diffusées sur ses trois CV, et il en
+// a explicitement demandé la publication. Restent absentes, faute d'être établies :
+// l'adresse postale, les horaires, le délai de réponse, la fourchette tarifaire.
+// Contraintes RGPD du `README.md` et règles de véracité du `CLAUDE.md`.
+import type { IContact } from './contact'
+import type { ILangue } from './langue'
+
 export interface IIdentite {
   readonly nom: string
   /** Intitulé professionnel, tel qu'il est revendiqué dans le `README.md`. */
@@ -24,6 +30,16 @@ export interface IIdentite {
    * moteurs tronquent — la contrainte est donc tenue au build, pas à la relecture.
    */
   readonly descriptionSite: string
+  /**
+   * Coordonnées directes. Point unique : la page de contact, le pied de page et le
+   * JSON-LD lisent d'ici, aucun ne réécrit une adresse ou un numéro.
+   */
+  readonly contact: IContact
+  /**
+   * Compétences linguistiques, telles que les CV de référence les classent — sous
+   * « Langues », et non parmi les certifications. Alimente `knowsLanguage` du JSON-LD.
+   */
+  readonly langues: readonly ILangue[]
   /**
    * Profils publics vérifiables, destinés au `sameAs` des données structurées.
    *

--- a/front/src/interfaces/langue.ts
+++ b/front/src/interfaces/langue.ts
@@ -1,0 +1,32 @@
+// langue.ts — jeromemarichez2026
+// Entité éditoriale : une compétence linguistique, avec son niveau et son référentiel.
+//
+// Pourquoi cette entité existe : les trois CV de référence classent « Anglais, B2
+// (EF SET, CECRL) » sous la rubrique **Langues**, jamais parmi les certifications. EF SET
+// est le test qui a évalué le niveau, pas un titre professionnel obtenu — le laisser dans
+// la liste des certifications gonflait celle-ci d'une ligne qui n'y a pas sa place.
+
+/**
+ * Une langue pratiquée et le niveau qui lui est reconnu.
+ *
+ * `niveau` et `referentiel` sont indissociables : « B2 » ne veut rien dire sans le
+ * référentiel qui le définit, et un niveau annoncé sans son cadre d'évaluation est
+ * exactement le genre d'affirmation invérifiable que les règles de véracité écartent.
+ */
+export interface ILangue {
+  readonly cle: string
+  /** Nom de la langue, en français : « Anglais ». */
+  readonly nom: string
+  /** Étiquette BCP 47 de la langue (`en`, `fr`) — destinée au JSON-LD. */
+  readonly code: string
+  /** Niveau atteint, tel qu'exprimé dans le référentiel : « B2 ». */
+  readonly niveau: string
+  /** Référentiel qui définit le niveau : « CECRL ». */
+  readonly referentiel: string
+  /**
+   * Organisme ou test ayant évalué le niveau (« EF SET »), ou `null` si l'évaluation
+   * n'est pas établie. Ce n'est **pas** une certification professionnelle : la
+   * distinction est portée par le modèle, pas par la vigilance du rédacteur.
+   */
+  readonly evaluePar: string | null
+}

--- a/front/src/schemas/contact.schema.ts
+++ b/front/src/schemas/contact.schema.ts
@@ -1,0 +1,20 @@
+// contact.schema.ts — jeromemarichez2026
+// Schéma Zod de l'entité IContact. Le type est dérivé du schéma (z.infer), jamais
+// écrit à la main. Convention : docs/architecture.md.
+import { z } from 'zod'
+import { TELEPHONE_NATIONAL_FR } from '@/utils/telephone'
+
+export const contactSchema = z.strictObject({
+  // `z.email()` et non `z.string()` : une adresse mal formée est une adresse à laquelle
+  // aucun prospect n'écrira jamais, et le défaut serait invisible en relecture.
+  email: z.email(),
+  // Format national français vérifiable, décrit une seule fois dans `utils/telephone.ts`
+  // — le même motif sert à valider la donnée et à la convertir en E.164. Une coquille
+  // (chiffre en trop, paire manquante, écriture collée) casse le build au lieu de
+  // publier un numéro injoignable sur toutes les pages du site.
+  telephone: z
+    .string()
+    .regex(TELEPHONE_NATIONAL_FR, 'Téléphone français attendu au format « 0X XX XX XX XX ».'),
+})
+
+export type ContactValide = z.infer<typeof contactSchema>

--- a/front/src/schemas/identite.schema.ts
+++ b/front/src/schemas/identite.schema.ts
@@ -1,6 +1,8 @@
 // identite.schema.ts — jeromemarichez2026
 // Schéma Zod de l'entité IIdentite. Convention : docs/architecture.md.
 import { z } from 'zod'
+import { contactSchema } from './contact.schema'
+import { langueSchema } from './langue.schema'
 
 export const identiteSchema = z.strictObject({
   nom: z.string().min(1),
@@ -15,6 +17,8 @@ export const identiteSchema = z.strictObject({
   // dit rien d'exploitable. Le site vend du référencement : la contrainte est vérifiée
   // par le schéma, pas laissée à la relecture.
   descriptionSite: z.string().min(50).max(160),
+  contact: contactSchema,
+  langues: z.array(langueSchema),
   // Seules des URL https vérifiables entrent ici — voir le commentaire de l'interface.
   profilsPublics: z.array(z.url({ protocol: /^https$/ })),
 })

--- a/front/src/schemas/langue.schema.ts
+++ b/front/src/schemas/langue.schema.ts
@@ -1,0 +1,22 @@
+// langue.schema.ts — jeromemarichez2026
+// Schéma Zod de l'entité ILangue. Le type est dérivé du schéma (z.infer), jamais
+// écrit à la main. Convention : docs/architecture.md.
+import { z } from 'zod'
+
+export const langueSchema = z.strictObject({
+  cle: z
+    .string()
+    .regex(/^[a-z0-9-]+$/, 'La clé d’une langue est en minuscules, chiffres et tirets.'),
+  nom: z.string().min(1),
+  // Étiquette BCP 47 : `en`, `fr`, éventuellement `en-GB`. Elle part telle quelle dans le
+  // JSON-LD, où une valeur fantaisiste ne serait rattachée à aucune langue connue.
+  code: z
+    .string()
+    .regex(/^[a-z]{2}(-[A-Z]{2})?$/, 'Étiquette BCP 47 attendue (« en », « en-GB »).'),
+  niveau: z.string().min(1),
+  referentiel: z.string().min(1),
+  // `null` = niveau non évalué par un test identifié. Jamais un organisme approché.
+  evaluePar: z.string().min(1).nullable(),
+})
+
+export type LangueValide = z.infer<typeof langueSchema>

--- a/front/src/utils/telephone.ts
+++ b/front/src/utils/telephone.ts
@@ -1,0 +1,43 @@
+// telephone.ts — jeromemarichez2026
+// Utilitaire transverse : formats d'un numéro de téléphone français. Pur, sans état,
+// sans métier — convention `src/utils/` du CLAUDE.md.
+//
+// Un numéro s'écrit de deux façons selon le lecteur : « 07 71 65 15 88 » pour un humain,
+// « +33771651588 » (E.164) pour schema.org, pour un lien `tel:` et pour n'importe quel
+// automate. Le contenu typé ne stocke que la première ; la seconde est dérivée ici. Le
+// jour où le numéro change, il change à un seul endroit.
+
+/**
+ * Numéro français au format national, groupé par paires : `0X XX XX XX XX`.
+ *
+ * Le motif refuse `00` en tête (aucun opérateur français n'attribue ce préfixe), impose
+ * les quatre paires et les espaces qui les séparent. Il est la référence commune de la
+ * validation (`schemas/contact.schema.ts`) et de la conversion ci-dessous : un format et
+ * son contrôle ne peuvent pas diverger s'ils sont écrits une seule fois.
+ */
+export const TELEPHONE_NATIONAL_FR = /^0[1-9](?: \d{2}){4}$/
+
+/** Indicatif téléphonique de la France, cohérent avec `identite.codePays` (`FR`). */
+export const INDICATIF_FRANCE = '+33'
+
+/**
+ * Convertit un numéro français national en E.164 : `07 71 65 15 88` → `+33771651588`.
+ *
+ * Le `0` initial est un **préfixe national d'acheminement** : il n'appartient pas au
+ * numéro et disparaît derrière l'indicatif pays, il n'est donc pas simplement « enlevé
+ * des espaces ». Un numéro qui ne respecte pas le format national lève une erreur plutôt
+ * que de produire une chaîne plausible mais injoignable — c'est précisément le genre de
+ * valeur qu'un JSON-LD publierait sans que personne ne s'en aperçoive.
+ *
+ * Volontairement limité à la France : le site n'a qu'un numéro, et un convertisseur
+ * international générique serait du code non couvert par un besoin réel.
+ */
+export function telephoneVersE164(telephoneNational: string): string {
+  if (!TELEPHONE_NATIONAL_FR.test(telephoneNational)) {
+    throw new Error(
+      `Numéro français attendu au format « 0X XX XX XX XX », reçu : « ${telephoneNational} ».`,
+    )
+  }
+  const chiffres = telephoneNational.replace(/ /g, '')
+  return `${INDICATIF_FRANCE}${chiffres.slice(1)}`
+}


### PR DESCRIPTION
Closes #13

Arbitrages rendus par Jérôme MARICHEZ le 2026-08-08, après recoupement de ses trois CV de
référence. Aucune valeur n'a été déduite, complétée ou extrapolée au-delà de ces
arbitrages.

## Ce que fait cette PR

**Les coordonnées entrent dans le contenu typé.** Deux entités nouvelles, chacune décrite
par son interface et validée par son schéma Zod au chargement du module — donc au build,
donc jamais en production :

| Entité | Fichiers | Validation |
|--------|----------|------------|
| `IContact` | `front/src/interfaces/contact.ts`, `front/src/schemas/contact.schema.ts` | `z.email()` sur l'e-mail ; motif national français `^0[1-9](?: \d{2}){4}$` sur le téléphone |
| `ILangue` | `front/src/interfaces/langue.ts`, `front/src/schemas/langue.schema.ts` | clé, étiquette BCP 47, niveau, référentiel, organisme évaluateur nullable |

`identite.profilsPublics` accueille le profil LinkedIn aux côtés du compte GitHub —
`z.url({ protocol: /^https$/ })` y impose déjà des URL absolues en HTTPS.

**Le format international n'est pas saisi deux fois.** Le contenu stocke le numéro
national, lisible par un humain ; `front/src/utils/telephone.ts` en dérive l'E.164 attendu
par schema.org et par un futur lien `tel:`. Le motif qui *valide* la donnée est celui-là
même qui *autorise* la conversion : un format et son contrôle ne peuvent pas diverger
s'ils sont écrits une seule fois. Deux écritures d'un même numéro divergent toujours, et
celle que seules les machines lisent divergerait en silence.

**Le nœud `Person` du JSON-LD** porte désormais `email`, `telephone` (E.164),
`knowsLanguage`, et un `sameAs` à deux profils. Rien n'y est écrit en dur : tout vient du
contenu typé.

## EF SET : sorti des certifications, représenté comme compétence linguistique

Les trois CV le classent sous « Langues » — « Anglais, B2 (EF SET, CECRL) ». EF SET est le
**test qui a évalué un niveau**, pas un titre professionnel obtenu.

Il aurait suffi de supprimer la ligne. Le choix retenu est de **représenter la compétence**
via `ILangue`, pour deux raisons : l'information est vraie et publique, il n'y avait aucune
raison de la perdre ; et surtout la distinction devient **structurelle** plutôt
qu'éditoriale. `ILangue` et `ICertification` étant deux entités distinctes, un niveau de
langue ne *peut plus* repartir dans `hasCredential` — la règle est portée par le modèle, pas
par la vigilance du prochain rédacteur. Le JSON-LD l'émet dans `knowsLanguage`, propriété
prévue par schema.org.

Le niveau CECRL (« B2 ») n'est **pas** émis dans le JSON-LD : schema.org ne définit aucune
propriété pour l'exprimer sur un nœud `Language`. Inventer une clé produirait une donnée
qu'aucun consommateur ne lit. Le niveau reste dans le contenu typé, pour le texte visible.

## Corrections de véracité — `README.md`

- **Microsoft Ads retiré.** Mention « à confirmer » au README, absent des trois CV : non
  établi, donc non publié.
- **Google Ads reste sans année.** 2021 sur deux CV, 2022 sur le troisième. La donnée
  portait déjà `annee: null` — inchangée ; le README est mis en cohérence
  (« *aucune année affichée* » au lieu de « 2021 *(à confirmer)* »).
- **EF SET** quitte le tableau des certifications pour une rubrique « Langues ».

Il reste donc **cinq** certifications, toutes en justificatif `a-fournir` : aucune URL
officielle n'a encore été transmise, et aucune ne s'invente.

## Vérification par exécution — JSON-LD réellement servi

Build `NEXT_PUBLIC_SITE_URL="https://jeromemarichez.fr" npm run build`, puis
`next start -p 3117`, puis extraction du `<script type="application/ld+json">` de la page
servie et `JSON.parse`. Sortie réelle :

```
--- JSON.parse du JSON-LD servi : OK ---
@context      : https://schema.org
nœuds @graph  : Person, ProfessionalService

Person.sameAs : [
  "https://github.com/Jerome-Marichez",
  "https://www.linkedin.com/in/jerome-marichez-31948712b"
]
Person.email  : "jeromemarichez@ik.me"
Person.telephone : "+33771651588"
Person.knowsLanguage : [{"@type":"Language","name":"Anglais","alternateName":"en"}]

hasCredential : [
  "Expert en informatique et systèmes d’information",
  "Développeur",
  "Claude with Google Cloud’s Vertex AI",
  "ISTQB Foundation",
  "WeLoveDev — Top 5 % React",
  "Google Analytics Individual Qualification (GAIQ)",
  "Google Ads"
]

OK   sameAs contient GitHub
OK   sameAs contient LinkedIn
OK   sameAs a exactement 2 profils
OK   email au bon format
OK   telephone en E.164
OK   telephone conforme au motif E.164
OK   aucune certification EF SET
OK   aucune certification Microsoft Ads
OK   anglais en knowsLanguage
OK   aucune adresse postale (streetAddress)
```

La marche à suivre est ajoutée à [`docs/seo.md`](docs/seo.md) — relire le nœud depuis la
page **servie**, la source ne prouvant rien de ce que les moteurs voient.

## Contrôles locaux

- `make lint` — Biome + limite 300 lignes : aucun fichier source ne dépasse 300 lignes
- `make test` — 4 tests, tous au vert
- `make build` — front (5 routes statiques) et back

## Tests à écrire par Jérôme MARICHEZ

Le `CLAUDE.md` réserve l'écriture des tests à Jérôme : **aucun fichier de test n'a été
écrit ni modifié**. Trois tests sont proposés, intention et contenu complet, dans le
rapport joint à la tâche — `telephoneVersE164`, la validation Zod de `IContact`, et
l'absence d'EF SET dans `hasCredential` du graphe construit.

## Ce que cette PR ne fait pas

- **La page `/contact` n'est pas construite** — hors périmètre, issue dédiée. Ce lot
  fournit la donnée qu'elle consommera (`identite.contact`).
- **Aucune obfuscation de l'e-mail au rendu** : rien n'affiche encore la donnée. À traiter
  quand la page sera écrite, comme l'issue le prévoit.
- **`email`/`telephone` ne sont posés que sur `Person`**, conformément à l'issue. Le nœud
  `ProfessionalService` pourrait porter un `contactPoint` ; sans `contactType` ni langue de
  service établis, il aurait fallu inventer.
- **Le `CLAUDE.md` n'est pas modifié** (interdit à l'assistant). Ses lignes 65-67 listent
  encore l'année Google Ads et l'existence de Microsoft Ads comme « à confirmer » : les
  deux points sont désormais tranchés. **À mettre à jour par Jérôme MARICHEZ.**
- **Aucune donnée inventée** : ni adresse postale, ni horaires, ni délai de réponse, ni
  fourchette tarifaire, ni compte Malt ou Twitter. Le français n'est pas déclaré en langue
  — il n'apparaît sur aucune des sources retenues et ne s'ajoute pas par déduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Lkzawdu7WwjAQxgKY2ar
