### PR TITLE
feature: accueil en chaine avec fil rouge e-commerce

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -69,6 +69,10 @@ Toutes les combinaisons sont vérifiées **dans les deux thèmes**. Seuils appli
 | `--color-focus` | `--color-surface-muted` | **7.64:1** | 3 | anneau de focus sur fond atténué |
 | `--color-focus` | `--color-accent-soft` | **7.40:1** | 3 | anneau de focus dans le panneau d'appel à l'action |
 | `--color-accent` | `--color-background` | **8.49:1** | 3 | fond d'un lien d'action plein |
+| `--color-depth-text` `#f4f8fb` | `--color-depth-top` `#0f4267` | **9.85:1** | 4.5 | texte sur la borne haute du dégradé de profondeur |
+| `--color-depth-text` | `--color-depth-bottom` `#072235` | **15.25:1** | 4.5 | texte sur la borne basse, et sur la pastille de rattachement |
+| `--color-depth-text-muted` `#b6c9d8` | `--color-depth-top` | **6.18:1** | 4.5 | étiquettes et texte secondaire, borne haute |
+| `--color-depth-text-muted` | `--color-depth-bottom` | **9.56:1** | 4.5 | étiquettes et texte secondaire, borne basse |
 
 ### Thème sombre
 
@@ -98,11 +102,28 @@ Toutes les combinaisons sont vérifiées **dans les deux thèmes**. Seuils appli
 | `--color-focus` | `--color-surface-muted` | **8.11:1** | 3 | anneau de focus sur fond atténué |
 | `--color-focus` | `--color-accent-soft` | **8.13:1** | 3 | anneau de focus dans le panneau d'appel à l'action |
 | `--color-accent` | `--color-background` | **9.79:1** | 3 | fond d'un lien d'action plein |
+| `--color-depth-text` `#eef4f8` | `--color-depth-top` `#0c3550` | **11.53:1** | 4.5 | texte sur la borne haute du dégradé de profondeur |
+| `--color-depth-text` | `--color-depth-bottom` `#061b2a` | **15.80:1** | 4.5 | texte sur la borne basse, et sur la pastille de rattachement |
+| `--color-depth-text-muted` `#adc0d0` | `--color-depth-top` | **6.84:1** | 4.5 | étiquettes et texte secondaire, borne haute |
+| `--color-depth-text-muted` | `--color-depth-bottom` | **9.37:1** | 4.5 | étiquettes et texte secondaire, borne basse |
+
+**Total : 28 combinaisons inventoriées, 56 mesures (deux thèmes), aucun échec.**
 
 **Combinaison la plus juste** : `--color-border-strong` sur `--color-surface-muted` en
 thème clair, à **3.13:1** pour un seuil de 3. C'est la marge la plus faible du socle :
 toute modification de `--color-border-strong` ou de `--color-surface-muted` doit être
-revérifiée.
+revérifiée. Les quatre combinaisons de profondeur, elles, sont larges — la plus juste,
+`--color-depth-text-muted` sur `--color-depth-top` en thème clair, tient **6.18:1** pour
+un seuil de 4.5.
+
+**Texte posé sur un dégradé.** Un ratio ne se calcule que contre une couleur unie, et
+un dégradé en présente une infinité. Les quatre combinaisons de profondeur sont mesurées
+contre les **deux bornes** du dégradé, ce qui suffit à le couvrir entièrement :
+`--color-depth-bottom` est plus sombre que `--color-depth-top` sur les trois canaux, donc
+toute couleur intermédiaire a une luminance comprise entre celles des deux bornes, et le
+ratio avec un avant-plan clair est encadré par les deux ratios mesurés. Cet
+ordonnancement canal par canal est ce qui rend la démonstration valide : il est à
+revérifier avant toute retouche d'une borne.
 
 `--color-border` (séparations décoratives) n'est volontairement pas soumis à un seuil :
 il ne porte aucune information et ne délimite aucun élément interactif. Le jour où une
