### PR TITLE
autre: verification des types en CI avant fusion dans dev

### DIFF
--- a/.github/workflows/ci-dev-lint.yml
+++ b/.github/workflows/ci-dev-lint.yml
@@ -1,5 +1,11 @@
 name: ci-dev-lint
-# Check rapide (PR -> dev) : lint Biome sur tout le dépôt + limite 300 lignes/fichier.
+# Check rapide (PR -> dev) : lint Biome + limite 300 lignes/fichier, et vérification
+# des types TypeScript (front + back, tests inclus).
+#
+# Le job « typecheck » est ajouté par l'issue #12 : les tests front sont compilés par
+# next/jest (SWC), qui transpile SANS vérifier les types. Sans ce job, une erreur de
+# types traverse lint + tests au vert et n'apparaît qu'au build de la PR vers main,
+# une fois le lot constitué. Il AJOUTE un contrôle, il n'en affaiblit aucun.
 on:
   pull_request:
     branches: [dev]
@@ -16,3 +22,18 @@ jobs:
         run: npx @biomejs/biome@^2.0.0 check .
       - name: Limite 300 lignes / fichier
         run: ./scripts/check-max-lines.sh
+
+  typecheck:
+    name: Types (tsc --noEmit, front + back)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      # tsc a besoin des dépendances : les types de React, Next, Zod et Jest
+      # viennent de node_modules, pas du dépôt.
+      - name: Installation
+        run: make install
+      - name: Vérification des types
+        run: make typecheck

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Interface de commandes unique (local + CI). `make help` liste les cibles.
 
 .DEFAULT_GOAL := help
-.PHONY: help install dev build lint test test-unit test-int test-mutation
+.PHONY: help install dev build lint typecheck test test-unit test-int test-mutation
 .PHONY: test-e2e
 .PHONY: test-system
 .PHONY: test-acceptance
@@ -15,6 +15,14 @@ help: ## Liste les commandes disponibles
 lint: ## Biome sur tout le dépôt + limite 300 lignes/fichier
 	npx @biomejs/biome@^2.0.0 check .
 	./scripts/check-max-lines.sh
+
+# Le front compile ses tests via next/jest (SWC) et le back via ts-jest : ni l'un ni
+# l'autre n'échoue sur une erreur de types. Cette cible est le seul contrôle de types
+# joué avant la fusion dans dev. Le back passe par tsconfig.typecheck.json, car son
+# tsconfig.json de build est limité à « src » (rootDir + declaration pour dist/).
+typecheck: ## Vérification des types TypeScript (front + back, tests inclus, sans artefact)
+	cd front && npx tsc --noEmit
+	cd back && npx tsc -p tsconfig.typecheck.json
 
 test: test-unit test-int ## Tests unitaires + intégration (rapides)
 

--- a/back/tsconfig.typecheck.json
+++ b/back/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "rootDir": "."
+  },
+  "include": ["src", "tests"]
+}

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -6,13 +6,19 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
 
 | Déclencheur | Workflows | Objectif |
 |-------------|-----------|----------|
-| **PR → `dev`** | `ci-dev-lint`, `ci-dev-tests` | Checks **rapides** : lint (Biome + limite 300 lignes), tests unitaires et intégration. |
+| **PR → `dev`** | `ci-dev-lint`, `ci-dev-tests` | Checks **rapides** : lint (Biome + limite 300 lignes), **vérification des types**, tests unitaires et intégration. |
 | **PR → `main`** | `ci-main-e2e`, `ci-main-system`, `ci-main-build` | Checks **complets** avant production : e2e navigateur, tests système, build. |
 
 ## Jobs
 
 - **lint** : `make lint` — Biome sur tout le dépôt + `scripts/check-max-lines.sh`
   (échec si un fichier source dépasse **300 lignes**).
