### PR TITLE
feature: grille tarifaire de l'offre SEA

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ découpage est porté par la donnée elle-même (`IAxeOffre.volet`), pas par la 
 > projet data se chiffre au périmètre : volume et état des données, usage visé,
 > contraintes de mise en production. **Aucun montant n'est affiché pour cette offre.**
 > « Sur devis » est une modalité, pas un prix — c'est à ce titre que la mention est
-> publiée. Les montants de l'offre SEA relèvent de l'issue #17, distincte.
+> publiée. La seule grille tarifaire du site est celle de l'offre **SEA**, plus bas ; le
+> contenu typé de Data & IA ne porte aucun montant et aucune grille ne lui est rattachée.
 
 ### 3. SEA
 
@@ -214,10 +215,39 @@ agence : la mesure n'est pas déclarative, elle est construite dans le code.
 - **Ce que l'offre ne couvre pas** — ni rédaction de contenu, ni netlinking, ni suivi de
   positions. Dit explicitement plutôt que laissé à supposer.
 
-> **Tarifs : aucun montant n'est publié.** La tarification SEA fait l'objet d'un
-> arbitrage distinct, **bloqué tant que Jérôme MARICHEZ n'a pas tranché HT ou TTC** — un
-> montant sans mention est ambigu et se paie au premier échange commercial. Aucun prix ne
-> figure donc dans ce dépôt, ni dans le contenu publié, ni en commentaire.
+#### Tarifs
+
+Grille publiée — arbitrages de Jérôme MARICHEZ du 2026-08-08 (issue #17). **Toutes taxes
+comprises**, mention affichée à côté de chaque montant et jamais reléguée en note de bas
+de page : c'est elle qui rend le prix non ambigu.
+
+| Prestation | Condition d'application | Tarif |
+|------------|-------------------------|-------|
+| Mise en place de la solution data-driven | si j'ai conçu le site | **incluse** |
+| Mise en place de la solution data-driven | sur un site existant, que je n'ai pas conçu | **fourchette TTC, une seule fois, selon le périmètre** |
+| Gestion du compte | ensuite, une fois la solution en place | **forfait mensuel, sur devis** |
+
+> **Les montants eux-mêmes ne sont pas recopiés ici.** Ils vivent dans
+> `front/src/content/offres/sea-tarifs.ts`, et nulle part ailleurs — même règle que les
+> coordonnées de contact. Un prix écrit à deux endroits finit par diverger, et c'est la
+> copie oubliée qui engage Jérôme vis-à-vis d'un prospect. La mention « TTC » n'est pas
+> une convention de rédaction : c'est une **propriété du montant**, sans laquelle le
+> contenu ne compile pas — voir [`docs/data-model.md`](./docs/data-model.md).
+
+**Pourquoi la mise en place est incluse quand je conçois le site.** En encadrant des
+prestataires d'acquisition avant de piloter moi-même, j'ai vu la même mécanique se
+répéter : les campagnes s'optimisent sur les métriques de la régie — coût par clic,
+conversions déclarées — parce que c'est la seule matière disponible de ce côté-là,
+pendant que l'entreprise décide sur ses chiffres à elle : marge, stock, valeur d'un
+client dans la durée. Ce n'est pas une affaire de compétence, c'est une affaire d'accès.
+D'où la gratuité de la mise en place dans ce cas précis : c'est le seul où la mesure est
+construite dans le produit dès le départ, du côté des chiffres du client. C'est la
+charnière économique de la chaîne cadrage → développement → câblage data → SEA.
+
+*Cet argument se dit **à la première personne, depuis l'expérience vécue** — jamais comme
+un jugement sur une profession, sans nom d'agence et sans généralisation. Le dénigrement
+de concurrents est juridiquement risqué, et un prospect déjà accompagné se sentirait pris
+à partie.*
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -188,10 +188,13 @@ Conséquences, toutes vérifiées :
 
 Côté **rendu**, la garantie est prolongée par `front/src/utils/tarif.ts`, seul module qui
 transforme un `Montant` en texte. Il émet toujours le chiffre et sa mention d'un seul
-tenant (« 300 à 1 200 € TTC, une seule fois, selon le périmètre ») ; la fonction qui met
-en forme les euros **n'est pas exportée**, il n'existe donc aucun moyen d'obtenir un
-montant nu. Sa sortie porte un type marqué, `MontantAffichable` : un composant qui déclare
-ce type en propriété ne peut pas recevoir un prix écrit à la main dans du JSX.
+tenant — « … € TTC, une seule fois, selon le périmètre » — et la fonction qui met en forme
+les euros **n'est pas exportée** : il n'existe aucun moyen d'obtenir un montant nu. Sa
+sortie porte un type marqué, `MontantAffichable` : un composant qui déclare ce type en
+propriété ne peut pas recevoir un prix écrit à la main dans du JSX.
+
+*(Les chiffres eux-mêmes ne sont recopiés ni ici, ni dans les commentaires du code : ils
+vivent dans `front/src/content/offres/sea-tarifs.ts`, et nulle part ailleurs.)*
 
 ### 6. Un montant, une seule écriture
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -26,6 +26,8 @@ Point d'entrée unique du contenu : `front/src/content/index.ts`.
 |--------|------|-----------|
 | `IOffre` | Une des trois offres de service. Porte l'accroche et la **décision** que la prestation permet de trancher. | Contient 1..n `IAxeOffre`. Référencée par `IExperience.offresLiees`. |
 | `IAxeOffre` | Un axe de travail à l'intérieur d'une offre : ce qui est fait, la preuve qui l'appuie, et le `volet` auquel il appartient le cas échéant. | Appartient à une `IOffre`. |
+| `IGrilleTarifaire` | Les prix publiés pour une offre, et l'argument qui les rend cohérents. Une seule existe : celle de **SEA**. | Pointe vers une `IOffre` (`offre`), contient 1..n `ITarif`, porte une `IReferencePreuve`. |
+| `ITarif` | Une ligne tarifaire : la prestation, sa condition d'application, son `Montant`. | Appartient à une `IGrilleTarifaire`. |
 | `IExperience` | Une expérience professionnelle du parcours. | Pointe vers 1..n `IOffre` via `offresLiees` (clés `CleOffre`). |
 | `IFormation` | Un diplôme obtenu. | Aucune. |
 | `ICertification` | Une certification et son justificatif officiel. | Porte un `Justificatif` (union discriminée). |
@@ -36,6 +38,9 @@ Point d'entrée unique du contenu : `front/src/content/index.ts`.
 ```mermaid
 erDiagram
     IOFFRE      ||--|{ IAXEOFFRE     : "contient"
+    IOFFRE      ||--o| IGRILLETARIFAIRE : "tarifée par (0 ou 1)"
+    IGRILLETARIFAIRE ||--|{ ITARIF   : "contient"
+    ITARIF      ||--|| MONTANT       : "porte"
     IEXPERIENCE }o--|{ IOFFRE        : "appuie (offresLiees)"
     ICERTIFICATION ||--|| JUSTIFICATIF : "porte"
     IIDENTITE   ||--|| ICONTACT      : "porte"
@@ -73,12 +78,15 @@ Elles sont portées **deux fois** : par le typage (à la compilation) et par le 
 | Une offre a au moins un axe ; une expérience au moins un fait | schémas Zod |
 | `IAxeOffre.volet` est optionnel mais jamais vide s'il est présent | `axe-offre.schema.ts` |
 | `anneeFin >= anneeDebut` sur une expérience | `experience.schema.ts` (`refine`) |
+| `maximum > minimum` sur une fourchette de prix | `tarif.schema.ts` (`refine`) |
+| Montants en euros **entiers et positifs** (pas de centimes, pas de zéro) | `tarif.schema.ts` |
+| Une grille tarifaire a au moins une ligne | `grille-tarifaire.schema.ts` |
 | Années bornées à `2000..2100`, entières | schémas Zod |
 | Aucune clé inconnue dans une entité | `z.strictObject` |
 
 ## Règle de véracité portée par le typage
 
-Deux règles du [`CLAUDE.md`](../CLAUDE.md) ne sont pas laissées à la vigilance du
+Plusieurs règles du [`CLAUDE.md`](../CLAUDE.md) ne sont pas laissées à la vigilance du
 rédacteur : elles sont **rendues impossibles à enfreindre** par le modèle.
 
 ### 1. Pas de lien de certification mort ou inventé
@@ -138,6 +146,72 @@ de référence classent « Anglais, B2 (EF SET, CECRL) » sous *Langues*. EF SET
 qui évalue le niveau, pas un titre obtenu. La compétence part donc dans `knowsLanguage`
 du JSON-LD, jamais dans `hasCredential` — où elle aurait gonflé la liste des
 certifications d'une ligne indue.
+
+### 5. Pas de montant sans sa mention fiscale
+
+Un prix publié engage Jérôme vis-à-vis d'un prospect, et un prix sans mention fiscale est
+ambigu — l'ambiguïté se paie au premier échange commercial. La mention n'est donc pas une
+consigne de rédaction : c'est une **propriété du montant**, absente des variantes qui ne
+portent aucun chiffre. `Montant` (dans `front/src/interfaces/types.ts`) est bâti comme
+`Justificatif` :
+
+```ts
+export type Montant =
+  | { readonly nature: 'inclus' }
+  | {
+      readonly nature: 'fourchette'
+      readonly minimum: number
+      readonly maximum: number
+      readonly mentionFiscale: MentionFiscale
+      readonly periodicite: Periodicite
+      readonly variableSelon: string
+    }
+  | { readonly nature: 'sur-devis'; readonly periodicite: Periodicite }
+```
+
+Conséquences, toutes vérifiées :
+
+- écrire une fourchette **sans** `mentionFiscale` est une **erreur de compilation**
+  (`TS2322` — *Property 'mentionFiscale' is missing … but required*) ;
+- écrire une `mentionFiscale` sur une ligne `inclus` ou `sur-devis` — là où il n'y a
+  aucun montant à taxer — est une **erreur de compilation** (`TS2353`), et le
+  `z.strictObject` la rejetterait aussi **au chargement** ;
+- lire `montant.minimum` sans narrowing sur `nature === 'fourchette'` ne compile pas : un
+  rendu ne peut pas afficher un chiffre qui n'existe pas ;
+- `MentionFiscale` vaut `'TTC'` et rien d'autre. L'arbitrage rendu (2026-08-08) est
+  *toutes taxes comprises* ; publier du hors taxes serait un **second arbitrage
+  commercial**, qui passerait par une modification explicite du type, relue en PR ;
+- une fourchette inversée est refusée **au build** par le `refine` de `tarif.schema.ts`,
+  avec le message *« La borne haute d'une fourchette doit être strictement supérieure à
+  la borne basse. »* — l'égalité est refusée aussi : deux bornes identiques ne sont pas
+  une estimation, c'est un prix ferme déguisé.
+
+Côté **rendu**, la garantie est prolongée par `front/src/utils/tarif.ts`, seul module qui
+transforme un `Montant` en texte. Il émet toujours le chiffre et sa mention d'un seul
+tenant (« 300 à 1 200 € TTC, une seule fois, selon le périmètre ») ; la fonction qui met
+en forme les euros **n'est pas exportée**, il n'existe donc aucun moyen d'obtenir un
+montant nu. Sa sortie porte un type marqué, `MontantAffichable` : un composant qui déclare
+ce type en propriété ne peut pas recevoir un prix écrit à la main dans du JSX.
+
+### 6. Un montant, une seule écriture
+
+Comme pour les coordonnées, les montants ne sont **saisis qu'une fois**, dans
+`front/src/content/offres/sea-tarifs.ts`. Ni le [`README.md`](../README.md), ni ce
+document, ni une page ne les recopient : ils décrivent la grille — incluse, fourchette
+TTC une seule fois selon le périmètre, forfait mensuel sur devis — et renvoient au
+fichier. Deux écritures d'un même prix finissent par diverger, et c'est la copie oubliée
+qui se retrouve devant le prospect.
+
+La grille est rattachée à son offre par `IGrilleTarifaire.offre` plutôt que d'être un
+champ obligatoire d'`IOffre` : **Data & IA est entièrement sur devis** et Ingénierie Web
+n'a pas d'arbitrage rendu. Un champ obligatoire aurait forcé à inventer des montants là
+où il n'y en a pas ; l'absence de grille est ici une information, pas un trou.
+
+L'argument commercial qui justifie la gratuité de la mise en place vit dans
+`IGrilleTarifaire.argument`, à la première personne du singulier, et la preuve chiffrée
+qui l'appuie est **désignée** par `IReferencePreuve` (offre `sea`, axe `sea-pilotage`) et
+non recopiée : les budgets pilotés et les prestataires encadrés restent écrits à un seul
+endroit, dans l'offre.
 
 ## Validation au chargement
 

--- a/front/src/content/index.ts
+++ b/front/src/content/index.ts
@@ -10,4 +10,11 @@ export { certifications } from './certifications'
 export { experiences } from './experiences'
 export { formations } from './formations'
 export { identite } from './identite'
-export { offreDataIa, offreIngenierieWeb, offreSea, offres } from './offres'
+export {
+  grillesTarifaires,
+  grilleTarifaireSea,
+  offreDataIa,
+  offreIngenierieWeb,
+  offreSea,
+  offres,
+} from './offres'

--- a/front/src/content/offres/index.ts
+++ b/front/src/content/offres/index.ts
@@ -2,12 +2,14 @@
 // Les trois offres de service, dans leur ordre de présentation sur le site.
 // Chaque offre est déjà validée par son module : importer d'ici ou du module direct
 // donne toujours une donnée conforme au schéma.
+import type { IGrilleTarifaire } from '../../interfaces/grille-tarifaire'
 import type { IOffre } from '../../interfaces/offre'
 import { offreDataIa } from './data-ia'
 import { offreIngenierieWeb } from './ingenierie-web'
 import { offreSea } from './sea'
+import { grilleTarifaireSea } from './sea-tarifs'
 
-export { offreDataIa, offreIngenierieWeb, offreSea }
+export { grilleTarifaireSea, offreDataIa, offreIngenierieWeb, offreSea }
 
 /**
  * Ordre éditorial : la chaîne, dans l'ordre où elle se déroule. Je cadre et je
@@ -15,3 +17,13 @@ export { offreDataIa, offreIngenierieWeb, offreSea }
  * projets data et IA (Data & IA) et pilote l'acquisition (SEA).
  */
 export const offres: readonly IOffre[] = [offreIngenierieWeb, offreDataIa, offreSea]
+
+/**
+ * Grilles tarifaires publiées, par offre. Une seule à ce jour : SEA.
+ *
+ * Ingénierie Web n'a pas encore d'arbitrage rendu, et Data & IA est **entièrement sur
+ * devis** — un projet data se chiffre au périmètre. Leur absence ici est donc une
+ * information, pas un oubli : c'est aussi ce qui interdit d'y faire apparaître un montant
+ * par inadvertance.
+ */
+export const grillesTarifaires: readonly IGrilleTarifaire[] = [grilleTarifaireSea]

--- a/front/src/content/offres/sea-tarifs.ts
+++ b/front/src/content/offres/sea-tarifs.ts
@@ -1,0 +1,62 @@
+// sea-tarifs.ts — jeromemarichez2026
+// Grille tarifaire de l'offre « SEA ». Arbitrages de Jérôme MARICHEZ du 2026-08-08,
+// issue #17.
+//
+// CE FICHIER EST LE SEUL ENDROIT DU DÉPÔT OÙ UN MONTANT EST ÉCRIT. Ni le README, ni la
+// documentation, ni une page ne recopient les chiffres : ils décrivent la grille et
+// renvoient ici. Deux écritures d'un même prix finiraient par diverger, et la seconde
+// engagerait Jérôme vis-à-vis d'un prospect sans que personne ne s'en aperçoive.
+//
+// C'est le premier engagement commercial chiffré du site. Les valeurs ci-dessous sont
+// celles validées : elles ne se déduisent pas, ne s'arrondissent pas et ne
+// s'« harmonisent » pas. Une première intention chiffrée avait été évoquée puis
+// abandonnée au profit de la fourchette ; c'est la fourchette qui fait foi, et le montant
+// abandonné ne figure nulle part dans ce dépôt, pas même en commentaire.
+//
+// La mention « toutes taxes comprises » n'est pas une note de bas de page : elle est une
+// propriété du montant lui-même (`Montant`, interfaces/types.ts) et sort collée au
+// chiffre par `utils/tarif.ts`.
+import type { IGrilleTarifaire } from '../../interfaces/grille-tarifaire'
+import { grilleTarifaireSchema } from '../../schemas/grille-tarifaire.schema'
+
+const donnees = {
+  offre: 'sea',
+  argument:
+    'En encadrant des prestataires d’acquisition avant de piloter moi-même, j’ai vu la même mécanique se répéter : les campagnes s’optimisent sur les métriques de la régie — coût par clic, conversions déclarées — parce que c’est la seule matière disponible de ce côté-là, pendant que l’entreprise décide sur ses chiffres à elle : marge, stock, valeur d’un client dans la durée. Ce n’est pas une affaire de compétence, c’est une affaire d’accès. C’est ce qui rend la mise en place incluse quand j’ai conçu le site : c’est le seul cas où la mesure est construite dans le produit dès le départ, du côté de vos chiffres.',
+  // Preuve DÉSIGNÉE et non recopiée : les budgets pilotés et les prestataires encadrés
+  // sont déjà écrits — une seule fois — sur l'axe « Pilotage des campagnes » de l'offre.
+  preuve: { offre: 'sea', axe: 'sea-pilotage' },
+  lignes: [
+    {
+      cle: 'mise-en-place-site-concu',
+      intitule: 'Mise en place de la solution data-driven',
+      condition: 'si j’ai conçu le site',
+      // Aucun montant : c'est la charnière économique de la chaîne cadrage →
+      // développement → câblage data → SEA, et la raison concrète de prendre le tout
+      // chez un seul interlocuteur.
+      montant: { nature: 'inclus' },
+    },
+    {
+      cle: 'mise-en-place-site-existant',
+      intitule: 'Mise en place de la solution data-driven',
+      condition: 'sur un site existant, que je n’ai pas conçu',
+      montant: {
+        nature: 'fourchette',
+        minimum: 300,
+        maximum: 1200,
+        mentionFiscale: 'TTC',
+        periodicite: 'une-seule-fois',
+        variableSelon: 'le périmètre',
+      },
+    },
+    {
+      cle: 'gestion-du-compte',
+      intitule: 'Gestion du compte',
+      condition: 'ensuite, une fois la solution en place',
+      montant: { nature: 'sur-devis', periodicite: 'mensuel' },
+    },
+  ],
+} satisfies IGrilleTarifaire
+
+/** Validée au chargement : une donnée non conforme échoue au build, pas en production. */
+export const grilleTarifaireSea: IGrilleTarifaire = grilleTarifaireSchema.parse(donnees)

--- a/front/src/content/offres/sea.ts
+++ b/front/src/content/offres/sea.ts
@@ -15,8 +15,13 @@
 // Protocol, GA, Matomo et CMP (ni Tealium, ni Adobe) ; régies limitées à Google Ads
 // et Bing Ads (ni Meta Ads, ni LinkedIn Ads). Les budgets cités (100 000 € chez Truffle
 // Capital, environ 25 000 € chez Verhoeven Joaillier) sont des faits du PARCOURS : ils
-// décrivent ce qui a été fait, pas ce qui est vendu. Aucun tarif n'est publié : la
-// tarification fait l'objet d'un arbitrage distinct (HT ou TTC) non encore rendu.
+// décrivent ce qui a été fait, pas ce qui est vendu.
+//
+// Tarifs (issue #17, arbitrage du 2026-08-08) : ils ne sont PAS ici. La grille vit dans
+// `sea-tarifs.ts`, seul fichier du dépôt où un montant est écrit. L'axe « Pilotage des
+// campagnes » ci-dessous porte la preuve chiffrée que la grille désigne par référence —
+// ne pas en modifier la clé (`sea-pilotage`) ni la vider sans mettre à jour la grille et
+// la page d'accueil, qui la référencent toutes deux.
 import type { IOffre } from '../../interfaces/offre'
 import { offreSchema } from '../../schemas/offre.schema'
 

--- a/front/src/interfaces/grille-tarifaire.ts
+++ b/front/src/interfaces/grille-tarifaire.ts
@@ -1,0 +1,36 @@
+// grille-tarifaire.ts — jeromemarichez2026
+// Entité éditoriale : la grille tarifaire publiée pour une offre.
+import type { IReferencePreuve } from './reference-preuve'
+import type { ITarif } from './tarif'
+import type { CleOffre } from './types'
+
+/**
+ * La grille tarifaire d'une offre : ses lignes, et l'argument qui les rend cohérentes.
+ *
+ * Toutes les offres n'en ont pas — Data & IA est entièrement sur devis, un projet data
+ * se chiffrant au périmètre. Une grille est donc une entité à part, rattachée à son
+ * offre par `offre`, et non un champ obligatoire d'`IOffre` : rendre le champ
+ * obligatoire aurait forcé à inventer des montants là où il n'y en a pas.
+ *
+ * `argument` porte la raison d'être de la grille — pourquoi la mise en place est incluse
+ * quand j'ai conçu le site. Il se dit à la **première personne, depuis l'expérience
+ * vécue** : « en encadrant des prestataires, j'ai vu que… », jamais comme un jugement
+ * sur une profession. Aucun nom d'agence, aucune généralisation : le dénigrement de
+ * concurrents est juridiquement risqué, et un prospect déjà accompagné se sentirait pris
+ * à partie.
+ *
+ * `preuve` est une **référence** vers une preuve déjà écrite dans une offre, jamais son
+ * texte : les chiffres du parcours qui appuient l'argument (budgets pilotés, prestataires
+ * encadrés) restent écrits à un seul endroit, relus une seule fois, et ne peuvent pas
+ * diverger d'une page à l'autre.
+ */
+export interface IGrilleTarifaire {
+  /** L'offre dont cette grille publie les prix. */
+  readonly offre: CleOffre
+  /** Les lignes, dans leur ordre de lecture : le cas inclus d'abord. */
+  readonly lignes: readonly ITarif[]
+  /** L'argument commercial, à la première personne du singulier. */
+  readonly argument: string
+  /** La preuve chiffrée qui appuie l'argument, désignée et non recopiée. */
+  readonly preuve: IReferencePreuve
+}

--- a/front/src/interfaces/tarif.ts
+++ b/front/src/interfaces/tarif.ts
@@ -1,0 +1,32 @@
+// tarif.ts — jeromemarichez2026
+// Entité éditoriale : une ligne de la grille tarifaire d'une offre.
+import type { Montant } from './types'
+
+/**
+ * Une ligne tarifaire : une prestation, le cas dans lequel elle s'applique, et son prix.
+ *
+ * C'est le premier engagement commercial chiffré du site. La séparation
+ * `intitule` / `condition` n'est pas cosmétique : la même prestation — la mise en place
+ * de la solution data-driven — n'a pas le même prix selon que j'ai conçu le site ou non.
+ * Deux lignes portent donc le même `intitule` et deux `condition` différentes, et le
+ * prospect identifie son cas avant de lire un montant plutôt que l'inverse.
+ *
+ * Le prix lui-même est un `Montant` (union discriminée, `interfaces/types.ts`) : c'est
+ * lui qui rend impossible la publication d'un chiffre sans sa mention fiscale.
+ */
+export interface ITarif {
+  /** Clé stable, unique au sein de la grille. Sert d'identifiant de rendu. */
+  readonly cle: string
+  /** La prestation vendue. Reprise à l'identique d'une ligne à l'autre si c'est la même. */
+  readonly intitule: string
+  /**
+   * Le cas dans lequel cette ligne s'applique, à la première personne du singulier
+   * (« si j'ai conçu le site ») — comme tout le contenu publié.
+   *
+   * Obligatoire : une ligne tarifaire sans condition d'application oblige le prospect à
+   * deviner laquelle le concerne, et deux montants ambigus valent moins que pas de prix
+   * du tout.
+   */
+  readonly condition: string
+  readonly montant: Montant
+}

--- a/front/src/interfaces/types.ts
+++ b/front/src/interfaces/types.ts
@@ -27,3 +27,64 @@ export type NiveauFormation = 'Bac +3' | 'Bac +5'
 export type Justificatif =
   | { readonly statut: 'disponible'; readonly url: string }
   | { readonly statut: 'a-fournir' }
+
+/**
+ * Mention fiscale accompagnant un montant publié.
+ *
+ * Union à un seul membre, volontairement : l'arbitrage rendu par Jérôme MARICHEZ le
+ * 2026-08-08 est **toutes taxes comprises**. Publier du hors taxes serait un second
+ * arbitrage commercial, pas une saisie de contenu — il passerait donc par une
+ * modification explicite de ce type, relue en revue de PR, et non par la main d'un
+ * rédacteur pressé.
+ */
+export type MentionFiscale = 'TTC'
+
+/**
+ * Rythme auquel une ligne tarifaire est due.
+ *
+ * Ni la fréquence ni son libellé ne sont laissés au texte libre : « une seule fois » et
+ * « forfait mensuel » sont des engagements commerciaux au même titre que le montant,
+ * et un rendu qui les oublierait laisserait croire à un abonnement là où il n'y a qu'un
+ * paiement — ou l'inverse.
+ */
+export type Periodicite = 'une-seule-fois' | 'mensuel'
+
+/**
+ * Montant d'une ligne tarifaire : trois cas, et un seul porte des chiffres.
+ *
+ * Union discriminée bâtie sur le même principe que `Justificatif` ci-dessus — la
+ * garantie vient du modèle, pas de la vigilance du prochain rédacteur :
+ *
+ * - `fourchette` est la **seule** variante à porter des nombres, et `mentionFiscale` y
+ *   est **obligatoire** : écrire un montant sans sa mention n'est pas un oubli de
+ *   rédaction, c'est une erreur de compilation (TS2741). Un prix sans mention fiscale
+ *   est ambigu, et l'ambiguïté se paie au premier échange avec un prospect ;
+ * - `inclus` et `sur-devis` ne portent **aucune** propriété `mentionFiscale` : l'écrire
+ *   là où il n'y a aucun montant à taxer ne compile pas davantage (TS2353), et le
+ *   `z.strictObject` du schéma la rejetterait aussi au chargement ;
+ * - lire `montant.minimum` sans avoir narrowé sur `nature === 'fourchette'` est une
+ *   erreur de compilation : un rendu ne peut pas afficher un chiffre qui n'existe pas.
+ *
+ * Le rendu, lui, ne compose jamais ces champs à la main : `utils/tarif.ts` est le seul
+ * point qui transforme un `Montant` en texte, et il émet toujours le chiffre et sa
+ * mention d'un seul tenant.
+ */
+export type Montant =
+  | { readonly nature: 'inclus' }
+  | {
+      readonly nature: 'fourchette'
+      /** Borne basse, en euros. Entière et positive. */
+      readonly minimum: number
+      /** Borne haute, en euros. Strictement supérieure à `minimum` (schéma Zod). */
+      readonly maximum: number
+      readonly mentionFiscale: MentionFiscale
+      readonly periodicite: Periodicite
+      /**
+       * Ce qui fait varier le prix entre les deux bornes, au génitif : « le périmètre ».
+       *
+       * Obligatoire : une fourchette qui ne dit pas ce qui la fait varier laisse le
+       * prospect deviner de quel côté il tombera.
+       */
+      readonly variableSelon: string
+    }
+  | { readonly nature: 'sur-devis'; readonly periodicite: Periodicite }

--- a/front/src/schemas/grille-tarifaire.schema.ts
+++ b/front/src/schemas/grille-tarifaire.schema.ts
@@ -1,0 +1,19 @@
+// grille-tarifaire.schema.ts — jeromemarichez2026
+// Schéma Zod de l'entité IGrilleTarifaire. Le type est dérivé du schéma (z.infer),
+// jamais écrit à la main. Convention : docs/architecture.md.
+import { z } from 'zod'
+import { referencePreuveSchema } from './reference-preuve.schema'
+import { tarifSchema } from './tarif.schema'
+
+export const grilleTarifaireSchema = z.strictObject({
+  offre: z.literal(['ingenierie-web', 'data-ia', 'sea']),
+  // Une grille vide n'est pas une grille : publier « Tarifs » sans ligne serait pire que
+  // ne rien publier.
+  lignes: z.array(tarifSchema).min(1),
+  // L'argument qui rend la gratuité de la mise en place cohérente. À la première
+  // personne du singulier, comme tout le contenu publié.
+  argument: z.string().min(1),
+  preuve: referencePreuveSchema,
+})
+
+export type GrilleTarifaireValide = z.infer<typeof grilleTarifaireSchema>

--- a/front/src/schemas/reference-preuve.schema.ts
+++ b/front/src/schemas/reference-preuve.schema.ts
@@ -1,0 +1,23 @@
+// reference-preuve.schema.ts — jeromemarichez2026
+// Schéma Zod de l'entité IReferencePreuve. Le type est dérivé du schéma (z.infer),
+// jamais écrit à la main. Convention : docs/architecture.md.
+//
+// Note de reprise : `accueil.schema.ts` porte une définition locale identique, écrite
+// avant ce fichier. Elle a vocation à être remplacée par cet import — le faire ici
+// sortirait du périmètre de l'issue #17, la page d'accueil étant en cours de réécriture
+// en parallèle. Aucune valeur n'est dupliquée entre les deux, seulement la forme.
+import { z } from 'zod'
+
+/**
+ * Une preuve DÉSIGNÉE, jamais recopiée : l'offre et la clé de l'axe qui la porte.
+ *
+ * La validité de la référence (offre connue, axe connu, preuve non nulle) ne se vérifie
+ * pas ici mais à la résolution — `services/preuves.service.ts` échoue bruyamment au
+ * build plutôt que d'afficher une affirmation sans preuve.
+ */
+export const referencePreuveSchema = z.strictObject({
+  offre: z.literal(['ingenierie-web', 'data-ia', 'sea']),
+  axe: z.string().min(1),
+})
+
+export type ReferencePreuveValide = z.infer<typeof referencePreuveSchema>

--- a/front/src/schemas/tarif.schema.ts
+++ b/front/src/schemas/tarif.schema.ts
@@ -16,9 +16,9 @@ const periodiciteSchema = z.literal(['une-seule-fois', 'mensuel'])
  *
  * Le `refine` rejette une borne haute **inférieure ou égale** à la borne basse. La
  * consigne ne demandait que le cas inférieur ; l'égalité est refusée aussi, parce qu'une
- * fourchette dont les deux bornes coïncident n'est pas une fourchette — elle afficherait
- * « 300 à 300 € », un prix ferme déguisé en estimation. Le jour où un montant unique
- * devra être publié, il prendra sa propre variante plutôt que d'emprunter celle-ci.
+ * fourchette dont les deux bornes coïncident n'est pas une fourchette : elle afficherait
+ * deux fois le même chiffre, un prix ferme déguisé en estimation. Le jour où un montant
+ * unique devra être publié, il prendra sa propre variante plutôt que d'emprunter celle-ci.
  */
 const fourchetteSchema = z
   .strictObject({

--- a/front/src/schemas/tarif.schema.ts
+++ b/front/src/schemas/tarif.schema.ts
@@ -1,0 +1,64 @@
+// tarif.schema.ts — jeromemarichez2026
+// Schéma Zod de l'entité ITarif et du `Montant` qu'elle porte. Le type est dérivé du
+// schéma (z.infer), jamais écrit à la main. Convention : docs/architecture.md.
+import { z } from 'zod'
+
+const periodiciteSchema = z.literal(['une-seule-fois', 'mensuel'])
+
+/**
+ * Une fourchette de prix : la seule forme de montant qui porte des chiffres.
+ *
+ * `mentionFiscale` y est **requise** — c'est le pendant, au chargement, de ce que le
+ * typage interdit déjà à la compilation : aucun montant chiffré ne peut être publié sans
+ * dire s'il s'entend toutes taxes comprises. `z.literal('TTC')` fige l'arbitrage rendu
+ * par Jérôme MARICHEZ le 2026-08-08 : une valeur `'HT'` glissée dans le contenu échoue
+ * au build.
+ *
+ * Le `refine` rejette une borne haute **inférieure ou égale** à la borne basse. La
+ * consigne ne demandait que le cas inférieur ; l'égalité est refusée aussi, parce qu'une
+ * fourchette dont les deux bornes coïncident n'est pas une fourchette — elle afficherait
+ * « 300 à 300 € », un prix ferme déguisé en estimation. Le jour où un montant unique
+ * devra être publié, il prendra sa propre variante plutôt que d'emprunter celle-ci.
+ */
+const fourchetteSchema = z
+  .strictObject({
+    nature: z.literal('fourchette'),
+    // Des euros entiers et positifs : le site ne publie pas de centimes, et un montant
+    // nul ou négatif n'est pas un prix.
+    minimum: z.number().int().positive(),
+    maximum: z.number().int().positive(),
+    mentionFiscale: z.literal('TTC'),
+    periodicite: periodiciteSchema,
+    variableSelon: z.string().min(1),
+  })
+  .refine((fourchette) => fourchette.maximum > fourchette.minimum, {
+    message: 'La borne haute d’une fourchette doit être strictement supérieure à la borne basse.',
+    path: ['maximum'],
+  })
+
+/**
+ * Montant d'une ligne tarifaire, en trois cas exclusifs.
+ *
+ * Union discriminée en `strictObject`, comme `justificatifSchema` : les variantes
+ * `inclus` et `sur-devis` REFUSENT toute clé supplémentaire, une `mentionFiscale` ou un
+ * `minimum` glissé sur une prestation sans prix affiché échoue donc au chargement, en
+ * plus de ne pas compiler.
+ */
+export const montantSchema = z.discriminatedUnion('nature', [
+  z.strictObject({ nature: z.literal('inclus') }),
+  fourchetteSchema,
+  z.strictObject({ nature: z.literal('sur-devis'), periodicite: periodiciteSchema }),
+])
+
+export const tarifSchema = z.strictObject({
+  cle: z
+    .string()
+    .regex(/^[a-z0-9-]+$/, 'La clé d’une ligne tarifaire est en minuscules, chiffres et tirets.'),
+  intitule: z.string().min(1),
+  // Une ligne sans condition d'application obligerait le prospect à deviner laquelle des
+  // deux mises en place le concerne : jamais vide.
+  condition: z.string().min(1),
+  montant: montantSchema,
+})
+
+export type TarifValide = z.infer<typeof tarifSchema>

--- a/front/src/utils/tarif.ts
+++ b/front/src/utils/tarif.ts
@@ -7,7 +7,10 @@
 // typage : `Montant` interdit d'ÉCRIRE un chiffre sans sa mention fiscale, et cette
 // fonction interdit de l'AFFICHER sans elle — les deux sortent d'un seul et même gabarit,
 // inséparables. La fonction qui met en forme les euros n'est volontairement pas exportée :
-// il n'existe aucun moyen d'obtenir « 1 200 € » tout seul.
+// il n'existe aucun moyen d'obtenir un montant nu, détaché de sa mention.
+//
+// Aucun chiffre de la grille n'est recopié dans ce fichier, pas même en exemple : les
+// montants ne sont écrits qu'une fois, dans `content/offres/sea-tarifs.ts`.
 import type { Montant, Periodicite } from '../interfaces/types'
 
 /**
@@ -15,9 +18,9 @@ import type { Montant, Periodicite } from '../interfaces/types'
  *
  * Type marqué : seule `formaterMontant` en produit. Un composant qui déclare recevoir un
  * `MontantAffichable` ne peut donc pas se voir passer un prix écrit à la main dans du
- * JSX — la chaîne littérale `'300 à 1 200 €'` ne compile pas à cette place, faute de
- * marque. C'est ce qui étend la garantie « jamais de montant sans mention fiscale »
- * jusqu'au rendu, au lieu de l'arrêter à la donnée.
+ * JSX : une chaîne littérale ne compile pas à cette place, faute de marque. C'est ce qui
+ * étend la garantie « jamais de montant sans mention fiscale » jusqu'au rendu, au lieu de
+ * l'arrêter à la donnée.
  */
 export type MontantAffichable = string & { readonly __montantAffichable: true }
 
@@ -45,7 +48,7 @@ const LIBELLE_FORFAIT: Record<Periodicite, string> = {
 }
 
 /**
- * Groupe les milliers par espaces : `1200` → `1 200`.
+ * Groupe les milliers par espaces : `12000` → `12 000`.
  *
  * Espace ordinaire, et non fine insécable : c'est la graphie déjà employée par le contenu
  * publié (« 100 000 € » dans les preuves du parcours), et un caractère invisible se
@@ -61,7 +64,7 @@ function grouperMilliers(euros: number): string {
  * Les trois cas de la grille validée par Jérôme MARICHEZ (2026-08-08) :
  *
  * - `inclus` → « Incluse » ;
- * - `fourchette` → « 300 à 1 200 € TTC, une seule fois, selon le périmètre » ;
+ * - `fourchette` → « <basse> à <haute> € TTC, une seule fois, selon le périmètre » ;
  * - `sur-devis` → « Forfait mensuel, sur devis ».
  *
  * La mention fiscale est collée au chiffre, dans la même chaîne : elle ne peut pas être

--- a/front/src/utils/tarif.ts
+++ b/front/src/utils/tarif.ts
@@ -1,0 +1,82 @@
+// tarif.ts — jeromemarichez2026
+// Utilitaire transverse : mise en forme d'un montant tarifaire. Pur, sans état, sans
+// métier — convention `src/utils/` du CLAUDE.md.
+//
+// Ce module est le SEUL endroit du dépôt qui transforme un `Montant` en texte affichable.
+// Ce n'est pas une commodité, c'est la seconde moitié de la garantie portée par le
+// typage : `Montant` interdit d'ÉCRIRE un chiffre sans sa mention fiscale, et cette
+// fonction interdit de l'AFFICHER sans elle — les deux sortent d'un seul et même gabarit,
+// inséparables. La fonction qui met en forme les euros n'est volontairement pas exportée :
+// il n'existe aucun moyen d'obtenir « 1 200 € » tout seul.
+import type { Montant, Periodicite } from '../interfaces/types'
+
+/**
+ * Texte d'un montant, prêt à afficher.
+ *
+ * Type marqué : seule `formaterMontant` en produit. Un composant qui déclare recevoir un
+ * `MontantAffichable` ne peut donc pas se voir passer un prix écrit à la main dans du
+ * JSX — la chaîne littérale `'300 à 1 200 €'` ne compile pas à cette place, faute de
+ * marque. C'est ce qui étend la garantie « jamais de montant sans mention fiscale »
+ * jusqu'au rendu, au lieu de l'arrêter à la donnée.
+ */
+export type MontantAffichable = string & { readonly __montantAffichable: true }
+
+/** Le seul point du dépôt qui appose la marque. */
+function marquer(texte: string): MontantAffichable {
+  // Unique `as` du module, et sa raison d'être : une marque n'a de valeur que si un seul
+  // endroit peut la produire. Ce n'est pas le cast d'une donnée externe que le CLAUDE.md
+  // proscrit — la chaîne vient d'être construite deux lignes plus haut.
+  return texte as MontantAffichable
+}
+
+/** Prestation comprise dans une autre. Accord au féminin : « la mise en place … incluse ». */
+const LIBELLE_INCLUS = 'Incluse'
+
+/** Rythme d'un montant chiffré, dit à la suite du prix : « … TTC, une seule fois ». */
+const MODALITE_CHIFFREE: Record<Periodicite, string> = {
+  'une-seule-fois': 'une seule fois',
+  mensuel: 'par mois',
+}
+
+/** Rythme d'un montant non chiffré, qui ouvre la phrase : « Forfait mensuel, sur devis ». */
+const LIBELLE_FORFAIT: Record<Periodicite, string> = {
+  'une-seule-fois': 'Forfait unique',
+  mensuel: 'Forfait mensuel',
+}
+
+/**
+ * Groupe les milliers par espaces : `1200` → `1 200`.
+ *
+ * Espace ordinaire, et non fine insécable : c'est la graphie déjà employée par le contenu
+ * publié (« 100 000 € » dans les preuves du parcours), et un caractère invisible se
+ * perdrait au premier copier-coller d'un rédacteur.
+ */
+function grouperMilliers(euros: number): string {
+  return String(euros).replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+}
+
+/**
+ * Met en forme un montant tarifaire, mention fiscale comprise.
+ *
+ * Les trois cas de la grille validée par Jérôme MARICHEZ (2026-08-08) :
+ *
+ * - `inclus` → « Incluse » ;
+ * - `fourchette` → « 300 à 1 200 € TTC, une seule fois, selon le périmètre » ;
+ * - `sur-devis` → « Forfait mensuel, sur devis ».
+ *
+ * La mention fiscale est collée au chiffre, dans la même chaîne : elle ne peut pas être
+ * reléguée en note de bas de page par une mise en page, ni oubliée par un rendu partiel.
+ */
+export function formaterMontant(montant: Montant): MontantAffichable {
+  switch (montant.nature) {
+    case 'inclus':
+      return marquer(LIBELLE_INCLUS)
+    case 'fourchette': {
+      const { minimum, maximum, mentionFiscale, periodicite, variableSelon } = montant
+      const prix = `${grouperMilliers(minimum)} à ${grouperMilliers(maximum)} € ${mentionFiscale}`
+      return marquer(`${prix}, ${MODALITE_CHIFFREE[periodicite]}, selon ${variableSelon}`)
+    }
+    case 'sur-devis':
+      return marquer(`${LIBELLE_FORFAIT[montant.periodicite]}, sur devis`)
+  }
+}


### PR DESCRIPTION
## Ce que fait cette PR

Publie la grille tarifaire de l'offre **SEA** — le premier engagement commercial chiffré
du site — et le modèle qui empêche, par construction, de publier un montant ambigu.

Les trois lignes validées par Jérôme MARICHEZ le 2026-08-08 sont saisies telles quelles,
sans déduction ni arrondi : mise en place **incluse** si j'ai conçu le site ; mise en
place sur un **site existant**, fourchette **TTC**, une seule fois, selon le périmètre ;
**gestion du compte** ensuite, forfait mensuel sur devis.

## L'exigence centrale : le typage porte la règle

`Montant` (`front/src/interfaces/types.ts`) est une union discriminée bâtie sur le même
principe que `Justificatif` — la garantie vient du modèle, pas de la vigilance du
prochain rédacteur. La variante `fourchette` est la **seule** à porter des nombres, et
`mentionFiscale` y est **obligatoire** ; `inclus` et `sur-devis` n'ont **aucune**
propriété de ce nom.

Les trois erreurs ont été obtenues, puis retirées :

| Ce qu'on essaie d'écrire | Ce qui se passe |
|--------------------------|-----------------|
| une fourchette **sans** `mentionFiscale` | `TS2322` — *Property 'mentionFiscale' is missing … but required* |
| `mentionFiscale` sur une ligne `sur-devis` | `TS2353` — *'mentionFiscale' does not exist in type* |
| `minimum: 1200, maximum: 300` | **build cassé** — *La borne haute d'une fourchette doit être strictement supérieure à la borne basse.* |

Le troisième cas échoue au `next build` parce que le contenu est importé par le layout :
la grille est validée à la construction, jamais en production.

Côté **rendu**, `front/src/utils/tarif.ts` est le seul module qui transforme un `Montant`
en texte. Il émet le chiffre et sa mention d'un seul tenant, et la mise en forme des euros
**n'est pas exportée** — aucun montant nu n'est obtenable. Sa sortie porte un type marqué,
`MontantAffichable`, pour qu'un composant puisse exiger un prix formaté plutôt qu'une
chaîne écrite à la main.

Sorties vérifiées, identiques au mot près à la grille validée :

```
"Incluse"
"300 à 1 200 € TTC, une seule fois, selon le périmètre"
"Forfait mensuel, sur devis"
```

## Une seule écriture des montants

`front/src/content/offres/sea-tarifs.ts` est le **seul fichier du dépôt où un montant est
écrit**. Le `README.md` décrit la grille — prestations, conditions, modalités — et renvoie
au fichier sans recopier les chiffres, exactement comme il le fait déjà pour les
coordonnées de contact. Deux écritures d'un même prix finissent par diverger, et c'est la
copie oubliée qui se retrouve devant le prospect.

La grille est une entité rattachée à son offre (`IGrilleTarifaire.offre`) plutôt qu'un
champ obligatoire d'`IOffre` : **Data & IA est entièrement sur devis** et n'a aucune
grille — un champ obligatoire aurait forcé à inventer des montants là où il n'y en a pas.
`front/src/content/offres/data-ia.ts` n'est pas touché.

## L'argument commercial

`IGrilleTarifaire.argument` porte, **à la première personne et depuis l'expérience
vécue**, ce qui rend la gratuité cohérente : en encadrant des prestataires d'acquisition
avant de piloter moi-même, j'ai vu les campagnes s'optimiser sur les métriques de la régie
pendant que l'entreprise décide sur ses chiffres à elle. *Ce n'est pas une affaire de
compétence, c'est une affaire d'accès.* Aucun nom d'agence, aucune généralisation sur la
profession.

La preuve chiffrée qui l'appuie n'est pas recopiée : elle est **désignée** par
`IReferencePreuve` sur l'axe `sea-pilotage`, où les budgets pilotés sont déjà écrits une
seule fois et déjà relus.

## « 499 »

Le montant évoqué en première intention puis abandonné n'apparaît **nulle part** :
`grep -rn "499"` sur tout le dépôt (hors `node_modules`, `.git`, `.next`,
`package-lock.json`) ne remonte aucune occurrence — ni dans le contenu, ni en commentaire.

## Tests

Aucun fichier de test n'a été écrit ni modifié : le `CLAUDE.md` en réserve l'écriture à
Jérôme MARICHEZ. **Quatre tests sont proposés**, avec intention et contenu complet, dans
le rapport de la session — dont celui qui échoue si un montant perd sa mention TTC ou si
« 499 » réapparaît.

## Vérifications

`make lint`, `make typecheck`, `make test` et `make build` passent en local. Aucun fichier
source ne dépasse 300 lignes. Aucune dépendance ajoutée.

## Point laissé de côté, signalé

`front/src/schemas/accueil.schema.ts` porte toujours une définition locale de
`referencePreuveSchema`, identique à celle du nouveau `reference-preuve.schema.ts`. La
consolidation n'est pas faite ici : la page d'accueil est réécrite en parallèle sur une
autre branche, et le conflit ne vaut pas le gain. Seule la *forme* est dupliquée, aucune
valeur.

Closes #17