@@ -140,7 +161,9 @@ Mesuré dans Chrome (headless, pilotage CDP) sur dix largeurs — 320, 360, 390,
 768, 1024, 1280, 1440 et 1920 px — dans les **deux thèmes**.
 
 Résultat : **aucun défilement horizontal** (`documentElement.scrollWidth` égal à la
-largeur du viewport dans les 40 mesures), et aucun élément débordant du viewport.
+largeur du viewport dans les 40 mesures du socle, puis dans les 20 mesures de la page
+d'accueil complète), et aucun élément débordant du viewport — la sonde énumère les
+descendants de `body` dont le bord droit dépasse `clientWidth`, et n'en trouve aucun.
 
 Trois garde-fous portent ce résultat, aucun ne consistant à masquer le débordement
 (`overflow-x: hidden` n'est employé nulle part) :
@@ -155,6 +178,31 @@ Le thème suit `prefers-color-scheme` : fond mesuré à `rgb(252, 252, 250)` en 
 `rgb(14, 16, 19)` en sombre, sans intervention. L'attribut `data-theme` sur `:root`
 permet de forcer l'un ou l'autre si un sélecteur de thème est ajouté plus tard.
 
+## Structure de la page d'accueil
+
+Relevée **sur la page servie** par `next start`, pas sur la source — c'est le seul
+endroit où l'on voit ce qu'un lecteur d'écran reçoit.
+
+| Point | Mesure | État |
+|-------|--------|------|
+| Titre de niveau 1 | `document.querySelectorAll('h1').length` vaut **1** | OK |
+| Continuité des niveaux | Séquence relevée : `h1, h2, h3×4, h2, h3×2, h2, h3×2, h2, h3×3, h2, h3×6, h2` — aucun saut de niveau | OK |
+| Régions nommées | **7** `section[aria-labelledby]` dans `main`, une par section de la page | OK |
+| Thème restitué | `rgb(252, 252, 250)` en clair, `rgb(14, 16, 19)` en sombre, sans intervention | OK |
+
+Deux points relèvent de WCAG 1.4.1 (« l'information n'est jamais portée par la seule
+couleur ») et sont traités par construction :
+
+- l'**ordre** de la chaîne et des chemins d'étapes est porté par des listes ordonnées
+  (`ol`) et par un rang écrit en toutes lettres (« Étape 1 »), jamais par la seule
+  disposition ;
+- le **filet de liaison** entre deux étapes est un pseudo-élément au `content` vide : il
+  ne peut être ni annoncé, ni nécessaire à la compréhension.
+
+Le motif de profondeur n'introduit aucun élément interactif sur le dégradé : les
+maillons de la chaîne et le panneau du constat ne contiennent aucun lien. Aucun anneau
+de focus n'a donc à être mesuré contre les bornes du dégradé.
+
 ## Vérification
 
 - Lint accessibilité (règles a11y de Biome) — `make lint`.
@@ -165,7 +213,7 @@ permet de forcer l'un ou l'autre si un sélecteur de thème est ajouté plus tar
 | Parcours | Audit | État |
 |----------|-------|------|
 | Layout global (en-tête, contenu, pied de page) | Contrastes recalculés, clavier, 320→1920 px, deux thèmes | Vérifié |
-| Page d'accueil | — | À faire (autre lot) |
+| Page d'accueil | Contrastes recalculés (28 couples), 320→1920 px dans les deux thèmes, hiérarchie de titres et régions relevées sur la page servie | Vérifié |
 | Pages de services | — | À faire (autre lot) |
 | Parcours | — | À faire (autre lot) |
 | Formulaire de contact | — | À faire (autre lot) ; couleurs d'état à définir et à mesurer |

--- a/docs/design.md
+++ b/docs/design.md
@@ -43,7 +43,7 @@ Source : `front/src/@shared/styles/tokens.css`.
 
 ### Couleurs
 
-Douze jetons, déclarés à l'identique dans les deux thèmes. Les valeurs de contraste
+Seize jetons, déclarés à l'identique dans les deux thèmes. Les valeurs de contraste
 mesurées sont dans [`accessibility.md`](./accessibility.md).
 
 | Jeton | Clair | Sombre | Usage |
@@ -60,6 +60,15 @@ mesurées sont dans [`accessibility.md`](./accessibility.md).
 | `--color-accent-contrast` | `#ffffff` | `#07131c` | texte posé sur l'accent |
 | `--color-accent-soft` | `#e3eef6` | `#152430` | pastilles, fonds d'accent discrets |
 | `--color-focus` | `#0b4f79` | `#7fc1f0` | anneau de focus |
+| `--color-depth-top` | `#0f4267` | `#0c3550` | borne haute du dégradé de profondeur |
+| `--color-depth-bottom` | `#072235` | `#061b2a` | borne basse du dégradé de profondeur |
+| `--color-depth-text` | `#f4f8fb` | `#eef4f8` | texte principal posé sur la profondeur |
+| `--color-depth-text-muted` | `#b6c9d8` | `#adc0d0` | étiquettes et texte secondaire sur la profondeur |
+
+Les quatre jetons `depth` forment un sous-système fermé : ils ne se mélangent jamais
+aux autres. Un texte posé sur le dégradé emploie `--color-depth-text`, jamais
+`--color-text` — les deux thèmes n'ont pas la même idée de ce qu'est du texte, alors
+que le dégradé, lui, reste sombre dans les deux.
 
 **Palette retenue** : un bleu d'encre profond sur un blanc légèrement chaud. Une seule
 teinte d'accent, pas de couleur secondaire décorative — un site qui vend de l'ingénierie
@@ -110,9 +119,28 @@ Deux espacements fluides portent la mise en page :
 
 `--radius-sm` 4 px, `--radius-md` 8 px, `--radius-lg` 14 px, `--radius-pill`.
 
-`--shadow-sm` et `--shadow-md` sont doux en thème clair et nettement plus sombres en
-thème sombre, où une ombre diffuse ne se voit plus : c'est alors `--color-border` qui
-porte l'essentiel de la séparation entre surfaces.
+Quatre niveaux d'ombre, doux en thème clair et nettement plus sombres en thème sombre,
+où une ombre diffuse ne se voit plus : c'est alors `--color-border` qui porte
+l'essentiel de la séparation entre surfaces.
+
+| Jeton | Rôle |
+|-------|------|
+| `--shadow-sm` | carte posée sur le fond (`Card` par défaut) |
+| `--shadow-md` | surface détachée : carte d'offre, point d'entrée |
+| `--shadow-lg` | surface franchement surélevée : maillon de la chaîne, panneau du constat |
+| `--shadow-xl` | la même, soulevée au survol |
+
+Deux jetons complètent le vocabulaire de profondeur :
+
+| Jeton | Valeur | Rôle |
+|-------|--------|------|
+| `--elevation-lift` | `-2px` | décalage vertical d'une surface soulevée au survol |
+| `--gradient-depth` | `linear-gradient(160deg, …)` | dégradé de bleu profond, bâti sur les deux bornes `--color-depth-*` |
+
+`--gradient-depth` n'est déclaré **que** dans `:root`, et suit pourtant le thème : ses
+deux bornes sont des `var()`, substituées au moment de l'emploi avec la valeur héritée
+par l'élément. L'angle est donc décidé une seule fois, et le thème sombre n'a rien à
+redéclarer.
 
 Largeurs utiles : `--layout-width-narrow` 44 rem (texte suivi),
 `--layout-width-default` 68 rem, `--layout-width-wide` 80 rem (en-tête, grilles).
@@ -196,18 +224,71 @@ employer est la page d'accueil (`views/accueil/`).
 | **Grille de cartes** | `views/accueil/sections/Offres` | `ul` en `grid` `auto-fit` : un lecteur d'écran annonce le nombre de cartes avant de les énumérer. Les `li` sont en `display: grid` pour que chaque carte occupe toute la hauteur de sa rangée et que les pieds de carte s'alignent. |
 | **Liste de preuves** | `views/accueil/sections/Preuves` | Volontairement **pas** des cartes : une preuve n'est pas une surface autonome mais un fait rattaché à une offre. Un filet d'accent de 1 px et un retrait suffisent à la délimiter. |
 | **Panneau d'appel à l'action** | `views/accueil/sections/AppelContact` | Bloc sur `--color-accent-soft`, arrondi en `--radius-lg`, fermant la page. Ne contient qu'un seul lien, et il est `primary`. |
+| **Chaîne** | `views/accueil/sections/Chaine` | `ol` en `grid` `auto-fit` : quatre maillons surélevés sur le dégradé de profondeur. L'ordre est l'information, d'où la liste **ordonnée**. |
+| **Chemin d'étapes** | `views/accueil/sections/PointsEntree` | `ol` de pastilles reliées par un filet. Le filet est un `::after` au `content` **vide** : purement décoratif, jamais restitué. |
+| **Constat en deux colonnes** | `views/accueil/sections/Pourquoi` | Panneau de profondeur, deux colonnes strictement symétriques. Aucun lien à l'intérieur. |
 
-Deux contraintes de ce dernier motif viennent d'une **mesure**, pas d'un goût :
+### Le motif de profondeur
+
+La direction artistique demande de la **tridimensionnalité**, obtenue en **élévation et
+en couches** — jamais en 3D. Une bibliothèque WebGL coûterait 150 à 600 ko et ferait de
+ce site la contre-démonstration de ce qu'il vend : la profondeur est donc entièrement
+en CSS, sans une ligne de JavaScript ni une dépendance.
+
+Quatre procédés, et rien d'autre :
+
+| Procédé | Jetons | Où |
+|---------|--------|-----|
+| Dégradé de bleu profond | `--gradient-depth` | maillons de la chaîne, panneau du constat |
+| Ombre portée franche | `--shadow-lg`, `--shadow-xl` | les mêmes, plus les cartes d'offre et les points d'entrée |
+| Décalage au survol | `--elevation-lift` | toute surface surélevée |
+| Couches de fond alternées | `tone="muted"` de `Section` | rythme vertical de la page |
+
+Deux règles tiennent ce motif :
+
+- **La profondeur bleutée marque ce qui explique, pas ce qui fait agir.** La chaîne et
+  le constat sont sur le dégradé ; les points d'entrée et les offres, qui portent les
+  liens, restent sur `--color-surface`. Un lien sur le dégradé demanderait un cinquième
+  jeu de couleurs (lien, survol, anneau de focus) pour un gain nul.
+- **Le décalage se déclenche aussi au clavier.** Partout où une surface se soulève au
+  survol, elle se soulève également en `:focus-within` : un visiteur au clavier voit la
+  même carte se détacher qu'un visiteur à la souris.
+
+Le mouvement réduit est traité **à la source** : les transitions sont exprimées avec
+`--transition-base`, que `globals.css` passe à `0s` sous
+`prefers-reduced-motion: reduce`. Le décalage devient alors instantané — plus rien ne
+s'anime, sans sélecteur universel ni `!important`. C'est le bénéfice direct de la règle
+« aucune valeur en dur » : il n'y a pas eu une seule animation à retrouver pour la
+neutraliser.
+
+L'élévation des cartes d'offre est appliquée depuis `offres.module.css` via la prop
+`className` de `Card`, et **non** dans `Card` elle-même : la profondeur est un motif de
+la page d'accueil, pas une propriété du composant partagé. Une carte de formulaire ou de
+page d'offre n'a aucune raison de se soulever.
+
+Deux contraintes du **panneau d'appel à l'action** viennent d'une **mesure**, pas d'un
+goût :
 
 - Il ne porte **aucun filet**. `--color-border` sur `--color-accent-soft` ne contraste
   qu'à **1.19:1** (thème clair) : la bordure serait invisible.
 - Il n'accueille **pas** de lien `secondary`. Au survol, un lien secondaire prend
   précisément `--color-accent-soft` comme fond — il disparaîtrait dans le panneau.
 
-Les trois combinaisons de couleurs introduites par ces motifs
-(`text-muted` / `accent-soft`, `accent-hover` / `accent-soft`, `focus` / `accent-soft`)
-sont inscrites dans `@shared/config/contrast-pairs.ts` et mesurées dans
-[`accessibility.md`](./accessibility.md).
+Les combinaisons de couleurs introduites par ces motifs sont inscrites dans
+`@shared/config/contrast-pairs.ts` et mesurées dans
+[`accessibility.md`](./accessibility.md) : trois par le panneau d'appel à l'action
+(`text-muted` / `accent-soft`, `accent-hover` / `accent-soft`, `focus` / `accent-soft`),
+quatre par le motif de profondeur (`depth-text` et `depth-text-muted`, chacun contre les
+deux bornes du dégradé).
+
+**Pourquoi deux bornes suffisent à couvrir un dégradé.** Un ratio ne se calcule que
+contre une couleur unie ; un dégradé en présente une infinité. `--color-depth-bottom`
+est plus sombre que `--color-depth-top` **sur les trois canaux** : toute couleur
+intermédiaire a donc une luminance comprise entre celles des deux bornes, et le ratio
+avec un avant-plan clair est encadré par les deux ratios mesurés. Vérifier les bornes
+vérifie tout le dégradé. Cet ordonnancement canal par canal est la condition de la
+démonstration : le jour où une borne est retouchée, c'est lui qu'il faut revérifier
+d'abord.
 
 ### Libellés de liens répétés
 

--- a/front/src/@shared/config/contrast-pairs.ts
+++ b/front/src/@shared/config/contrast-pairs.ts
@@ -108,6 +108,37 @@ export const CONTRAST_REQUIREMENTS: readonly IContrastRequirement[] = [
     usage: "libellé d'un lien d'action plein survolé",
   },
 
+  // ------------------------------------------- Profondeur (page d'accueil)
+  // Le texte de la chaîne et du constat se pose sur un DÉGRADÉ, pas sur un aplat.
+  // Vérifier ses deux bornes suffit à couvrir tout le dégradé : `--color-depth-bottom`
+  // est plus sombre que `--color-depth-top` sur les trois canaux, donc toute couleur
+  // intermédiaire a une luminance comprise entre les deux, et le ratio avec un
+  // avant-plan clair est encadré par les deux ratios mesurés ici.
+  {
+    foreground: 'color-depth-text',
+    background: 'color-depth-top',
+    minimumRatio: 4.5,
+    usage: 'texte principal sur la borne haute du dégradé de profondeur',
+  },
+  {
+    foreground: 'color-depth-text',
+    background: 'color-depth-bottom',
+    minimumRatio: 4.5,
+    usage: 'texte principal sur la borne basse du dégradé, et sur la pastille de rattachement',
+  },
+  {
+    foreground: 'color-depth-text-muted',
+    background: 'color-depth-top',
+    minimumRatio: 4.5,
+    usage: 'étiquettes et texte secondaire sur la borne haute du dégradé',
+  },
+  {
+    foreground: 'color-depth-text-muted',
+    background: 'color-depth-bottom',
+    minimumRatio: 4.5,
+    usage: 'étiquettes et texte secondaire sur la borne basse du dégradé',
+  },
+
   // ------------------------------- Composants d'interface (WCAG 1.4.11, 3:1)
   {
     foreground: 'color-border-strong',

--- a/front/src/@shared/styles/tokens.css
+++ b/front/src/@shared/styles/tokens.css
@@ -29,6 +29,17 @@
   --color-accent-soft: #e3eef6;
   --color-focus: #0b4f79;
 
+  /* Profondeur : les deux bornes du dégradé de bleu profond et les deux couleurs
+   * de texte qui se posent dessus. Les bornes sont ordonnées canal par canal
+   * (`bottom` est plus sombre que `top` sur R, V ET B) : toute couleur
+   * intermédiaire du dégradé a donc une luminance comprise entre les deux, et
+   * vérifier le contraste aux deux bornes suffit à le garantir partout.
+   * Ratios mesurés : docs/accessibility.md. */
+  --color-depth-top: #0f4267;
+  --color-depth-bottom: #072235;
+  --color-depth-text: #f4f8fb;
+  --color-depth-text-muted: #b6c9d8;
+
   /* ------------------------------------------------------------- Typographie */
   /* Pile système : aucune requête réseau, aucun décalage de mise en page au
    * chargement, aucun appel à un service tiers (contrainte RGPD du README). */
@@ -83,6 +94,19 @@
   /* ------------------------------------------------------------------ Ombres */
   --shadow-sm: 0 1px 2px rgb(22 24 28 / 6%), 0 1px 3px rgb(22 24 28 / 8%);
   --shadow-md: 0 2px 4px rgb(22 24 28 / 5%), 0 8px 24px rgb(22 24 28 / 9%);
+  --shadow-lg: 0 4px 8px rgb(22 24 28 / 8%), 0 16px 40px rgb(22 24 28 / 14%);
+  --shadow-xl: 0 8px 16px rgb(22 24 28 / 10%), 0 28px 64px rgb(22 24 28 / 18%);
+
+  /* --------------------------------------------------------------- Élévation */
+  /* Décalage vertical d'une surface « soulevée » au survol. Négatif : la surface
+   * monte vers le lecteur. Sous `prefers-reduced-motion`, la transition qui le
+   * porte vaut 0s — le décalage devient instantané, plus rien ne bouge. */
+  --elevation-lift: -2px;
+
+  /* Le dégradé de profondeur n'est déclaré QU'ICI, et pourtant il suit le thème :
+   * ses deux bornes sont des `var()`, substituées au moment de l'emploi avec la
+   * valeur héritée par l'élément. Un seul point de vérité pour l'angle. */
+  --gradient-depth: linear-gradient(160deg, var(--color-depth-top), var(--color-depth-bottom));
 
   /* ------------------------------------------------------------------ Layout */
   --layout-width-narrow: 44rem;
@@ -117,10 +141,19 @@
   --color-accent-soft: #152430;
   --color-focus: #7fc1f0;
 
+  /* Bornes assombries : sur un fond #0e1013, le dégradé du thème clair
+   * rayonnerait. Même ordonnancement canal par canal que le thème clair. */
+  --color-depth-top: #0c3550;
+  --color-depth-bottom: #061b2a;
+  --color-depth-text: #eef4f8;
+  --color-depth-text-muted: #adc0d0;
+
   /* Sur fond sombre une ombre diffuse ne se voit plus : on l'assombrit et on
    * s'appuie davantage sur --color-border pour séparer les surfaces. */
   --shadow-sm: 0 1px 2px rgb(0 0 0 / 40%);
   --shadow-md: 0 2px 4px rgb(0 0 0 / 35%), 0 10px 28px rgb(0 0 0 / 50%);
+  --shadow-lg: 0 4px 8px rgb(0 0 0 / 45%), 0 18px 44px rgb(0 0 0 / 60%);
+  --shadow-xl: 0 8px 18px rgb(0 0 0 / 50%), 0 30px 70px rgb(0 0 0 / 68%);
 }
 
 /* Préférence système : thème sombre par défaut, sauf `data-theme='light'` explicite. */
@@ -141,7 +174,14 @@
     --color-accent-soft: #152430;
     --color-focus: #7fc1f0;
 
+    --color-depth-top: #0c3550;
+    --color-depth-bottom: #061b2a;
+    --color-depth-text: #eef4f8;
+    --color-depth-text-muted: #adc0d0;
+
     --shadow-sm: 0 1px 2px rgb(0 0 0 / 40%);
     --shadow-md: 0 2px 4px rgb(0 0 0 / 35%), 0 10px 28px rgb(0 0 0 / 50%);
+    --shadow-lg: 0 4px 8px rgb(0 0 0 / 45%), 0 18px 44px rgb(0 0 0 / 60%);
+    --shadow-xl: 0 8px 18px rgb(0 0 0 / 50%), 0 30px 70px rgb(0 0 0 / 68%);
   }
 }