+- **typecheck (dev)** : `make typecheck` — `tsc --noEmit` sur le front **et** le back,
+  `tests/**` inclus. Job du workflow `ci-dev-lint`. C'est le **seul** contrôle de types
+  joué avant la fusion dans `dev` : Biome ne voit pas les types, et `next/jest` compile
+  les tests front avec **SWC**, qui transpile sans type-checker. Sans ce job, une erreur
+  de types passe lint + tests au vert et n'éclate qu'au `build` de la PR vers `main` —
+  au pire moment, le lot déjà constitué. Détail : [`tooling.md`](./tooling.md).
 - **tests (dev)** : unitaires + intégration, front et back.
 - **e2e (main)** : stack démarrée puis Cypress headless.
 - **système (main)** : vrai serveur HTTP + client réel.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,9 +41,19 @@ le dépôt ne contient ni `jest.mock`, ni dossier `__mocks__`, ni fichier de dou
 module CSS est un **actif de style**, pas un module métier — la règle « pas de mocks »
 ci-dessous porte sur la **logique métier**, qui n'est jamais remplacée.
 
-**Contrepartie assumée** : SWC transpile **sans vérifier les types**. Le type-checking
-des tests reste couvert par TypeScript lui-même — `npx tsc --noEmit` dans `front/`, et
-`next build` en CI, dont le périmètre inclut `front/tests/**`.
+**Contrepartie assumée** : SWC transpile **sans vérifier les types**. Un test front peut
+donc être **vert avec une erreur de types** — c'est vérifié, pas supposé : une erreur de
+types inoffensive à l'exécution laisse `npx jest` afficher `2 passed` là où `tsc` échoue
+sur le même fichier.
+
+Le type-checking est donc porté par une cible dédiée, **`make typecheck`**
+(`tsc --noEmit`, front + back, `tests/**` inclus), exécutée par le workflow
+`ci-dev-lint` **avant toute fusion dans `dev`**. Elle ne remplace pas les tests : les
+tests vérifient le **comportement**, `tsc` vérifie la **cohérence des types**. Voir
+[`tooling.md`](./tooling.md) et [`ci-cd.md`](./ci-cd.md).
+
+Côté back, `ts-jest` remonte déjà les diagnostics de types à l'exécution des tests, mais
+seulement pour les fichiers **atteints par un test** : `make typecheck` couvre le reste.
 
 ## Cycle : le test d'abord, écrit par le développeur
 
@@ -132,6 +142,7 @@ sous le seuil `break`). Lancer : `make test-mutation`.
 ## Commandes
 
 ```bash
+make typecheck        # vérification des types (tsc --noEmit, front + back, tests inclus)
 make test             # unitaires + intégration
 make test-unit        # unitaires (Jest)
 make test-int         # intégration (Jest)

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -21,6 +21,40 @@ Toutes les opérations passent par `make` (voir `Makefile`) : agnostique, docume
 make lint
 ```
 
+## Vérification des types — `make typecheck`
+
+Le lint **ne voit pas les types** : Biome analyse la syntaxe, pas le graphe de types.
+Et aucun runner de test du dépôt ne comble ce trou côté front — `next/jest` compile
+avec **SWC**, qui *transpile* sans type-checker.
+
+`make typecheck` est donc le **seul** contrôle de types joué avant la fusion dans `dev` :
+
+```bash
+make typecheck   # tsc --noEmit sur le front et le back, tests inclus, sans artefact
+```
+
+| Côté | Commande | Périmètre |
+|------|----------|-----------|
+| front | `npx tsc --noEmit` | `src/**` **et** `tests/**` — le `tsconfig.json` du front inclut déjà `**/*.ts(x)` |
+| back | `npx tsc -p tsconfig.typecheck.json` | `src/**` **et** `tests/**` |
+
+**Pourquoi un `back/tsconfig.typecheck.json` séparé.** Le `back/tsconfig.json` sert au
+**build** : il est limité à `include: ["src"]`, avec `rootDir: "src"`, `declaration` et
+`outDir: "dist"`. Y ajouter `tests` polluerait `dist/` et casserait `rootDir`. Le fichier
+de typecheck **étend** ce tsconfig et se contente d'élargir le périmètre en `noEmit` —
+la configuration de build reste intacte, les deux ne peuvent pas diverger.
+
+Vérifier le périmètre réellement couvert (et non supposé) :
+
+```bash
+cd back && npx tsc -p tsconfig.typecheck.json --listFilesOnly | grep -v node_modules
+```
+
+**Non couvert, volontairement** : `front/tests/e2e/**` et `front/cypress.config.ts`,
+exclus du `tsconfig.json` du front parce que les types de Cypress écrasent le `expect()`
+de Jest — Cypress type-vérifie ses specs lui-même. L'exclusion est antérieure à cette
+cible et documentée dans le `tsconfig.json`.
+
 ## Chaîne de test front — Jest, jsdom, next/jest
 
 `front/jest.config.mjs` tourne en environnement **`jsdom`** (les tests rendent des
@@ -29,6 +63,11 @@ TypeScript/JSX compilé par **SWC**, alias `@/…` de `tsconfig.json`, et résol
 imports `*.module.css` par un proxy d'objet. **Aucune dépendance ajoutée**, aucune
 doublure de module écrite à la main. `back/jest.config.mjs` reste en environnement
 **`node`** avec `ts-jest`. Détail : [`testing.md`](./testing.md).
+
+Conséquence directe sur les types : **SWC transpile sans vérifier**, donc un test front
+peut passer au vert avec une erreur de types. `ts-jest`, côté back, remonte lui des
+diagnostics — mais seulement sur les fichiers atteints par un test. D'où
+`make typecheck` ci-dessus, qui couvre les deux côtés intégralement.
 
 ## Fichiers générés — ce qui n'entre pas dans le dépôt
 


### PR DESCRIPTION
## Contexte

Une erreur de typage TypeScript pouvait traverser toute la chaîne d'intégration sans être
vue. Depuis le passage du front à `next/jest`, **SWC transpile sans vérifier les types** :
Jest exécute le code sans type-checker. Les seuls contrôles de types du dépôt étaient
`next build` et `tsc`, joués uniquement par `ci-main-build.yml`, déclenché sur les PR vers
`main`.

Conséquence : une PR vers `dev` pouvait être verte (lint + tests) tout en contenant une
erreur de types, révélée seulement à l'ouverture de la PR de mise en production — au pire
moment, quand le lot est déjà constitué. Le lint Biome ne comble pas ce trou : il n'a
aucune vision des types.

## Ce que fait cette PR

- Cible **`make typecheck`** : `tsc --noEmit` sur le front **et** le back, **aucun
  artefact produit**.
- Le job **`typecheck`** de `ci-dev-lint.yml` l'exécute : une erreur de types fait
  échouer la CI **avant** la fusion dans `dev`.
- `make help` documente la cible.
- `docs/ci-cd.md`, `docs/testing.md` et `docs/tooling.md` mis à jour.

## Modification d'un workflow CI — justification explicite (règle 8 du CLAUDE.md)

La règle 8 interdit de modifier un fichier de configuration CI/CD **dans le but
d'affaiblir un contrôle ou de masquer une régression**.

**Cette PR fait exactement l'inverse : elle ajoute un contrôle.** `ci-dev-lint.yml` gagne
un job `typecheck` qui rend la CI *plus* stricte qu'avant — une PR vers `dev` qui passait
au vert avec une erreur de types échouera désormais. Rien n'est retiré, désarmé ni
assoupli :

- aucun autre workflow n'est touché (`ci-dev-tests`, `ci-main-*`, `release-main` inchangés) ;
- aucun seuil (couverture, mutation, limite 300 lignes) n'est modifié ;
- `biome.json` et les règles de lint sont inchangés ;
- aucun `continue-on-error`, `allow_failure`, `|| true`, `[skip ci]` ni `--no-verify`.

Le job `lint` existant est laissé tel quel ; `typecheck` est un job **séparé et parallèle**,
pour ne pas ralentir le retour du lint.

## Périmètre réellement couvert — vérifié, non supposé

Vérifié avec `tsc --listFilesOnly` plutôt que déduit de la configuration.

| Côté | Avant | Après |
|------|-------|-------|
| front `src/**` | couvert (PR vers `main` uniquement) | couvert **avant `dev`** |
| front `tests/**` | **jamais type-vérifié en CI de `dev`** | **couvert** |
| back `src/**` | couvert (PR vers `main` uniquement) | couvert **avant `dev`** |
| back `tests/**` | **jamais type-vérifié du tout** | **couvert** |

Le trou le plus net était le back : `back/tsconfig.json` porte `include: ["src"]`, donc
`tsc` ne voyait **aucun** fichier de `back/tests/`. Sortie avant/après :

```
$ cd back && npx tsc --noEmit --listFilesOnly | grep -v node_modules   # AVANT
back/src/index.ts
back/src/interfaces/types.ts
back/src/schemas/exemple.schema.ts

$ cd back && npx tsc -p tsconfig.typecheck.json --listFilesOnly | grep -v node_modules   # APRES
back/src/index.ts
back/src/interfaces/types.ts
back/src/schemas/exemple.schema.ts
back/tests/unitaire/exemple.test.ts        <-- desormais couvert
```

Côté front, `front/tests/unitaire/exemple.spec.ts` apparaît bien dans la liste des
fichiers de `tsc` (le `tsconfig.json` du front inclut déjà `**/*.ts(x)`) : c'est
`next/jest` qui ne le type-vérifiait pas, pas `tsconfig`. La cible referme ce trou dès la
CI de `dev`.

**Ces vingt tests aujourd'hui proposés à Jérôme et pas encore posés seront donc
type-vérifiés le jour où ils arriveront** — c'est précisément `front/tests/**` et
`back/tests/**` qui ne l'étaient pas.

### Pourquoi un `back/tsconfig.typecheck.json` séparé

`back/tsconfig.json` sert au **build** : `include: ["src"]`, `rootDir: "src"`,
`declaration: true`, `outDir: "dist"`. Y ajouter `tests` polluerait `dist/` et casserait
`rootDir`. Le nouveau fichier **étend** le tsconfig de build et se contente d'élargir le
périmètre en `noEmit` — la configuration de build reste intacte et les deux ne peuvent pas
diverger. `make build` reste vert (vérifié).

### Non couvert, volontairement

`front/tests/e2e/**` et `front/cypress.config.ts` restent exclus par le `tsconfig.json` du
front : les types de Cypress écrasent le `expect()` de Jest, et les tests unitaires ne
compileraient plus. Cypress type-vérifie ses specs lui-même. **Exclusion antérieure à
cette PR**, déjà documentée dans le `tsconfig.json` — je ne l'ai ni créée ni élargie.

## Démonstration : la vérification échoue réellement

Une vérification qui n'échoue jamais ne vérifie rien. Sorties **réelles**, copiées telles
quelles.

### 1. Erreur volontaire dans le code source du front

`front/src/utils/telephone.ts` — `const chiffres: number = telephoneNational.replace(...)` :

```
$ make typecheck
cd front && npx tsc --noEmit
src/utils/telephone.ts(41,9): error TS2322: Type 'string' is not assignable to type 'number'.
src/utils/telephone.ts(42,41): error TS2339: Property 'slice' does not exist on type 'number'.
make: *** [typecheck] Error 2
########## EXIT CODE = 2 ##########
```

### 2. Erreur volontaire dans le code source du back

`back/src/interfaces/types.ts` — `export const erreurVolontaire: number = 'ceci-est-une-chaine'` :

```
$ make typecheck
cd front && npx tsc --noEmit
cd back && npx tsc -p tsconfig.typecheck.json
src/interfaces/types.ts(8,14): error TS2322: Type 'string' is not assignable to type 'number'.
make: *** [typecheck] Error 2
########## EXIT CODE = 2 ##########
```

### 3. Erreur volontaire dans `back/tests/`

`back/tests/unitaire/exemple.test.ts` — `id: 'erreur-volontaire'` :

```
$ make typecheck
cd front && npx tsc --noEmit
cd back && npx tsc -p tsconfig.typecheck.json
tests/unitaire/exemple.test.ts(16,35): error TS2322: Type 'string' is not assignable to type 'number'.
make: *** [typecheck] Error 2
########## EXIT CODE = 2 ##########
```

### 4. Erreur volontaire dans `front/tests/` — la démonstration du trou lui-même

Le cas décisif. Une erreur de types **inoffensive à l'exécution**, dans
`front/tests/unitaire/exemple.spec.ts` :

```ts
const erreurVolontaire: number = 'chaine-inoffensive-a-l-execution'
```

Jest (via `next/jest`, donc SWC) **ne voit rien** :

```
$ cd front && npx jest tests/unitaire
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

`make typecheck` attrape l'erreur sur **exactement le même fichier** :

```
$ make typecheck
cd front && npx tsc --noEmit
tests/unitaire/exemple.spec.ts(16,11): error TS2322: Type 'string' is not assignable to type 'number'.
make: *** [typecheck] Error 2
########## EXIT CODE = 2 ##########
```

C'est très exactement le trou décrit dans l'issue : **tests verts, types faux**.

**Nuance relevée en chemin** : côté back, `ts-jest` remonte déjà les diagnostics de types
et aurait fait échouer le cas 3 à l'exécution des tests — mais seulement pour les fichiers
**atteints par un test**. Le trou béant est côté front (SWC), et le back reste non couvert
partout où aucun test ne passe. La documentation dit désormais cela précisément, plutôt
que d'attribuer au back une faiblesse qu'il n'a pas.

### Retrait

Les quatre erreurs ont été retirées intégralement. Arbre de travail vérifié avant commit :

```
$ git diff --stat -- front/tests back/tests front/src back/src
(vide)

$ git status --short
 M .github/workflows/ci-dev-lint.yml
 M Makefile
 M docs/ci-cd.md
 M docs/testing.md
 M docs/tooling.md
?? back/tsconfig.typecheck.json
```

**Aucun fichier de test n'est modifié par cette PR** — le diff ne touche ni `front/tests/`,
ni `back/tests/`, ni aucun `src/`. Les erreurs des cas 3 et 4 ont été introduites puis
retirées localement, jamais commitées : l'écriture des tests reste réservée à
Jérôme MARICHEZ.

## Vérifications locales

```
make lint        OK   (Biome : 103 fichiers, 2 infos préexistantes — schéma 2.5.2 vs CLI 2.5.7
                       et champ `recommended` déprécié ; sortie 0, biome.json non touché)
make typecheck   OK
make test        OK   (front 2 passed, back 2 passed, intégration : no tests)
make build       OK   (next build + tsc back)
```

`make help` :

```
  typecheck        Vérification des types TypeScript (front + back, tests inclus, sans artefact)
```

## Critères d'acceptation

- [x] `make typecheck` vérifie les types du front **et** du back sans produire d'artefact
- [x] La cible couvre les fichiers de `tests/` (vérifié par `--listFilesOnly`)
- [x] `ci-dev-lint.yml` l'exécute : une erreur de types fait échouer la CI avant `dev`
- [x] Démonstration faite qu'une erreur échoue réellement, dans le source **et** dans `tests/`
- [x] `make help` documente la cible
- [x] `make lint`, `make test`, `make build` et `make typecheck` passent

Aucune dépendance ajoutée : TypeScript était déjà présent des deux côtés.

Closes #12