--- a/front/src/content/accueil.ts
+++ b/front/src/content/accueil.ts
@@ -2,18 +2,26 @@
 // Contenu éditorial de la page d'accueil.
 //
 // Sources de vérité, dans cet ordre : README.md (positionnement, promesse centrale,
-// arborescence) puis CLAUDE.md (ligne éditoriale et règles de véracité).
+// la chaîne et les deux points d'entrée) puis CLAUDE.md (ligne éditoriale et règles
+// de véracité). Arbitrages de Jérôme MARICHEZ du 2026-08-08 (issue #19).
 //
 // Véracité — points tenus ici :
 // - La promesse est reprise dans les termes du README : « un seul interlocuteur […]
 //   aucune sous-traitance — celui qui cadre est celui qui code, mesure et exploite ».
-// - « neuf ans », « en petite équipe ou en autonomie complète » et « décisions
-//   techniques assumées en production » viennent du tableau de positionnement du
-//   README. Aucun chiffre n'est arrondi ni extrapolé.
-// - AUCUNE preuve n'est réécrite ici : la section « preuves » ne contient que des
+// - LE FIL ROUGE E-COMMERCE EST ILLUSTRATIF. Aucun nom d'entreprise, aucune
+//   formulation au passé, aucun résultat chiffré ne lui est rattaché. Jérôme n'a
+//   aucune référence client publiable et n'a jamais mené cette chaîne complète chez
+//   un même e-commerçant : le taggage GTM relève de la période Acetelecom /
+//   MailingVox, l'e-commerce de la période Verhoeven Joaillier. Le champ
+//   `chaine.avertissement` le dit dans le TEXTE VISIBLE — c'est une exigence de
+//   véracité, pas une précaution de style.
+// - AUCUNE preuve n'est réécrite ici : `preuves` et `pourquoi` ne portent que des
 //   RÉFÉRENCES vers des preuves déjà rédigées et relues dans content/offres/.
-//   Une preuve recopiée pourrait diverger de sa page d'offre ; une preuve saisie
-//   directement échapperait à la relecture de véracité.
+// - La section `pourquoi` s'énonce à la PREMIÈRE PERSONNE, depuis l'expérience
+//   vécue. Aucun nom d'agence, aucune généralisation sur la profession, aucun verbe
+//   d'intention prêté à un tiers : le constat porte sur un périmètre d'accès à la
+//   donnée, c'est-à-dire sur un dispositif, jamais sur des personnes.
+// - Aucun prix, aucun montant : la tarification vit dans l'offre SEA, pas ici.
 // - Aucun délai de réponse n'est annoncé : aucun engagement de ce type n'est établi.
 // - Aucun emoji, aucun superlatif (CLAUDE.md, « Ligne éditoriale »).
 import type { IAccueil } from '../interfaces/accueil'
@@ -37,9 +45,138 @@ const donnees = {
     actionSecondaire: { href: '/parcours', libelle: 'Voir mon parcours' },
   },
 
+  chaine: {
+    titre: 'Une chaîne, pas un catalogue',
+    lead: 'Le site produit la donnée, la donnée se structure, le taggage la rend mesurable, et c’est elle qui arbitre les budgets. Chaque étape existe parce que la précédente lui a passé quelque chose.',
+    libelleAvertissement: 'Scénario illustratif',
+    // Le texte visible qui empêche toute lecture « étude de cas ». Il nomme
+    // explicitement ce qui n'a PAS eu lieu, plutôt que de rester vague.
+    avertissement:
+      'Le déroulé e-commerce ci-dessous est un exemple construit pour rendre la chaîne lisible. Il ne décrit aucun client et aucune mission : je n’ai pas mené cette chaîne entière chez un même e-commerçant. Les compétences qu’elle mobilise, elles, sont attestées offre par offre — le taggage et l’entrepôt d’un côté, l’e-commerce de l’autre, sur des périodes différentes de mon parcours.',
+    libelleEtape: 'Étape',
+    libelleIllustration: 'Sur une boutique en ligne',
+    libelleRattachement: 'Couvert par',
+    maillons: [
+      {
+        cle: 'site',
+        titre: 'Le site',
+        role: 'Je cadre le besoin, puis je développe le produit : parcours, pages, tunnel de commande, mise en production et exploitation. Le site est conçu dès le départ pour produire de la donnée, au lieu d’être instrumenté après coup.',
+        illustration:
+          'les fiches produit et les étapes du tunnel sont écrites avec, dès les spécifications, les événements qu’il faudra mesurer plus tard.',
+        libelleSortie: 'Ce qu’il passe à l’étape suivante',
+        sortie: 'Un produit en ligne dont chaque étape est identifiable et nommée.',
+        offres: ['ingenierie-web'],
+      },
+      {
+        cle: 'entrepot',
+        titre: 'La donnée structurée et l’entrepôt',
+        role: 'Je modélise la donnée selon votre métier, puis je l’agrège, la réconcilie et la dédoublonne dans un entrepôt unique. La qualité de la donnée est un prérequis, jamais un correctif appliqué après coup.',
+        illustration:
+          'commandes, marges, stocks et sources d’acquisition cessent de vivre dans quatre outils qui ne comptent pas de la même façon.',
+        libelleSortie: 'Ce qu’il passe à l’étape suivante',
+        sortie: 'Un entrepôt où un euro dépensé et un euro encaissé désignent le même client.',
+        // L'entrepôt est le pivot : il alimente l'acquisition ET les projets data
+        // et IA (README.md — « La chaîne, et les deux points d'entrée »).
+        offres: ['sea', 'data-ia'],
+      },
+      {
+        cle: 'taggage',
+        titre: 'Le taggage',
+        role: 'Je pose le plan de collecte : conteneur Google Tag Manager web et server-side, dataLayer, nomenclature d’événements documentée, consentement géré par catégorie. La conformité conditionne l’architecture de collecte, elle ne s’y ajoute pas.',
+        illustration:
+          'l’ajout au panier, le paiement, le remboursement et le retour remontent avec le même identifiant de commande que l’entrepôt.',
+        libelleSortie: 'Ce qu’il passe à l’étape suivante',
+        sortie:
+          'Une mesure qui décrit ce qui s’est passé, et qui se raccorde à vos chiffres de gestion.',
+        offres: ['sea'],
+      },
+      {
+        cle: 'sea',
+        titre: 'Le SEA',
+        role: 'Je pilote Google Ads et Bing Ads sur la rentabilité client à long terme plutôt que sur les métriques natives des régies : structuration des campagnes, A/B testing, arbitrages de budget.',
+        illustration:
+          'le budget se déplace vers les produits qui laissent de la marge et que le stock permet de livrer, pas vers ceux qui cliquent le mieux.',
+        // Dernier maillon : il ne passe pas la main, il rend une décision.
+        libelleSortie: 'Ce que vous en retirez',
+        sortie:
+          'La décision de remettre — ou non — un euro sur une campagne, prise sur vos chiffres à vous.',
+        offres: ['sea'],
+      },
+    ],
+  },
+
+  pointsEntree: {
+    titre: 'Où vous entrez dans la chaîne',
+    lead: 'Deux situations, deux points d’entrée. Dans les deux cas, l’interlocuteur ne change pas d’une étape à l’autre.',
+    libelleChemin: 'Le chemin',
+    points: [
+      {
+        cle: 'depart-zero',
+        situation: 'Vous partez de zéro',
+        description:
+          'Il n’y a pas encore de produit. On cadre le besoin, je développe, et je câble la donnée dans la foulée : la mesure n’est pas rajoutée à la fin, elle est prévue dans les spécifications.',
+        etapes: ['Cadrage', 'Développement', 'Câblage data', 'SEA'],
+        liens: [
+          {
+            offre: 'ingenierie-web',
+            libelle: 'Commencer par le cadrage — offre Ingénierie Web',
+          },
+        ],
+      },
+      {
+        cle: 'application-existante',
+        situation: 'Vous avez déjà une application',
+        description:
+          'Le produit tourne déjà. On part de l’existant : je branche la collecte et l’entrepôt sur ce qui est en place, puis cette donnée sert à piloter l’acquisition, à alimenter des projets data et IA, ou les deux.',
+        etapes: ['Câblage data', 'SEA ou Data & IA'],
+        liens: [
+          { offre: 'sea', libelle: 'Brancher la mesure sur l’existant — offre SEA' },
+          { offre: 'data-ia', libelle: 'Exploiter la donnée existante — offre Data & IA' },
+        ],
+      },
+    ],
+  },
+
+  pourquoi: {
+    titre: 'D’où vient cette promesse',
+    // Première personne, depuis l'expérience vécue. « Six chiffres » renvoie aux
+    // 100 000 € pilotés chez Truffle Capital : le chiffre exact est apporté par la
+    // preuve référencée plus bas, pas réécrit ici.
+    lead: 'En pilotant des budgets d’acquisition à six chiffres, puis en encadrant les prestataires qui les dépensaient, j’ai vu la même coupure revenir : les chiffres sur lesquels une campagne s’optimise ne sont pas ceux sur lesquels l’entreprise décide.',
+    colonnes: [
+      {
+        cle: 'metriques-regie',
+        titre: 'Ce qu’une régie publicitaire mesure',
+        elements: [
+          'le coût par clic',
+          'les conversions qu’elle déclare elle-même',
+          'le volume d’impressions et de clics',
+        ],
+      },
+      {
+        cle: 'chiffres-entreprise',
+        titre: 'Ce sur quoi vous décidez',
+        elements: [
+          'la marge que laisse chaque produit',
+          'le stock réellement disponible',
+          'la valeur d’un client sur la durée',
+        ],
+      },
+    ],
+    conclusion:
+      'La seconde colonne ne sort d’aucune régie : elle sort de votre système d’information. Un intervenant qui n’y a pas accès travaille sur la première — c’est le seul jeu de chiffres dont il dispose. Question de périmètre, pas de compétence. Câbler la donnée et piloter l’acquisition avec le même interlocuteur, c’est faire tenir les deux colonnes dans le même tableau.',
+    // Les deux faits du parcours qui fondent le constat, repris par référence :
+    // budgets pilotés et prestataires encadrés d'une part, mesure de la rentabilité
+    // à long terme d'autre part.
+    references: [
+      { offre: 'sea', axe: 'sea-pilotage' },
+      { offre: 'sea', axe: 'rentabilite-long-terme' },
+    ],
+  },
+
   offres: {
-    titre: 'Trois offres, un seul interlocuteur',
-    lead: 'Chaque offre se termine sur ce que vous pouvez décider, pas sur une liste d’outils.',
+    titre: 'Les trois pôles de la chaîne',
+    lead: 'Le même interlocuteur les tient tous les trois. Chaque offre se termine sur ce que vous pouvez décider, pas sur une liste d’outils.',
     libelleDecision: 'Ce que vous décidez',
     // Complété par le titre de l'offre : « Voir l'offre Ingénierie Web ». Les trois
     // liens restent distincts et compréhensibles hors contexte (WCAG 2.4.4).
@@ -49,13 +186,15 @@ const donnees = {
   preuves: {
     titre: 'Ce qui rend ces offres crédibles',
     lead: 'Chaque affirmation de ce site porte sa preuve : un chiffre, une durée ou une contrainte tenue. Voici celles qui sont publiables.',
-    // Les cinq preuves listées au README, plus le développement en IA augmentée
-    // piloté par les tests — différenciateur que le CLAUDE.md impose de faire
-    // apparaître partout où le site parle de programmation.
+    // Les preuves listées au README, plus le développement en IA augmentée piloté par
+    // les tests — différenciateur que le CLAUDE.md impose de faire apparaître partout
+    // où le site parle de programmation.
     // Ordre : les trois offres sont représentées dès les trois premières lignes.
+    // SEA est représentée ici par le plan de taggage : ses deux preuves de pilotage
+    // sont déjà portées par la section « pourquoi », et les répéter les affaiblirait.
     references: [
       { offre: 'ingenierie-web', axe: 'ui-ux' },
-      { offre: 'sea', axe: 'sea-pilotage' },
+      { offre: 'sea', axe: 'mesure-taggage' },
       { offre: 'data-ia', axe: 'data-mining' },
       { offre: 'ingenierie-web', axe: 'migrations' },
       { offre: 'ingenierie-web', axe: 'front-end' },

--- a/front/src/interfaces/accueil.ts
+++ b/front/src/interfaces/accueil.ts
@@ -6,6 +6,9 @@
 // faire relire une formulation ne demande jamais de toucher au rendu
 // (docs/architecture.md — « le contenu éditorial est de la donnée, pas du JSX »).
 import type { IAppelAction } from './appel-action'
+import type { IColonneConstat } from './colonne-constat'
+import type { IMaillonChaine } from './maillon-chaine'
+import type { IPointEntree } from './point-entree'
 import type { IReferencePreuve } from './reference-preuve'
 
 /** Métadonnées de la route, consommées par l'export `metadata` de app/page.tsx. */
@@ -21,6 +24,61 @@ interface IAccrocheAccueil {
   readonly lead: string
   readonly actionPrincipale: IAppelAction
   readonly actionSecondaire: IAppelAction
+}
+
+/**
+ * Section de la chaîne : l'enchaînement des quatre maillons, illustré par un scénario
+ * e-commerce.
+ *
+ * `avertissement` n'est pas optionnel. Le scénario est illustratif et doit être annoncé
+ * comme tel DANS LE TEXTE VISIBLE : Jérôme n'a aucune référence client publiable, et il
+ * n'a jamais mené cette chaîne complète chez un même e-commerçant — le taggage GTM
+ * relève de la période Acetelecom / MailingVox, l'e-commerce de la période Verhoeven
+ * Joaillier. Rendre le champ obligatoire met cette exigence dans le TYPE : une chaîne
+ * sans avertissement ne compile pas (CLAUDE.md — « Règles de véracité du contenu »).
+ */
+interface ISectionChaine {
+  readonly titre: string
+  readonly lead: string
+  /** Étiquette courte de l'avertissement, affichée comme une pastille. */
+  readonly libelleAvertissement: string
+  /** Mention visible du caractère illustratif du scénario. Jamais vide. */
+  readonly avertissement: string
+  /** Amorce du rang, complétée par le numéro du maillon : « Étape 1 ». */
+  readonly libelleEtape: string
+  /** Étiquette introduisant `IMaillonChaine.illustration`. */
+  readonly libelleIllustration: string
+  /** Étiquette introduisant les offres qui couvrent le maillon. */
+  readonly libelleRattachement: string
+  readonly maillons: readonly IMaillonChaine[]
+}
+
+/** Section des deux points d'entrée : elle permet au visiteur de se situer. */
+interface ISectionPointsEntree {
+  readonly titre: string
+  readonly lead: string
+  /** Étiquette introduisant le chemin d'étapes d'un point d'entrée. */
+  readonly libelleChemin: string
+  readonly points: readonly IPointEntree[]
+}
+
+/**
+ * Section du « pourquoi » : d'où vient la promesse d'interlocuteur unique.
+ *
+ * Le texte s'énonce À LA PREMIÈRE PERSONNE, depuis l'expérience vécue — jamais comme
+ * un jugement sur une profession. `references` désigne des preuves déjà écrites et
+ * relues dans `content/offres/` : la section ne peut donc avancer aucun chiffre qui ne
+ * soit pas déjà une preuve établie du parcours (issue #19, règle de formulation).
+ */
+interface ISectionPourquoi {
+  readonly titre: string
+  /** L'entrée en matière, à la première personne : « j'ai vu que… ». */
+  readonly lead: string
+  /** Les deux jeux de chiffres qui ne se rencontrent pas. */
+  readonly colonnes: readonly IColonneConstat[]
+  /** Ce que le constat implique. Porte sur un dispositif, jamais sur des personnes. */
+  readonly conclusion: string
+  readonly references: readonly IReferencePreuve[]
 }
 
 /** Section des trois offres. Les offres elles-mêmes viennent de `content/offres/`. */
@@ -50,10 +108,19 @@ interface ISectionContact {
   readonly action: IAppelAction
 }
 
-/** Contenu éditorial complet de la page d'accueil. */
+/**
+ * Contenu éditorial complet de la page d'accueil.
+ *
+ * L'ordre des champs est l'ordre de lecture de la page : la promesse, la chaîne, où
+ * l'on y entre, d'où vient la promesse, les trois pôles, les preuves, l'action
+ * attendue.
+ */
 export interface IAccueil {
   readonly meta: IMetaAccueil
   readonly accroche: IAccrocheAccueil
+  readonly chaine: ISectionChaine
+  readonly pointsEntree: ISectionPointsEntree
+  readonly pourquoi: ISectionPourquoi
   readonly offres: ISectionOffres
   readonly preuves: ISectionPreuves
   readonly contact: ISectionContact

--- a/front/src/interfaces/colonne-constat.ts
+++ b/front/src/interfaces/colonne-constat.ts
@@ -1,0 +1,23 @@
+// colonne-constat.ts — jeromemarichez2026
+// Entité éditoriale : une colonne du constat qui fonde la promesse d'interlocuteur
+// unique sur la page d'accueil.
+
+/**
+ * Une colonne du constat : un jeu de chiffres, et à quoi il sert.
+ *
+ * Le constat s'énonce en deux colonnes parce que c'est exactement sa forme : les
+ * chiffres sur lesquels une campagne s'optimise et ceux sur lesquels une entreprise
+ * décide ne sont pas les mêmes, et ils ne vivent pas au même endroit.
+ *
+ * Ce que ce découpage n'est PAS : un jugement sur une profession. Aucune colonne ne
+ * nomme d'acteur, aucune ne porte de verbe d'intention. Une colonne décrit un
+ * dispositif — un périmètre d'accès à la donnée — pas des personnes ni des sociétés
+ * (règle de formulation de l'issue #19, non négociable).
+ */
+export interface IColonneConstat {
+  /** Clé stable, unique. Sert de clé de rendu de liste. */
+  readonly cle: string
+  readonly titre: string
+  /** Les chiffres de cette colonne. Énoncés nus, sans commentaire. */
+  readonly elements: readonly string[]
+}

--- a/front/src/interfaces/maillon-chaine.ts
+++ b/front/src/interfaces/maillon-chaine.ts
@@ -1,0 +1,37 @@
+// maillon-chaine.ts — jeromemarichez2026
+// Entité éditoriale : un maillon de la chaîne racontée par la page d'accueil.
+import type { CleOffre } from './types'
+
+/**
+ * Un maillon de la chaîne — le site, la donnée structurée et l'entrepôt, le taggage,
+ * le SEA.
+ *
+ * `sortie` est le champ structurant : un maillon ne se décrit pas par ce qu'il
+ * contient mais par CE QU'IL PRODUIT, c'est-à-dire par ce dont le maillon suivant a
+ * besoin pour exister. C'est ce qui fait lire la page comme un enchaînement et non
+ * comme un catalogue (README.md — « La chaîne, et les deux points d'entrée »).
+ *
+ * `illustration` porte le fil rouge e-commerce. Ce scénario est ILLUSTRATIF : il ne
+ * décrit aucun client et aucune mission réelle. Le maillon ne dit donc jamais « chez
+ * un client », et la section qui l'affiche porte l'avertissement correspondant en
+ * texte visible (CLAUDE.md — « Règles de véracité du contenu »).
+ */
+export interface IMaillonChaine {
+  /** Clé stable, unique dans la chaîne. Sert de clé de rendu de liste. */
+  readonly cle: string
+  readonly titre: string
+  /** Ce que je fais à cette étape, à la première personne. */
+  readonly role: string
+  /** Déclinaison du fil rouge e-commerce. Scénario illustratif, jamais un cas client. */
+  readonly illustration: string
+  /**
+   * Étiquette de `sortie`, propre au maillon : les trois premiers passent la main au
+   * suivant, le dernier rend une décision au lecteur. Porter l'étiquette par la donnée
+   * évite au rendu de traiter le dernier maillon comme un cas particulier.
+   */
+  readonly libelleSortie: string
+  /** Ce que l'étape produit — et donc ce dont la suivante part. */
+  readonly sortie: string
+  /** Offres qui couvrent ce maillon. Au moins une ; l'entrepôt en couvre deux. */
+  readonly offres: readonly CleOffre[]
+}

--- a/front/src/interfaces/maillon-resolu.ts
+++ b/front/src/interfaces/maillon-resolu.ts
@@ -1,0 +1,17 @@
+// maillon-resolu.ts — jeromemarichez2026
+// Entité de rendu : un maillon de la chaîne, une fois ses clés d'offres remplacées
+// par les titres réels. Produite par services/chaine.service.ts.
+import type { IMaillonChaine } from './maillon-chaine'
+
+/**
+ * Un maillon prêt à afficher : identique au maillon éditorial, sauf que `offres` ne
+ * porte plus des clés mais les TITRES des offres, lus dans `content/offres/`.
+ *
+ * Le titre n'est jamais recopié dans le contenu de l'accueil : c'est la même règle que
+ * pour la navigation (`@shared/config/navigation.ts`), où une recopie avait déjà fait
+ * diverger « Data et IA » de « Data & IA » (issue #11).
+ */
+export interface IMaillonResolu extends Omit<IMaillonChaine, 'offres'> {
+  /** Titres des offres qui couvrent le maillon, dans l'ordre déclaré. */
+  readonly offres: readonly string[]
+}

--- a/front/src/interfaces/point-entree.ts
+++ b/front/src/interfaces/point-entree.ts
@@ -1,0 +1,38 @@
+// point-entree.ts — jeromemarichez2026
+// Entité éditoriale : un point d'entrée dans la chaîne — la façon dont le visiteur
+// se situe. Deux cas existent : partir de zéro, ou brancher sur une application déjà
+// en service (README.md — « La chaîne, et les deux points d'entrée »).
+import type { CleOffre } from './types'
+
+/**
+ * Lien vers une page d'offre.
+ *
+ * La destination n'est PAS écrite : elle est dérivée de la clé par
+ * `@shared/config/routes.ts`. Un seul module connaît le gabarit `/services/<cle>`, et
+ * le contenu éditorial n'a donc jamais d'URL à tenir à jour.
+ *
+ * `libelle` est complet et non composé : deux points d'entrée voisins mènent à des
+ * étapes différentes, leurs liens doivent rester discernables une fois restitués hors
+ * contexte par un lecteur d'écran (WCAG 2.4.4).
+ */
+export interface ILienOffre {
+  readonly offre: CleOffre
+  readonly libelle: string
+}
+
+/** Une situation de départ, et le chemin qu'elle ouvre dans la chaîne. */
+export interface IPointEntree {
+  /** Clé stable, unique. Sert de clé de rendu de liste. */
+  readonly cle: string
+  /** La situation, dite du point de vue du visiteur : « Vous partez de zéro ». */
+  readonly situation: string
+  readonly description: string
+  /**
+   * Les étapes traversées depuis ce point d'entrée, dans l'ordre. Rendues comme un
+   * chemin : c'est ce qui donne à voir que les deux entrées rejoignent la même chaîne
+   * à des endroits différents.
+   */
+  readonly etapes: readonly string[]
+  /** Où mène ce point d'entrée. Au moins un lien ; la seconde entrée bifurque. */
+  readonly liens: readonly ILienOffre[]
+}

--- a/front/src/schemas/accueil.schema.ts
+++ b/front/src/schemas/accueil.schema.ts
@@ -10,9 +10,38 @@ const appelActionSchema = z.strictObject({
   libelle: z.string().min(1),
 })
 
+const cleOffreSchema = z.literal(['ingenierie-web', 'data-ia', 'sea'])
+
 const referencePreuveSchema = z.strictObject({
-  offre: z.literal(['ingenierie-web', 'data-ia', 'sea']),
+  offre: cleOffreSchema,
   axe: z.string().min(1),
+})
+
+const maillonChaineSchema = z.strictObject({
+  cle: z.string().min(1),
+  titre: z.string().min(1),
+  role: z.string().min(1),
+  illustration: z.string().min(1),
+  libelleSortie: z.string().min(1),
+  sortie: z.string().min(1),
+  // Un maillon rattaché à aucune offre serait une étape que personne ne couvre.
+  offres: z.array(cleOffreSchema).min(1),
+})
+
+const pointEntreeSchema = z.strictObject({
+  cle: z.string().min(1),
+  situation: z.string().min(1),
+  description: z.string().min(1),
+  // Un point d'entrée sans étapes ne situerait rien : c'est le chemin qui informe.
+  etapes: z.array(z.string().min(1)).min(1),
+  // Un point d'entrée qui ne mène nulle part laisserait le visiteur sur place.
+  liens: z.array(z.strictObject({ offre: cleOffreSchema, libelle: z.string().min(1) })).min(1),
+})
+
+const colonneConstatSchema = z.strictObject({
+  cle: z.string().min(1),
+  titre: z.string().min(1),
+  elements: z.array(z.string().min(1)).min(1),
 })
 
 export const accueilSchema = z.strictObject({
@@ -25,6 +54,36 @@ export const accueilSchema = z.strictObject({
     lead: z.string().min(1),
     actionPrincipale: appelActionSchema,
     actionSecondaire: appelActionSchema,
+  }),
+  chaine: z.strictObject({
+    titre: z.string().min(1),
+    lead: z.string().min(1),
+    libelleAvertissement: z.string().min(1),
+    // Le caractère illustratif du scénario e-commerce doit apparaître dans le texte
+    // visible : un avertissement vide ferait échouer le build (CLAUDE.md, véracité).
+    avertissement: z.string().min(1),
+    libelleEtape: z.string().min(1),
+    libelleIllustration: z.string().min(1),
+    libelleRattachement: z.string().min(1),
+    // Les quatre maillons du fil rouge : le site, la donnée structurée et l'entrepôt,
+    // le taggage, le SEA. Moins de deux maillons ne feraient plus une chaîne.
+    maillons: z.array(maillonChaineSchema).min(2),
+  }),
+  pointsEntree: z.strictObject({
+    titre: z.string().min(1),
+    lead: z.string().min(1),
+    libelleChemin: z.string().min(1),
+    // Deux points d'entrée au minimum : c'est le choix offert qui situe le visiteur.
+    points: z.array(pointEntreeSchema).min(2),
+  }),
+  pourquoi: z.strictObject({
+    titre: z.string().min(1),
+    lead: z.string().min(1),
+    // Le constat est une opposition : une seule colonne ne l'énoncerait pas.
+    colonnes: z.array(colonneConstatSchema).min(2),
+    conclusion: z.string().min(1),
+    // L'argument s'adosse au parcours : au moins une preuve établie le soutient.
+    references: z.array(referencePreuveSchema).min(1),
   }),
   offres: z.strictObject({
     titre: z.string().min(1),

--- a/front/src/services/chaine.service.ts
+++ b/front/src/services/chaine.service.ts
@@ -1,0 +1,39 @@
+// chaine.service.ts — jeromemarichez2026
+// Logique métier : rapprocher un maillon de la chaîne des offres qui le couvrent.
+// Aucune logique de rendu ici (docs/architecture.md — services/ vs hooks).
+import type { IMaillonChaine } from '../interfaces/maillon-chaine'
+import type { IMaillonResolu } from '../interfaces/maillon-resolu'
+import type { IOffre } from '../interfaces/offre'
+import type { CleOffre } from '../interfaces/types'
+
+/**
+ * Remplace une clé d'offre par le titre réel de l'offre.
+ *
+ * Échoue bruyamment plutôt que d'afficher une approximation : une clé qui ne désigne
+ * aucune offre est une erreur d'édition. Le contenu étant résolu au rendu serveur,
+ * donc au BUILD, cette erreur survient à la compilation — jamais devant un visiteur,
+ * et jamais sous la forme d'un maillon rattaché à une offre inexistante.
+ */
+function titreOffre(cle: CleOffre, maillon: string, offres: readonly IOffre[]): string {
+  const offre = offres.find((candidate) => candidate.cle === cle)
+  if (offre === undefined) {
+    throw new Error(`Maillon « ${maillon} » : offre « ${cle} » inconnue.`)
+  }
+
+  return offre.titre
+}
+
+/**
+ * Résout les maillons dans leur ordre de déclaration : l'ordre d'affichage EST la
+ * chaîne — le site, la donnée structurée et l'entrepôt, le taggage, le SEA. C'est un
+ * choix éditorial porté par le contenu, jamais par le rendu.
+ */
+export function resoudreMaillons(
+  maillons: readonly IMaillonChaine[],
+  offres: readonly IOffre[],
+): readonly IMaillonResolu[] {
+  return maillons.map((maillon) => ({
+    ...maillon,
+    offres: maillon.offres.map((cle) => titreOffre(cle, maillon.cle, offres)),
+  }))
+}

--- a/front/src/views/accueil/AccueilView.tsx
+++ b/front/src/views/accueil/AccueilView.tsx
@@ -3,27 +3,43 @@
 // C'est le seul endroit de la page qui lit le contenu ; les sections, elles, sont
 // pures et ne connaissent que leurs props (docs/design.md — « Pur par défaut »).
 import { accueil, offres } from '@/content'
+import { resoudreMaillons } from '@/services/chaine.service'
 import { resoudrePreuves } from '@/services/preuves.service'
 import { Accroche } from './sections/Accroche'
 import { AppelContact } from './sections/AppelContact'
+import { Chaine } from './sections/Chaine'
 import { Offres } from './sections/Offres'
+import { PointsEntree } from './sections/PointsEntree'
+import { Pourquoi } from './sections/Pourquoi'
 import { Preuves } from './sections/Preuves'
 
 /**
- * Ordre des sections : la promesse, ce qui est vendu, ce qui le rend crédible, puis
- * l'action attendue. C'est l'ordre du tableau de positionnement du README, et celui
- * de la navigation principale — les offres avant le parcours, le contact en dernier.
+ * Ordre des sections — c'est le raisonnement de la page, pas une mise en page :
  *
- * La résolution des preuves a lieu ici, au rendu du serveur, donc au build : une
- * référence cassée fait échouer la compilation au lieu de produire une page en ligne
- * portant une affirmation sans preuve.
+ * 1. la promesse (`Accroche`, seul `h1`) ;
+ * 2. la chaîne qu'elle recouvre, illustrée de bout en bout (`Chaine`) ;
+ * 3. où le visiteur y entre, selon qu'il part de zéro ou non (`PointsEntree`) ;
+ * 4. d'où vient la promesse, depuis l'expérience vécue (`Pourquoi`) ;
+ * 5. les trois pôles, atteignables (`Offres`) ;
+ * 6. ce qui les rend crédibles (`Preuves`) ;
+ * 7. l'action attendue (`AppelContact`).
+ *
+ * Les deux résolutions ont lieu ici, au rendu du serveur, donc au build : une
+ * référence de preuve cassée ou une clé d'offre inconnue fait échouer la compilation
+ * au lieu de produire une page en ligne portant une affirmation sans preuve ou un
+ * maillon rattaché à une offre qui n'existe pas.
  */
 export function AccueilView() {
+  const maillons = resoudreMaillons(accueil.chaine.maillons, offres)
   const preuves = resoudrePreuves(accueil.preuves.references, offres)
+  const preuvesPourquoi = resoudrePreuves(accueil.pourquoi.references, offres)
 
   return (
     <>
       <Accroche contenu={accueil.accroche} />
+      <Chaine contenu={accueil.chaine} maillons={maillons} />
+      <PointsEntree contenu={accueil.pointsEntree} />
+      <Pourquoi contenu={accueil.pourquoi} preuves={preuvesPourquoi} />
       <Offres contenu={accueil.offres} offres={offres} />
       <Preuves contenu={accueil.preuves} preuves={preuves} />
       <AppelContact contenu={accueil.contact} />

--- a/front/src/views/accueil/sections/Chaine/chaine.module.css
+++ b/front/src/views/accueil/sections/Chaine/chaine.module.css
@@ -1,0 +1,142 @@
+/* Chaîne — le motif de PROFONDEUR de la page d'accueil.
+ *
+ * La tridimensionnalité est obtenue en élévation et en couches, jamais en 3D : un
+ * dégradé de bleu profond, une ombre portée franche, et un décalage de deux pixels au
+ * survol. Aucune bibliothèque, aucun JavaScript — une 3D WebGL coûterait 150 à 600 ko
+ * et ferait de ce site la contre-démonstration de ce qu'il vend.
+ *
+ * Toutes les valeurs viennent des jetons (docs/design.md). Contrastes du dégradé et
+ * des deux couleurs de texte qui s'y posent : docs/accessibility.md. */
+
+.avertissement {
+  max-width: var(--layout-width-narrow);
+  margin-bottom: var(--space-lg);
+  padding: var(--space-sm) var(--space-md);
+
+  /* 1 px : seule épaisseur de filet employée par le socle (voir Card, Preuves). */
+  border-left: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-text-muted);
+}
+
+/* Pastille annonçant le caractère illustratif du scénario. `block` : l'étiquette est
+ * une ligne à part entière, elle ne se confond pas avec le début de la phrase. */
+.avertissementLibelle {
+  display: block;
+  color: var(--color-accent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.chaine {
+  display: grid;
+
+  /* Le nombre de colonnes se déduit de la place : quatre maillons de 15 rem tiennent
+   * dans le conteneur `wide` (80 rem), puis la grille passe à deux colonnes et à une.
+   * `min()` empêche la piste de réclamer 15 rem quand le viewport est plus étroit —
+   * c'est ce qui évite le défilement horizontal à 320 px. */
+  grid-template-columns: repeat(auto-fit, minmax(min(15rem, 100%), 1fr));
+  gap: var(--space-md);
+  padding-left: 0;
+  list-style: none;
+}
+
+/* `grid` plutôt que `block` : la carte occupe toute la hauteur de sa rangée, les
+ * maillons restent donc alignés d'une colonne à l'autre. */
+.maillon {
+  display: grid;
+  min-width: 0;
+}
+
+.carte {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  min-width: 0;
+  padding: var(--space-md);
+  border-radius: var(--radius-lg);
+
+  /* Le dégradé est un jeton : son angle et ses deux bornes sont décidés une seule
+   * fois, et il suit le thème sans être redéclaré ici. */
+  background-image: var(--gradient-depth);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-depth-text);
+  transition:
+    transform var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+/* Le maillon se soulève légèrement au survol. Sous `prefers-reduced-motion`, les
+ * jetons `--transition-*` valent 0s : le décalage devient instantané, donc plus rien
+ * ne s'anime — sans sélecteur universel ni `!important` (globals.css). */
+.carte:hover {
+  transform: translateY(var(--elevation-lift));
+  box-shadow: var(--shadow-xl);
+}
+
+.rang {
+  color: var(--color-depth-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.titre {
+  font-size: var(--font-size-lg);
+}
+
+.role,
+.illustration,
+.sortie {
+  color: var(--color-depth-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* La sortie ferme la carte et porte le chaînage : ce qu'elle énonce est ce dont le
+ * maillon suivant part. `margin-top: auto` la colle en bas, les sorties s'alignent
+ * donc d'une colonne à l'autre. */
+.sortie {
+  margin-top: auto;
+  padding-top: var(--space-2xs);
+  color: var(--color-depth-text);
+}
+
+.etiquette {
+  display: block;
+  color: var(--color-depth-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.rattachement {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+}
+
+.offres {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  padding-left: 0;
+  list-style: none;
+}
+
+/* Pastille de rattachement : volontairement NON cliquable. Les trois pôles sont
+ * atteignables depuis la section « offres » et depuis les points d'entrée ; les
+ * rendre cliquables ici multiplierait des liens au libellé identique (WCAG 2.4.4). */
+.offre {
+  padding: var(--space-3xs) var(--space-2xs);
+  border-radius: var(--radius-pill);
+  background-color: var(--color-depth-bottom);
+  color: var(--color-depth-text);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+}

--- a/front/src/views/accueil/sections/Chaine/index.tsx
+++ b/front/src/views/accueil/sections/Chaine/index.tsx
@@ -1,0 +1,64 @@
+import { Section } from '@/@shared/components/Section'
+import type { IAccueil } from '@/interfaces/accueil'
+import type { IMaillonResolu } from '@/interfaces/maillon-resolu'
+import styles from './chaine.module.css'
+
+interface IChaineProps {
+  contenu: IAccueil['chaine']
+  maillons: readonly IMaillonResolu[]
+}
+
+/**
+ * La chaîne, rendue comme un enchaînement et non comme une liste.
+ *
+ * Trois choix portent cette lecture :
+ * - une liste ORDONNÉE (`ol`) — l'ordre est l'information, un lecteur d'écran annonce
+ *   le nombre d'étapes avant de les énumérer ;
+ * - un rang visible (« Étape 1 »), composé du libellé porté par le contenu et de
+ *   l'index : rien n'est écrit en dur dans ce composant ;
+ * - une sortie explicite en pied de chaque maillon, dont l'énoncé est justement ce
+ *   dont le maillon suivant part. C'est ce chaînage textuel qui tient à toutes les
+ *   largeurs, là où un trait de liaison se briserait au passage à une colonne.
+ *
+ * L'avertissement précède les maillons : le caractère illustratif du scénario
+ * e-commerce se lit AVANT le scénario, jamais après.
+ */
+export function Chaine({ contenu, maillons }: IChaineProps) {
+  return (
+    <Section id="chaine" lead={contenu.lead} title={contenu.titre} tone="muted" width="wide">
+      <p className={styles.avertissement}>
+        <span className={styles.avertissementLibelle}>{contenu.libelleAvertissement}</span>
+        {contenu.avertissement}
+      </p>
+      <ol className={styles.chaine}>
+        {maillons.map((maillon, index) => (
+          <li className={styles.maillon} key={maillon.cle}>
+            <article className={styles.carte}>
+              <p className={styles.rang}>{`${contenu.libelleEtape} ${index + 1}`}</p>
+              <h3 className={styles.titre}>{maillon.titre}</h3>
+              <p className={styles.role}>{maillon.role}</p>
+              <p className={styles.illustration}>
+                <span className={styles.etiquette}>{contenu.libelleIllustration}</span>
+                {maillon.illustration}
+              </p>
+              <p className={styles.sortie}>
+                <span className={styles.etiquette}>{maillon.libelleSortie}</span>
+                {maillon.sortie}
+              </p>
+              <div className={styles.rattachement}>
+                <span className={styles.etiquette}>{contenu.libelleRattachement}</span>
+                <ul className={styles.offres}>
+                  {maillon.offres.map((offre) => (
+                    <li className={styles.offre} key={offre}>
+                      {offre}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </article>
+          </li>
+        ))}
+      </ol>
+    </Section>
+  )
+}

--- a/front/src/views/accueil/sections/Offres/index.tsx
+++ b/front/src/views/accueil/sections/Offres/index.tsx
@@ -21,11 +21,12 @@ interface IOffresProps {
  */
 export function Offres({ contenu, offres }: IOffresProps) {
   return (
-    <Section id="offres" lead={contenu.lead} title={contenu.titre} tone="muted" width="wide">
+    <Section id="offres" lead={contenu.lead} title={contenu.titre} width="wide">
       <ul className={styles.grille}>
         {offres.map((offre) => (
           <li className={styles.item} key={offre.cle}>
             <Card
+              className={styles.carte}
               footer={
                 <ActionLink href={cheminOffre(offre.cle)} variant="secondary">
                   {`${contenu.libelleLien} ${offre.titre}`}

--- a/front/src/views/accueil/sections/Offres/offres.module.css
+++ b/front/src/views/accueil/sections/Offres/offres.module.css
@@ -20,6 +20,26 @@
   min-width: 0;
 }
 
+/* Élévation appliquée ICI et non dans `Card` : la profondeur est un motif de la page
+ * d'accueil, pas une propriété du composant partagé — une carte de formulaire ou de
+ * page d'offre n'a aucune raison de se soulever. `Card` reste donc inchangée, et
+ * c'est sa prop `className` qui porte le motif. */
+.carte {
+  box-shadow: var(--shadow-md);
+  transition:
+    transform var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+/* `focus-within` autant que `hover` : la carte contient un lien, un visiteur au
+ * clavier voit donc la même surface se détacher qu'un visiteur à la souris. Sous
+ * `prefers-reduced-motion`, les jetons `--transition-*` valent 0s (globals.css). */
+.carte:hover,
+.carte:focus-within {
+  transform: translateY(var(--elevation-lift));
+  box-shadow: var(--shadow-lg);
+}
+
 .decision {
   color: var(--color-text);
 }

--- a/front/src/views/accueil/sections/PointsEntree/index.tsx
+++ b/front/src/views/accueil/sections/PointsEntree/index.tsx
@@ -1,0 +1,57 @@
+import { ActionLink } from '@/@shared/components/ActionLink'
+import { Section } from '@/@shared/components/Section'
+import { cheminOffre } from '@/@shared/config/routes'
+import type { IAccueil } from '@/interfaces/accueil'
+import styles from './points-entree.module.css'
+
+interface IPointsEntreeProps {
+  contenu: IAccueil['pointsEntree']
+}
+
+/**
+ * Les deux points d'entrée dans la chaîne : partir de zéro, ou brancher sur une
+ * application déjà en service. C'est la section qui permet au visiteur de SE SITUER.
+ *
+ * Le chemin de chaque entrée est une liste ordonnée : l'ordre porte l'information, et
+ * le trait de liaison entre deux étapes n'est qu'un décor — il est dessiné par un
+ * pseudo-élément au contenu vide, donc jamais restitué par un lecteur d'écran.
+ * L'information n'est ainsi portée ni par la seule couleur, ni par le seul dessin
+ * (WCAG 1.4.1).
+ *
+ * Les libellés de liens sont complets et distincts, jamais composés d'une amorce
+ * répétée : restitués hors contexte, quatre liens « En savoir plus » seraient
+ * indiscernables (WCAG 2.4.4).
+ */
+export function PointsEntree({ contenu }: IPointsEntreeProps) {
+  return (
+    <Section id="points-entree" lead={contenu.lead} title={contenu.titre} width="wide">
+      <ul className={styles.grille}>
+        {contenu.points.map((point) => (
+          <li className={styles.item} key={point.cle}>
+            <article className={styles.carte}>
+              <h3 className={styles.situation}>{point.situation}</h3>
+              <p className={styles.description}>{point.description}</p>
+              <div className={styles.chemin}>
+                <span className={styles.etiquette}>{contenu.libelleChemin}</span>
+                <ol className={styles.etapes}>
+                  {point.etapes.map((etape) => (
+                    <li className={styles.etape} key={etape}>
+                      <span className={styles.etapeLibelle}>{etape}</span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+              <div className={styles.actions}>
+                {point.liens.map((lien) => (
+                  <ActionLink href={cheminOffre(lien.offre)} key={lien.offre} variant="secondary">
+                    {lien.libelle}
+                  </ActionLink>
+                ))}
+              </div>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </Section>
+  )
+}

--- a/front/src/views/accueil/sections/PointsEntree/points-entree.module.css
+++ b/front/src/views/accueil/sections/PointsEntree/points-entree.module.css
@@ -1,0 +1,118 @@
+/* Points d'entrée — deux surfaces surélevées, posées sur le fond de page.
+ *
+ * Elles portent le même vocabulaire d'élévation que la chaîne (ombre franche,
+ * décalage de deux pixels), mais restent sur `--color-surface` : la profondeur
+ * bleutée est réservée à ce qui EXPLIQUE (la chaîne, le constat), pas à ce qui
+ * fait AGIR. */
+
+.grille {
+  display: grid;
+
+  /* Deux cartes côte à côte dès que 20 rem par piste tiennent dans le conteneur,
+   * l'une sous l'autre en dessous. `min()` évite qu'une piste réclame plus que le
+   * viewport à 320 px. */
+  grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));
+  gap: var(--space-md);
+  padding-left: 0;
+  list-style: none;
+}
+
+.item {
+  display: grid;
+  min-width: 0;
+}
+
+.carte {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-width: 0;
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  transition:
+    transform var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+/* `focus-within` autant que `hover` : la carte contient des liens, un visiteur au
+ * clavier doit voir la même surface se détacher qu'un visiteur à la souris. Sous
+ * `prefers-reduced-motion`, les jetons `--transition-*` valent 0s. */
+.carte:hover,
+.carte:focus-within {
+  transform: translateY(var(--elevation-lift));
+  box-shadow: var(--shadow-lg);
+}
+
+.situation {
+  font-size: var(--font-size-lg);
+}
+
+.description {
+  color: var(--color-text-muted);
+}
+
+.chemin {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+}
+
+.etiquette {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.etapes {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding-left: 0;
+  list-style: none;
+}
+
+/* L'étape est un conteneur SANS fond : la pastille est portée par le libellé, de
+ * sorte que le trait de liaison ci-dessous se dessine à l'extérieur de la pastille
+ * et non par-dessus son fond. */
+.etape {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  min-width: 0;
+}
+
+.etapeLibelle {
+  padding: var(--space-3xs) var(--space-2xs);
+  border-radius: var(--radius-pill);
+  background-color: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+}
+
+/* Trait de liaison entre deux étapes. `content: ''` : purement décoratif, aucun
+ * lecteur d'écran n'a à l'annoncer — l'ordre est déjà porté par la liste ordonnée,
+ * l'information n'est donc jamais portée par le seul dessin (WCAG 1.4.1). */
+.etape:not(:last-child)::after {
+  width: var(--space-xs);
+  height: 1px;
+  background-color: var(--color-border-strong);
+  content: "";
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+
+  /* Colle les actions en bas : dans la grille, les deux cartes gardent leurs liens
+   * alignés quelle que soit la longueur de leur description. */
+  margin-top: auto;
+  padding-top: var(--space-2xs);
+}

--- a/front/src/views/accueil/sections/Pourquoi/index.tsx
+++ b/front/src/views/accueil/sections/Pourquoi/index.tsx
@@ -1,0 +1,53 @@
+import { Section } from '@/@shared/components/Section'
+import type { IAccueil } from '@/interfaces/accueil'
+import type { IPreuveResolue } from '@/interfaces/preuve-resolue'
+import styles from './pourquoi.module.css'
+
+interface IPourquoiProps {
+  contenu: IAccueil['pourquoi']
+  preuves: readonly IPreuveResolue[]
+}
+
+/**
+ * D'où vient la promesse d'interlocuteur unique : un constat fait en encadrant des
+ * prestataires d'acquisition, énoncé à la première personne.
+ *
+ * Le constat est rendu en deux colonnes parce que c'est sa forme même : deux jeux de
+ * chiffres qui ne se rencontrent pas. Les colonnes ne s'opposent pas visuellement par
+ * une couleur (ni « bien » ni « mal ») — elles sont strictement symétriques, et seul
+ * le texte de conclusion dit ce qui les sépare : un périmètre d'accès à la donnée.
+ *
+ * Les chiffres du parcours ne sont pas écrits ici : ils viennent des offres, résolus
+ * par `services/preuves.service.ts`. La page ne peut donc pas avancer un montant que
+ * la page d'offre correspondante ne dit pas.
+ */
+export function Pourquoi({ contenu, preuves }: IPourquoiProps) {
+  return (
+    <Section id="pourquoi" lead={contenu.lead} title={contenu.titre} tone="muted" width="default">
+      <div className={styles.panneau}>
+        <div className={styles.colonnes}>
+          {contenu.colonnes.map((colonne) => (
+            <div className={styles.colonne} key={colonne.cle}>
+              <h3 className={styles.colonneTitre}>{colonne.titre}</h3>
+              <ul className={styles.elements}>
+                {colonne.elements.map((element) => (
+                  <li className={styles.element} key={element}>
+                    {element}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <p className={styles.conclusion}>{contenu.conclusion}</p>
+        <ul className={styles.preuves}>
+          {preuves.map((preuve) => (
+            <li className={styles.preuve} key={preuve.cle}>
+              {preuve.enonce}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Section>
+  )
+}

--- a/front/src/views/accueil/sections/Pourquoi/pourquoi.module.css
+++ b/front/src/views/accueil/sections/Pourquoi/pourquoi.module.css
@@ -1,0 +1,83 @@
+/* Pourquoi — le constat qui fonde la promesse, posé sur le même bleu profond que la
+ * chaîne. Les deux blocs qui EXPLIQUENT partagent ce vocabulaire de profondeur ;
+ * ceux qui font agir restent sur les surfaces claires du socle.
+ *
+ * Le panneau ne contient aucun lien : le seul appel à l'action de la page reste
+ * celui qui la ferme. C'est aussi ce qui permet au dégradé de n'accueillir que du
+ * texte, dont les deux couleurs sont mesurées contre ses deux bornes
+ * (docs/accessibility.md). */
+
+.panneau {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  min-width: 0;
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  background-image: var(--gradient-depth);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-depth-text);
+}
+
+.colonnes {
+  display: grid;
+
+  /* Les deux colonnes passent l'une sous l'autre quand la place manque, sans point
+   * de rupture. `min()` évite qu'une piste réclame plus large que le viewport. */
+  grid-template-columns: repeat(auto-fit, minmax(min(16rem, 100%), 1fr));
+  gap: var(--space-lg);
+}
+
+.colonne {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  min-width: 0;
+}
+
+/* Symétrie voulue : les deux colonnes ont exactement le même traitement. Distinguer
+ * l'une par une couleur reviendrait à porter un jugement là où le texte n'en porte
+ * pas — le constat décrit un périmètre d'accès à la donnée, pas un camp. */
+.colonneTitre {
+  color: var(--color-depth-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.elements {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+  padding-left: 0;
+  list-style: none;
+}
+
+.element {
+  /* 1 px : seule épaisseur de filet employée par le socle. Le filet remplace la
+   * puce, retirée avec `list-style` — la liste garde donc un repère visuel. */
+  border-left: 1px solid var(--color-depth-text-muted);
+  padding-left: var(--space-sm);
+  color: var(--color-depth-text);
+}
+
+.conclusion {
+  color: var(--color-depth-text);
+  font-size: var(--font-size-md);
+}
+
+.preuves {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  padding-left: 0;
+  list-style: none;
+}
+
+/* Les preuves ferment le panneau en retrait typographique : ce sont des faits du
+ * parcours qui appuient le constat, pas le constat lui-même. */
+.preuve {
+  color: var(--color-depth-text-muted);
+  font-size: var(--font-size-sm);
+}

--- a/front/src/views/accueil/sections/Preuves/index.tsx
+++ b/front/src/views/accueil/sections/Preuves/index.tsx
@@ -17,7 +17,7 @@ interface IPreuvesProps {
  */
 export function Preuves({ contenu, preuves }: IPreuvesProps) {
   return (
-    <Section id="preuves" lead={contenu.lead} title={contenu.titre} width="wide">
+    <Section id="preuves" lead={contenu.lead} title={contenu.titre} tone="muted" width="wide">
       <ul className={styles.grille}>
         {preuves.map((preuve) => (
           <li className={styles.item} key={preuve.cle}>


### PR DESCRIPTION
## Ce que fait cette PR

L'accueil ne presente plus un catalogue de trois offres : il raconte une **chaine** et permet au visiteur de **se situer**.

```
le site  ->  la donnee structuree et l'entrepot  ->  le taggage  ->  le SEA
```

Sept sections, dans un ordre qui est le raisonnement de la page : la promesse (`h1`), la chaine, ou l'on y entre, d'ou elle vient, les trois poles, ce qui les rend credibles, l'action attendue.

### La chaine se lit comme un enchainement

Chaque maillon se decrit par **ce qu'il produit**, et ce qu'il produit est ce dont le suivant part. Le chainage est donc textuel : il tient a 320 px comme a 1920 px, la ou un trait de liaison se briserait au passage a une colonne. La liste est **ordonnee** (`ol`) et chaque maillon porte son rang en toutes lettres (« Etape 1 ») — l'ordre n'est jamais porte par la seule disposition.

### Les deux points d'entree

« Vous partez de zero » mene au cadrage (Ingenierie Web) ; « Vous avez deja une application » mene au cablage data et **bifurque** vers SEA et vers Data & IA. Les trois poles restent donc atteignables depuis cette section, en plus de la grille d'offres.

### Le fil rouge e-commerce est explicitement illustratif

C'est une exigence de **veracite**, pas une precaution de style. Le scenario ne nomme aucune entreprise et ne porte aucun resultat chiffre, et une pastille « Scenario illustratif » precede les maillons avec ce texte visible :

> Le derole e-commerce ci-dessous est un exemple construit pour rendre la chaine lisible. Il ne decrit aucun client et aucune mission : je n'ai pas mene cette chaine entiere chez un meme e-commercant. Les competences qu'elle mobilise, elles, sont attestees offre par offre — le taggage et l'entrepot d'un cote, l'e-commerce de l'autre, sur des periodes differentes de mon parcours.

Le champ `chaine.avertissement` est **obligatoire et non vide** dans le schema Zod : une chaine sans avertissement ne compile pas. L'exigence est dans le type, pas dans la vigilance.

Verifie sur la page servie : les seuls noms d'entreprise presents (Truffle Capital, Verhoeven Joaillier) apparaissent dans la preuve du parcours, jamais dans le fil rouge.

### L'argument qui fonde la promesse

Enonce **a la premiere personne, depuis l'experience vecue** : « En pilotant des budgets d'acquisition a six chiffres, puis en encadrant les prestataires qui les depensaient, j'ai vu la meme coupure revenir… »

Le constat porte sur un **perimetre d'acces a la donnee** — un dispositif — jamais sur des personnes ou des societes. Aucun nom d'agence, aucune generalisation sur la profession. Les deux colonnes sont strictement symetriques : aucune n'est distinguee par une couleur, la mise en forme ne porte pas le jugement que le texte ne porte pas.

Les chiffres ne sont pas reecrits : ils viennent des preuves deja redigees et relues dans `content/offres/`, resolues par `preuves.service.ts`.

### Profondeur CSS sobre

Degrade de bleu profond, ombre portee franche, decalage de deux pixels au survol. **Aucune 3D WebGL, aucune dependance, aucun JavaScript d'animation** — une bibliotheque 3D couterait 150 a 600 ko et ferait du site la contre-demonstration de ce qu'il vend.

La profondeur bleutee marque ce qui **explique** (la chaine, le constat) ; ce qui fait **agir** reste sur les surfaces claires du socle. Le decalage se declenche aussi en `:focus-within` : un visiteur au clavier voit la meme surface se detacher qu'un visiteur a la souris. `prefers-reduced-motion` est respecte a la source — les transitions passent par les jetons `--transition-*` que `globals.css` annule.

## Mesures reelles

| Point | Mesure |
|-------|--------|
| Rendu statique | `○ /` — `prerendered as static content` dans la sortie de `make build` |
| Defilement horizontal | **20 mesures** (320, 360, 390, 414, 600, 768, 1024, 1280, 1440, 1920 px x 2 themes), Chrome headless via CDP : `scrollWidth` egal au viewport partout, **aucun** element depassant `clientWidth` |
| Contrastes | **28 couples, 56 ratios** recalcules depuis `tokens.css`, **aucun echec**. Nouveaux couples : 9.85 / 15.25 / 6.18 / 9.56 (clair), 11.53 / 15.80 / 6.84 / 9.37 (sombre), seuil 4.5 |
| Structure | 1 `h1`, 7 regions nommees, hierarchie continue relevee **sur la page servie** |
| JSON-LD | analysable (`JSON.parse` sur le graphe servi) |

**Texte sur un degrade** : un ratio ne se calcule que contre une couleur unie. Les combinaisons sont mesurees contre les **deux bornes**, ce qui suffit — `--color-depth-bottom` est plus sombre que `--color-depth-top` sur les trois canaux, donc toute couleur intermediaire a une luminance comprise entre les deux et le ratio est encadre par les deux mesures.

## Perimetre

- **Aucun prix.** L'accueil ne lit pas `sea-tarifs.ts` : verifie sur la page servie, `sea-tarifs` et `MontantAffichable` y sont absents. Les seuls montants presents sont les budgets **pilotes par le passe** (100 000 € chez Truffle Capital, ~25 000 € chez Verhoeven Joaillier), preuves du parcours qui fondent l'argument — pas des tarifs.
- Rebase sur `dev` apres la fusion de #21, sans conflit. Les quatre controles ont ete rejoues apres rebase.
- `content/offres/`, `interfaces/tarif*`, `schemas/tarif*`, `README.md` et `docs/data-model.md` ne sont pas touches.
- Aucune dependance ajoutee. Aucun fichier source ne depasse 300 lignes.

## Tests

Le `CLAUDE.md` reserve l'ecriture des tests a Jerome MARICHEZ : **aucun fichier de test n'est ecrit ni modifie ici**. Quatre tests sont proposes (intention + contenu complet) dans le rapport accompagnant cette PR — deux unitaires sur `chaine.service.ts`, un sur la presence obligatoire de l'avertissement illustratif, un d'integration sur la hierarchie de titres de la vue.

## Controles

`make lint`, `make typecheck`, `make test` et `make build` passent en local, avant et apres le rebase.

Closes #19