### PR TITLE
autre: poser les tests des domaines stables

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -120,6 +120,56 @@ vers un mock.
 
 Le hook se désarme par `ALLOW_TEST_DOUBLES=1` — décision de Jérôme MARICHEZ, à justifier.
 
+## Ce qui est couvert aujourd'hui
+
+Premier lot de tests des **domaines stables**, posé sur délégation explicite de Jérôme
+MARICHEZ du 2026-08-08 (`TESTS_WRITABLE_BY_ASSISTANT=1`, issue #26). Chaque fichier porte
+en tête son bloc **`Intention : …`**. Tous les tests ci-dessous ont été **exécutés** :
+**353 tests, 17 suites, front** (`make test`).
+
+| Domaine | Fichier (`front/tests/unitaire/`) | Ce qui est verrouillé |
+|---|---|---|
+| Contrastes | `contrastes-jetons.spec.ts` | Chaque couple de `contrast-pairs.ts` tient son seuil WCAG **dans les deux thèmes**, valeurs lues dans le vrai `tokens.css` |
+| Lecture des jetons | `proprietes-personnalisees-css.spec.ts` | `:root` ne peut pas attraper `:root[data-theme="dark"]` ; un sélecteur absent **lève** au lieu de rendre une table vide |
+| Calcul de contraste | `couleur-contraste.spec.ts` | Bornes WCAG (21:1, 1:1), luminance relative, refus de toute valeur non hexadécimale |
+| Parité des thèmes | `parite-themes.spec.ts` | Clair et sombre déclarent le **même jeu** de `--color-*` ; le bloc `prefers-color-scheme` est aligné sur le thème sombre forcé |
+| Composants du socle | `card.spec.tsx`, `action-link.spec.tsx`, `socle-structure.spec.tsx` | Niveaux de titre, zones optionnelles, `rel="noopener noreferrer"`, ouverture annoncée **dans le nom accessible**, région nommée par son propre titre, navigation du pied de page dérivée du contenu |
+| Données structurées | `json-ld.spec.tsx`, `donnees-structurees.spec.ts` | Graphe sérialisable, `Person` ↔ `ProfessionalService` reliés par `@id`, **aucune propriété non établie** à aucune profondeur, EF SET en `knowsLanguage` et jamais en `hasCredential`, aucun lien de justificatif inventé |
+| Métadonnées | `metadonnees-seo.spec.ts` | Canonique = `og:url`, gabarit de titre, `absoluteTitle`, refus d'une description hors bornes ou d'un chemin mal formé |
+| Routes et sitemap | `routes-sitemap.spec.ts` | Table de vérité de la découverte (groupe de routes, dossier privé, emplacement parallèle, route interceptée, segment dynamique), sitemap projeté des routes réelles, `robots.txt` |
+| Navigation dérivée | `navigation-derivee.spec.ts` | Les libellés **viennent** du contenu (comparaison relationnelle, jamais littérale) ; l'URL vient de la **clé**, jamais du titre |
+| Identité | `identite-telephone.spec.ts` | Conversion E.164, motif national unique partagé par la validation et la conversion, refus des schémas Zod (e-mail, HTTPS, code pays, bornes SEO) |
+| Contenu éditorial | `contenu-schemas.spec.ts`, `contenu-veracite.spec.ts` | Conformité Zod du jeu de données réel, **lien de certification mort impossible**, termes interdits, absence de « nous », SEO non vendu, mention arXiv conforme à l'arbitrage du 2026-08-08 |
+| Offre Data & IA | `offre-data-ia.spec.ts` | L'**ordre des axes est le message** (fiabilité, puis qualification, puis les volets) ; les volets sont une donnée, pas une mise en forme |
+
+**Note de véracité** : la proposition initiale interdisait « Universitat » et « Barcelona »
+dans le contenu publié. Elle est **périmée** — Jérôme MARICHEZ a arbitré l'inverse le
+2026-08-08 : l'Universitat de Barcelona est nommée comme **éditrice** de la publication
+arXiv. L'interdiction qui demeure est « en collaboration avec », et c'est elle qui est
+testée.
+
+## Ce qui n'est pas couvert
+
+Dit franchement, pour que personne ne s'appuie sur une garantie qui n'existe pas :
+
+- **Page d'accueil** (`AccueilView`, `content/accueil.ts`, `services/preuves.service.ts`)
+  et **grille tarifaire** (`sea-tarifs.ts`, `utils/tarif.ts`) : deuxième vague. Les deux
+  domaines étaient en réécriture au moment de ce lot ; leurs tests sont proposés dans les
+  PR correspondantes.
+- **`SiteHeader`** : il rend `NavLink`, composant client qui lit la route courante
+  (`usePathname`) pour poser `aria-current="page"`. Hors contexte de routeur, ce
+  comportement ne s'observe pas sans doublure de module — interdite ici. Il relève du
+  niveau **e2e**.
+- **Accessibilité de mise en page** : lien d'évitement effectivement ramené dans le champ
+  visuel au focus, ordre de tabulation, absence de défilement horizontal à 320 px. jsdom
+  ne calcule pas de mise en page : niveau **e2e (Cypress)**, qui ne tourne que sur les PR
+  vers `main`.
+- **Niveaux intégration, système, e2e et acceptation** : encore vides côté front.
+- **`buildRootMetadata` en conditions de production** : `NEXT_PUBLIC_SITE_URL` n'est pas
+  renseignée en test, l'origine est donc le repli de développement. Les assertions portent
+  sur la **relation** entre canonique, `og:url` et sitemap, jamais sur un domaine écrit en
+  dur.
+
 ## Qualité des tests — mutation testing (Stryker)
 
 **Stryker** mesure la capacité des tests unitaires/intégration à détecter de vraies

--- a/front/tests/unitaire/action-link.spec.tsx
+++ b/front/tests/unitaire/action-link.spec.tsx
@@ -1,0 +1,100 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26 ;
+ * test proposé à l'origine dans la PR #8, consolidé ici contre le composant réel) :
+ * `ActionLink` rend TOUJOURS un lien, jamais un bouton, parce que les appels à l'action
+ * du site sont des navigations. Un lien externe s'ouvre dans un nouvel onglet, se protège
+ * par `rel="noopener noreferrer"` et ANNONCE l'ouverture aux lecteurs d'écran : la
+ * mention doit faire partie du NOM ACCESSIBLE, pas seulement du texte visible.
+ *
+ * Cas limites couverts : variante secondaire, lien interne (aucune cible d'ouverture,
+ * aucun `rel`), classe additionnelle combinée à celles du module CSS, ancre interne.
+ *
+ * Le nom accessible est réellement comparé, accents compris : la proposition d'origine a
+ * d'abord échoué parce qu'elle attendait « nouvelle fenetre » là où le composant rend
+ * « nouvelle fenêtre ».
+ *
+ * Niveau : unitaire (React Testing Library, jsdom — couvre au passage `next/link`).
+ * Jeu de données : aucun — composant pur, ses entrées sont ses props.
+ */
+import { render, screen } from '@testing-library/react'
+import { ActionLink } from '@/@shared/components/ActionLink'
+
+describe('ActionLink', () => {
+  it('rend un lien interne, sans ouverture dans un nouvel onglet', () => {
+    render(<ActionLink href="/contact">Me contacter</ActionLink>)
+
+    const lien = screen.getByRole('link', { name: 'Me contacter' })
+    expect(lien.tagName).toBe('A')
+    expect(lien.getAttribute('href')).toBe('/contact')
+    expect(lien.getAttribute('target')).toBeNull()
+    expect(lien.getAttribute('rel')).toBeNull()
+    expect(lien.getAttribute('data-variant')).toBe('primary')
+  })
+
+  it('n’est jamais un bouton, même en variante secondaire', () => {
+    render(
+      <ActionLink href="/parcours" variant="secondary">
+        Voir le parcours
+      </ActionLink>,
+    )
+
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.getByRole('link', { name: 'Voir le parcours' }).tagName).toBe('A')
+  })
+
+  it('annonce l’ouverture dans un nouvel onglet pour un lien externe', () => {
+    render(
+      <ActionLink external href="https://example.org/certificat">
+        Voir la certification
+      </ActionLink>,
+    )
+
+    const lien = screen.getByRole('link', { name: 'Voir la certification (nouvelle fenêtre)' })
+    expect(lien.getAttribute('href')).toBe('https://example.org/certificat')
+    expect(lien.getAttribute('target')).toBe('_blank')
+    expect(lien.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('protège chaque lien externe contre l’accès à la fenêtre ouvrante', () => {
+    render(
+      <ActionLink external href="https://example.org/">
+        Lien externe
+      </ActionLink>,
+    )
+
+    const rel = screen.getByRole('link', { name: /Lien externe/ }).getAttribute('rel') ?? ''
+    expect(rel.split(' ')).toEqual(expect.arrayContaining(['noopener', 'noreferrer']))
+  })
+
+  it('porte la variante demandée dans ses classes et dans son attribut de données', () => {
+    render(
+      <ActionLink href="/offres" variant="secondary">
+        Voir les offres
+      </ActionLink>,
+    )
+
+    const lien = screen.getByRole('link', { name: 'Voir les offres' })
+    expect(lien.className).toBe('action secondary')
+    expect(lien.getAttribute('data-variant')).toBe('secondary')
+  })
+
+  it('combine la classe additionnelle avec celles du module CSS', () => {
+    render(
+      <ActionLink className="pleine-largeur" href="/contact">
+        Me contacter
+      </ActionLink>,
+    )
+
+    expect(screen.getByRole('link', { name: 'Me contacter' }).className).toBe(
+      'action primary pleine-largeur',
+    )
+  })
+
+  it('conserve le chemin d’une ancre interne', () => {
+    render(<ActionLink href="/#contenu">Aller au contenu</ActionLink>)
+
+    expect(screen.getByRole('link', { name: 'Aller au contenu' }).getAttribute('href')).toBe(
+      '/#contenu',
+    )
+  })
+})

--- a/front/tests/unitaire/card.spec.tsx
+++ b/front/tests/unitaire/card.spec.tsx
@@ -1,0 +1,114 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26 ;
+ * test proposé à l'origine dans la PR #8, consolidé ici contre le composant réel) :
+ * `Card` rend une surface autonome dont le titre respecte le NIVEAU demandé, et dont
+ * les zones optionnelles n'apparaissent que si elles sont fournies. Le niveau de titre
+ * est un choix d'accessibilité, pas un détail de style : une carte posée dans une
+ * section titrée en `h2` doit pouvoir descendre en `h3` sans casser la hiérarchie.
+ *
+ * Cas limites couverts : niveau de titre non par défaut (2 et 4), carte sans titre
+ * (aucun heading ne doit apparaître), carte sans eyebrow ni footer, classe additionnelle
+ * ajoutée à celle du module CSS, ordre des zones dans le DOM.
+ *
+ * Ce test prouve aussi l'outillage : le module CSS est résolu par `next/jest` en proxy
+ * d'objet (`styles.card` vaut `'card'`), donc la classe appliquée reste assertable sans
+ * aucune doublure écrite à la main.
+ *
+ * Niveau : unitaire (React Testing Library, jsdom).
+ * Jeu de données : aucun — composant pur, ses entrées sont ses props.
+ */
+import { render, screen } from '@testing-library/react'
+import { Card } from '@/@shared/components/Card'
+
+describe('Card', () => {
+  it('titre en h3 par défaut, à l’intérieur d’une surface « article »', () => {
+    render(<Card title="Ingénierie Web">Un seul interlocuteur.</Card>)
+
+    const titre = screen.getByRole('heading', { level: 3, name: 'Ingénierie Web' })
+    expect(screen.getByRole('article').contains(titre)).toBe(true)
+    expect(screen.getByText('Un seul interlocuteur.')).not.toBeNull()
+  })
+
+  it.each([
+    [2, 'H2'],
+    [3, 'H3'],
+    [4, 'H4'],
+  ] as const)('suit le niveau de titre demandé — %i', (niveau, balise) => {
+    render(
+      <Card headingLevel={niveau} title="Mes offres">
+        Corps
+      </Card>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Mes offres' }).tagName).toBe(balise)
+  })
+
+  it('rend une carte sans titre quand aucun titre n’est fourni', () => {
+    render(<Card>Corps seul</Card>)
+
+    expect(screen.queryByRole('heading')).toBeNull()
+    expect(screen.getByText('Corps seul')).not.toBeNull()
+  })
+
+  it('n’affiche ni eyebrow ni footer quand ils ne sont pas fournis', () => {
+    render(<Card title="Sans extras">Corps</Card>)
+
+    expect(screen.queryByText('Offre')).toBeNull()
+    // Seul le corps est un « div » : ni la zone d'eyebrow ni celle du footer n'existent.
+    expect(screen.getByRole('article').querySelectorAll('div').length).toBe(1)
+  })
+
+  it('affiche l’eyebrow au-dessus du titre quand il est fourni', () => {
+    render(
+      <Card eyebrow="Offre" title="Data & IA">
+        Corps
+      </Card>,
+    )
+
+    const article = screen.getByRole('article')
+    const eyebrow = screen.getByText('Offre')
+    const titre = screen.getByRole('heading', { name: 'Data & IA' })
+
+    expect(eyebrow.tagName).toBe('P')
+    expect(article.contains(eyebrow)).toBe(true)
+    // `compareDocumentPosition` : l'eyebrow précède bien le titre dans l'ordre du DOM.
+    expect(eyebrow.compareDocumentPosition(titre) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('rend la zone d’actions après le corps quand un footer est fourni', () => {
+    render(
+      <Card footer={<span>Action</span>} title="Avec footer">
+        Corps
+      </Card>,
+    )
+
+    const corps = screen.getByText('Corps')
+    const action = screen.getByText('Action')
+
+    expect(screen.getByRole('article').querySelectorAll('div').length).toBe(2)
+    expect(corps.compareDocumentPosition(action) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('applique la classe du module CSS et la classe additionnelle', () => {
+    render(
+      <Card className="pleine-largeur" title="Titre">
+        Corps
+      </Card>,
+    )
+
+    expect(screen.getByRole('article').className).toBe('card pleine-largeur')
+  })
+
+  it('n’ajoute aucune classe parasite quand aucune classe additionnelle n’est passée', () => {
+    render(<Card title="Titre">Corps</Card>)
+
+    expect(screen.getByRole('article').className).toBe('card')
+  })
+
+  it('n’est pas cliquable dans son ensemble : la carte ne porte aucun lien implicite', () => {
+    render(<Card title="Titre">Corps</Card>)
+
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/front/tests/unitaire/contenu-schemas.spec.ts
+++ b/front/tests/unitaire/contenu-schemas.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * le jeu de données éditorial réel du dépôt est conforme à ses schémas Zod, et ces
+ * schémas REFUSENT réellement ce qu'ils prétendent refuser. Un schéma qui accepte tout
+ * ne protège rien : le contenu est validé au chargement du module, donc une donnée non
+ * conforme doit casser le BUILD, jamais atteindre la production.
+ *
+ * Le garde-fou central est l'union discriminée `Justificatif` : la variante `a-fournir`
+ * ne porte AUCUNE propriété `url`. Le typage l'interdit à la compilation, et le
+ * `z.strictObject` le rattrape au chargement si quelqu'un contourne le typage — c'est ce
+ * qui rend un lien de certification mort structurellement impossible.
+ *
+ * Cas limites couverts : clé inconnue rejetée par `strictObject` sur chaque entité ;
+ * tableau d'axes vide ; clé en majuscules ; preuve vide (différente de `null`, qui est
+ * légitime) ; justificatif `a-fournir` porteur d'une `url` ; justificatif `disponible`
+ * en HTTP ; année hors bornes ou non entière ; niveau de diplôme hors référentiel ;
+ * année de fin antérieure à l'année de début ; unicité des clés.
+ *
+ * Niveau : unitaire (schémas purs sur le contenu réel).
+ * Jeu de données : le contenu éditorial réel du dépôt, et des variantes invalides
+ * dérivées de lui pour les refus.
+ */
+import { certifications, experiences, formations, identite, offres } from '@/content'
+import { axeOffreSchema } from '@/schemas/axe-offre.schema'
+import { certificationSchema, justificatifSchema } from '@/schemas/certification.schema'
+import { experienceSchema } from '@/schemas/experience.schema'
+import { formationSchema } from '@/schemas/formation.schema'
+import { offreSchema } from '@/schemas/offre.schema'
+
+const AXE_VALIDE = {
+  cle: 'cadrage',
+  titre: 'Cadrage',
+  description: 'Recueil du besoin et spécifications.',
+  preuve: null,
+} as const
+
+const CERTIFICATION_VALIDE = {
+  cle: 'istqb-foundation',
+  intitule: 'ISTQB Foundation',
+  organisme: 'ISTQB',
+  annee: 2026,
+  justificatif: { statut: 'a-fournir' },
+} as const
+
+const cles = (elements: readonly { cle: string }[]): readonly string[] =>
+  elements.map((element) => element.cle)
+
+describe('conformité du contenu réel', () => {
+  it('valide chaque offre publiée', () => {
+    for (const offre of offres) {
+      expect(() => offreSchema.parse(offre)).not.toThrow()
+    }
+  })
+
+  it('valide chaque certification, formation et expérience publiée', () => {
+    for (const certification of certifications) {
+      expect(() => certificationSchema.parse(certification)).not.toThrow()
+    }
+    for (const formation of formations) {
+      expect(() => formationSchema.parse(formation)).not.toThrow()
+    }
+    for (const experience of experiences) {
+      expect(() => experienceSchema.parse(experience)).not.toThrow()
+    }
+  })
+
+  it('publie trois offres, chacune avec au moins un axe', () => {
+    expect(offres).toHaveLength(3)
+    for (const offre of offres) {
+      expect(offre.axes.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('ne déclare jamais deux fois la même clé', () => {
+    for (const collection of [certifications, formations, experiences, identite.langues, offres]) {
+      expect(new Set(cles(collection)).size).toBe(collection.length)
+    }
+  })
+
+  it('ne déclare jamais deux fois le même axe au sein d’une offre', () => {
+    for (const offre of offres) {
+      expect(new Set(cles(offre.axes)).size).toBe(offre.axes.length)
+    }
+  })
+
+  it('rattache chaque expérience à des offres qui existent', () => {
+    const clesOffres = new Set(cles(offres))
+
+    for (const experience of experiences) {
+      for (const offreLiee of experience.offresLiees) {
+        expect(clesOffres.has(offreLiee)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('offreSchema — refus', () => {
+  const offreValide = offres[0]
+
+  it.each([
+    ['clé hors des trois offres arbitrées', { cle: 'seo-sea' }],
+    ['titre vide', { titre: '' }],
+    ['accroche vide', { accroche: '' }],
+    ['décision permise vide', { decisionPermise: '' }],
+    ['tableau d’axes vide', { axes: [] }],
+  ])('refuse une offre avec %s', (_cas, surcharge) => {
+    expect(() => offreSchema.parse({ ...offreValide, ...surcharge })).toThrow()
+  })
+
+  it('refuse une clé inconnue plutôt que de l’ignorer', () => {
+    expect(() => offreSchema.parse({ ...offreValide, tarif: '1000 €' })).toThrow()
+  })
+})
+
+describe('axeOffreSchema — refus', () => {
+  it.each([
+    ['clé en majuscules', { cle: 'Cadrage' }],
+    ['clé avec espace', { cle: 'cadrage initial' }],
+    ['titre vide', { titre: '' }],
+    ['description vide', { description: '' }],
+    ['preuve vide au lieu de null', { preuve: '' }],
+    ['volet vide', { volet: '' }],
+  ])('refuse un axe avec %s', (_cas, surcharge) => {
+    expect(() => axeOffreSchema.parse({ ...AXE_VALIDE, ...surcharge })).toThrow()
+  })
+
+  it('accepte une preuve absente sous la forme explicite null', () => {
+    expect(() => axeOffreSchema.parse({ ...AXE_VALIDE, preuve: null })).not.toThrow()
+  })
+
+  it('accepte un volet nommé et refuse une clé inconnue', () => {
+    expect(() => axeOffreSchema.parse({ ...AXE_VALIDE, volet: 'Agents autonomes' })).not.toThrow()
+    expect(() => axeOffreSchema.parse({ ...AXE_VALIDE, montant: 1000 })).toThrow()
+  })
+})
+
+describe('justificatifSchema — un lien mort est impossible', () => {
+  it('accepte un justificatif à fournir, sans URL', () => {
+    expect(() => justificatifSchema.parse({ statut: 'a-fournir' })).not.toThrow()
+  })
+
+  it('refuse une URL glissée dans un justificatif à fournir', () => {
+    expect(() =>
+      justificatifSchema.parse({ statut: 'a-fournir', url: 'https://example.org/certificat' }),
+    ).toThrow()
+  })
+
+  it('accepte un justificatif disponible en HTTPS absolu', () => {
+    expect(() =>
+      justificatifSchema.parse({ statut: 'disponible', url: 'https://example.org/certificat' }),
+    ).not.toThrow()
+  })
+
+  it.each([
+    ['HTTP', 'http://example.org/certificat'],
+    ['relative', '/certificat'],
+    ['vide', ''],
+    ['texte', 'à fournir'],
+  ])('refuse un justificatif disponible dont l’URL est %s', (_cas, url) => {
+    expect(() => justificatifSchema.parse({ statut: 'disponible', url })).toThrow()
+  })
+
+  it('refuse un justificatif disponible sans URL', () => {
+    expect(() => justificatifSchema.parse({ statut: 'disponible' })).toThrow()
+  })
+
+  it('refuse un statut inconnu', () => {
+    expect(() => justificatifSchema.parse({ statut: 'en-cours' })).toThrow()
+  })
+})
+
+describe('certificationSchema — refus', () => {
+  it.each([
+    ['année antérieure aux bornes', { annee: 1999 }],
+    ['année non entière', { annee: 2026.5 }],
+    ['intitulé vide', { intitule: '' }],
+    ['organisme vide', { organisme: '' }],
+    ['clé en majuscules', { cle: 'ISTQB' }],
+  ])('refuse une certification avec %s', (_cas, surcharge) => {
+    expect(() => certificationSchema.parse({ ...CERTIFICATION_VALIDE, ...surcharge })).toThrow()
+  })
+
+  it('accepte une année non établie sous la forme explicite null', () => {
+    expect(() => certificationSchema.parse({ ...CERTIFICATION_VALIDE, annee: null })).not.toThrow()
+  })
+})
+
+describe('formationSchema et experienceSchema — refus', () => {
+  it('refuse un niveau de diplôme hors du référentiel des CV', () => {
+    const formation = formations[0]
+
+    expect(() => formationSchema.parse({ ...formation, niveau: 'Bac +2' })).toThrow()
+  })
+
+  it('refuse une expérience dont l’année de fin précède l’année de début', () => {
+    const experience = experiences[0]
+
+    expect(() =>
+      experienceSchema.parse({ ...experience, anneeDebut: 2026, anneeFin: 2023 }),
+    ).toThrow()
+  })
+
+  it('refuse une expérience sans fait ni offre liée', () => {
+    const experience = experiences[0]
+
+    expect(() => experienceSchema.parse({ ...experience, faits: [] })).toThrow()
+    expect(() => experienceSchema.parse({ ...experience, offresLiees: [] })).toThrow()
+  })
+
+  it('refuse une offre liée qui n’existe pas', () => {
+    const experience = experiences[0]
+
+    expect(() => experienceSchema.parse({ ...experience, offresLiees: ['seo-sea'] })).toThrow()
+  })
+})

--- a/front/tests/unitaire/contenu-veracite.spec.ts
+++ b/front/tests/unitaire/contenu-veracite.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * le contenu PUBLIÉ respecte les règles de véracité bloquantes du CLAUDE.md. Le corpus
+ * examiné est la DONNÉE exportée (offres, expériences, identité, certifications,
+ * formations), pas le texte des fichiers sources : un terme interdit cité dans un
+ * commentaire d'en-tête — pour expliquer pourquoi il est interdit — n'est pas publié.
+ *
+ * Ce qui est vérifié : aucun terme interdit ; le site parle à la première personne du
+ * singulier (« je », jamais « nous ») ; le SEO n'est pas vendu comme prestation ; aucune
+ * certification ne peut porter un lien mort ; EF SET n'est pas une certification ;
+ * Microsoft Ads est absent ; l'ISTQB reste au niveau Foundation.
+ *
+ * CORRECTION D'UNE PROPOSITION PÉRIMÉE : le test de véracité initial interdisait
+ * « Universitat » et « Barcelona ». Jérôme MARICHEZ a arbitré l'inverse le 2026-08-08 —
+ * l'Universitat de Barcelona est nommée comme ÉDITRICE de la publication arXiv, la
+ * méthode ayant été implémentée par lui. Ce test vérifie donc la mention ET l'absence de
+ * la formule qui reste interdite : « en collaboration avec ».
+ *
+ * Cas limites couverts : « Kubernetes » n'est pas interdit en soi — il ne l'est que
+ * revendiqué ; l'absence de K8s se dit telle quelle, c'est un argument de lucidité, et le
+ * test exige que toute occurrence soit une négation.
+ *
+ * HORS PÉRIMÈTRE ASSUMÉ (deuxième vague, réécritures en cours) : le contenu de la page
+ * d'accueil et la grille tarifaire ne sont pas dans le corpus.
+ *
+ * Niveau : unitaire (données pures).
+ * Jeu de données : le contenu éditorial réel du dépôt.
+ */
+import { certifications, experiences, formations, identite, offres } from '@/content'
+
+/** Le contenu réellement publié, hors accueil et tarifs (deuxième vague). */
+const CORPUS = JSON.stringify({ certifications, experiences, formations, identite, offres })
+
+/** Termes que le site ne doit jamais publier (CLAUDE.md, règles de véracité). */
+const TERMES_INTERDITS = [
+  'en collaboration avec',
+  'LangChain',
+  'LlamaIndex',
+  'AppsFlyer',
+  'Adjust',
+  'Amplitude',
+  'Tealium',
+  'Adobe Launch',
+  'Adobe Analytics',
+  'Meta Ads',
+  'LinkedIn Ads',
+  'GraphQL',
+  'NestJS',
+  'Prisma',
+  'Gherkin',
+  'Cucumber',
+  'PyTorch',
+  'Microsoft Ads',
+  'mentorat',
+] as const
+
+describe('termes interdits', () => {
+  it.each(TERMES_INTERDITS)('ne publie jamais « %s »', (terme) => {
+    expect(CORPUS.toLowerCase()).not.toContain(terme.toLowerCase())
+  })
+
+  it('ne revendique aucun ISTQB au-delà du niveau Foundation', () => {
+    expect(CORPUS).not.toMatch(/ISTQB[^"]*(Avanc|Advanced)/i)
+    expect(CORPUS).not.toMatch(/Automatisation de [Tt]est/)
+  })
+
+  it('ne mentionne Kubernetes que pour dire qu’il n’est pas administré en propre', () => {
+    const occurrences = CORPUS.match(/Kubernetes/g) ?? []
+
+    for (const _occurrence of occurrences) {
+      expect(CORPUS).toContain('Pas de cluster Kubernetes administré en propre')
+    }
+    expect(CORPUS).not.toMatch(/cluster Kubernetes administré en propre[^"]*par mes soins/i)
+  })
+})
+
+describe('publication arXiv — arbitrage du 2026-08-08', () => {
+  const axeSupervise = offres
+    .flatMap((offre) => offre.axes)
+    .find((axe) => axe.cle === 'apprentissage-supervise')
+
+  it('nomme l’Universitat de Barcelona comme éditrice de la publication', () => {
+    expect(axeSupervise?.description).toContain('Universitat de Barcelona')
+    expect(axeSupervise?.description).toContain('arXiv')
+  })
+
+  it('attribue l’implémentation à Jérôme, sans annoncer de collaboration', () => {
+    expect(axeSupervise?.description).toMatch(/implémentée moi-même/)
+    expect(axeSupervise?.description).not.toContain('en collaboration avec')
+  })
+})
+
+describe('première personne du singulier', () => {
+  it.each(['nous', 'notre', 'nos', 'notre équipe'])('ne dit jamais « %s »', (pronom) => {
+    expect(CORPUS.toLowerCase()).not.toMatch(new RegExp(`\\b${pronom}\\b`))
+  })
+
+  it('parle bien à la première personne quelque part dans les offres', () => {
+    expect(JSON.stringify(offres)).toMatch(/\bje\b/i)
+  })
+})
+
+describe('le SEO n’est pas une prestation vendue', () => {
+  it('ne connaît que les trois clés d’offre arbitrées', () => {
+    expect(offres.map((offre) => offre.cle)).toEqual(['ingenierie-web', 'data-ia', 'sea'])
+  })
+
+  it('a définitivement renommé « seo-sea » en « sea »', () => {
+    expect(CORPUS).not.toContain('seo-sea')
+    expect(offres.find((offre) => offre.cle === 'sea')?.titre).toBe('SEA')
+  })
+
+  it('n’intitule aucune offre avec du référencement naturel', () => {
+    for (const offre of offres) {
+      expect(offre.titre).not.toMatch(/SEO/i)
+    }
+  })
+
+  it('ne garde « SEO » dans un titre d’axe que comme propriété du livrable', () => {
+    const axesSeo = offres.flatMap((offre) =>
+      offre.axes.filter((axe) => /SEO/i.test(axe.titre)).map((axe) => ({ offre: offre.cle, axe })),
+    )
+
+    expect(axesSeo.map(({ offre, axe }) => [offre, axe.cle])).toEqual([
+      ['ingenierie-web', 'seo-ready'],
+    ])
+  })
+
+  it('dit explicitement ce que l’offre SEA ne couvre pas', () => {
+    const perimetre = offres
+      .find((offre) => offre.cle === 'sea')
+      ?.axes.find((axe) => axe.cle === 'perimetre')
+
+    expect(perimetre?.description).toMatch(/pas une prestation de référencement naturel/i)
+    expect(perimetre?.description).toMatch(/netlinking/)
+    expect(perimetre?.description).toMatch(/suivi de positions/)
+  })
+
+  it('ne mentionne le SEO dans l’offre SEA que pour l’exclure ou comme fait du parcours', () => {
+    const axesAvecSeo = (offres.find((offre) => offre.cle === 'sea')?.axes ?? [])
+      .filter((axe) => JSON.stringify(axe).includes('SEO'))
+      .map((axe) => axe.cle)
+
+    expect(axesAvecSeo.sort()).toEqual(['perimetre', 'sea-pilotage'])
+  })
+
+  it('garde l’expérience SEO passée au parcours, qui est un fait vérifiable', () => {
+    expect(JSON.stringify(experiences)).toMatch(/SEO/)
+  })
+})
+
+describe('certifications — aucun lien mort possible', () => {
+  it('n’émet une URL que pour un justificatif disponible', () => {
+    for (const certification of certifications) {
+      if (certification.justificatif.statut === 'disponible') {
+        expect(certification.justificatif.url.startsWith('https://')).toBe(true)
+      } else {
+        expect('url' in certification.justificatif).toBe(false)
+      }
+    }
+  })
+
+  it('ne publie pas EF SET comme certification', () => {
+    for (const certification of certifications) {
+      expect(certification.intitule).not.toMatch(/EF SET/i)
+    }
+  })
+
+  it('ne publie pas Microsoft Ads, non établie', () => {
+    for (const certification of certifications) {
+      expect(certification.intitule).not.toMatch(/Microsoft Ads/i)
+    }
+  })
+
+  it('n’affiche aucune année pour la certification Google Ads, non tranchée', () => {
+    expect(certifications.find((certification) => certification.cle === 'google-ads')?.annee).toBe(
+      null,
+    )
+  })
+
+  it('classe EF SET comme évaluateur d’une langue, pas comme titre professionnel', () => {
+    expect(identite.langues.some((langue) => langue.evaluePar === 'EF SET')).toBe(true)
+  })
+})
+
+describe('ligne éditoriale', () => {
+  it('termine chaque offre sur une décision, jamais sur une liste d’outils', () => {
+    for (const offre of offres) {
+      expect(offre.decisionPermise).toMatch(/vous (décidez|savez)/i)
+    }
+  })
+
+  it('n’écrit jamais une preuve vide plutôt que d’en inventer une', () => {
+    for (const axe of offres.flatMap((offre) => offre.axes)) {
+      expect(axe.preuve === null || axe.preuve.trim().length > 0).toBe(true)
+    }
+  })
+
+  it('n’utilise aucun emoji dans le contenu publié', () => {
+    expect(CORPUS).not.toMatch(/\p{Extended_Pictographic}/u)
+  })
+
+  it('annonce le développement en IA augmentée piloté par les tests', () => {
+    expect(CORPUS).toMatch(/IA augmentée/)
+    expect(CORPUS).toMatch(/TDD|piloté par les tests/)
+  })
+})

--- a/front/tests/unitaire/contrastes-jetons.spec.ts
+++ b/front/tests/unitaire/contrastes-jetons.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * chaque combinaison texte/fond et bordure/fond déclarée dans
+ * `@shared/config/contrast-pairs.ts` tient son seuil WCAG dans LES DEUX thèmes,
+ * avec les valeurs réellement écrites dans `@shared/styles/tokens.css`.
+ * C'est le critère d'acceptation « contraste AA » rendu exécutable : 4.5:1 pour du
+ * texte courant (WCAG 1.4.3), 3:1 pour un composant d'interface (1.4.11).
+ *
+ * Cas limites couverts : un jeton cité par une exigence mais absent du thème fait
+ * échouer le test bruyamment plutôt que de le laisser passer à vide ; l'inventaire
+ * des exigences ne peut pas se vider sans que le test le signale ; le seuil déclaré
+ * ne peut pas descendre sous les minima WCAG.
+ *
+ * Niveau : unitaire (fonctions pures, aucun rendu).
+ * Jeu de données : le vrai `tokens.css` du dépôt et le vrai inventaire d'exigences —
+ * aucune couleur n'est recopiée ici, sans quoi le test mesurerait sa propre copie.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { CONTRAST_REQUIREMENTS, THEME_SELECTORS } from '@/@shared/config/contrast-pairs'
+import { contrastRatio } from '@/@shared/utils/color'
+import { extractCustomProperties } from '@/@shared/utils/css-custom-properties'
+
+/** Chemin résolu depuis le fichier de test : insensible au répertoire de travail. */
+const CHEMIN_TOKENS = join(__dirname, '..', '..', 'src', '@shared', 'styles', 'tokens.css')
+const tokens = readFileSync(CHEMIN_TOKENS, 'utf8')
+
+/** Minima WCAG 2.1 — aucune exigence du dépôt ne peut descendre en dessous. */
+const MINIMUM_COMPOSANT = 3
+const MINIMUM_TEXTE = 4.5
+
+function jetonsDuTheme(selecteur: string): ReadonlyMap<string, string> {
+  return extractCustomProperties(tokens, selecteur)
+}
+
+/** Lecture stricte : un jeton absent est une erreur, jamais un test qui s'évapore. */
+function valeurJeton(jetons: ReadonlyMap<string, string>, nom: string): string {
+  const valeur = jetons.get(nom)
+  if (valeur === undefined) {
+    throw new Error(
+      `Jeton « --${nom} » absent du thème : tokens.css et contrast-pairs.ts divergent.`,
+    )
+  }
+  return valeur
+}
+
+describe('inventaire des exigences de contraste', () => {
+  it('déclare des combinaisons à vérifier', () => {
+    expect(CONTRAST_REQUIREMENTS.length).toBeGreaterThan(0)
+  })
+
+  it('couvre les deux thèmes du site', () => {
+    expect(Object.keys(THEME_SELECTORS).sort()).toEqual(['clair', 'sombre'])
+  })
+
+  it('ne déclare aucun seuil inférieur aux minima WCAG', () => {
+    for (const exigence of CONTRAST_REQUIREMENTS) {
+      expect(exigence.minimumRatio).toBeGreaterThanOrEqual(MINIMUM_COMPOSANT)
+    }
+  })
+
+  it('décrit où chaque combinaison apparaît réellement', () => {
+    for (const exigence of CONTRAST_REQUIREMENTS) {
+      expect(exigence.usage.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('exige 4.5:1 dès qu’un jeton de texte est en avant-plan', () => {
+    const exigencesDeTexte = CONTRAST_REQUIREMENTS.filter((exigence) =>
+      exigence.foreground.startsWith('color-text'),
+    )
+    expect(exigencesDeTexte.length).toBeGreaterThan(0)
+    for (const exigence of exigencesDeTexte) {
+      expect(exigence.minimumRatio).toBe(MINIMUM_TEXTE)
+    }
+  })
+})
+
+describe.each(Object.entries(THEME_SELECTORS))(
+  'contraste des jetons — thème %s',
+  (_theme, selecteur) => {
+    const jetons = jetonsDuTheme(selecteur)
+
+    it('déclare des jetons de couleur', () => {
+      const couleurs = [...jetons.keys()].filter((nom) => nom.startsWith('color-'))
+      expect(couleurs.length).toBeGreaterThan(0)
+    })
+
+    it.each(
+      CONTRAST_REQUIREMENTS.map(
+        (exigence) =>
+          [
+            `${exigence.foreground} sur ${exigence.background} — ${exigence.usage}`,
+            exigence,
+          ] as const,
+      ),
+    )('%s', (_libelle, exigence) => {
+      const avantPlan = valeurJeton(jetons, exigence.foreground)
+      const arrierePlan = valeurJeton(jetons, exigence.background)
+
+      expect(contrastRatio(avantPlan, arrierePlan)).toBeGreaterThanOrEqual(exigence.minimumRatio)
+    })
+  },
+)

--- a/front/tests/unitaire/couleur-contraste.spec.ts
+++ b/front/tests/unitaire/couleur-contraste.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * le calcul de contraste lui-même est juste. Il est le second endroit où le test des
+ * jetons pourrait passer à vide : un `contrastRatio` qui renverrait toujours une grande
+ * valeur validerait n'importe quelle palette. On le confronte donc aux bornes connues de
+ * WCAG 2.1 — noir sur blanc vaut 21:1, une couleur sur elle-même vaut 1:1 — et à la
+ * définition de la luminance relative (§ dfn-relative-luminance).
+ *
+ * Cas limites couverts : notation courte `#abc` équivalente à `#aabbcc` ; casse et
+ * espaces indifférents ; l'ordre des arguments ne change pas le ratio ; toute entrée qui
+ * n'est pas une couleur hexadécimale valide lève une erreur explicite au lieu de
+ * produire un ratio plausible (chaîne vide, dièse manquant, longueur invalide, chiffre
+ * non hexadécimal, notation `rgb()`).
+ *
+ * Niveau : unitaire (fonctions pures, aucun jeu de données externe).
+ */
+import { contrastRatio, parseHexColor, relativeLuminance } from '@/@shared/utils/color'
+
+const NOIR = '#000000'
+const BLANC = '#ffffff'
+/** Contraste maximal possible en sRGB, valeur de référence de WCAG 2.1. */
+const CONTRASTE_MAXIMAL = 21
+
+describe('parseHexColor', () => {
+  it('convertit une notation longue en canaux 0-255', () => {
+    expect(parseHexColor('#16181c')).toEqual([22, 24, 28])
+  })
+
+  it('développe la notation courte à trois chiffres', () => {
+    expect(parseHexColor('#abc')).toEqual(parseHexColor('#aabbcc'))
+  })
+
+  it('accepte les majuscules et les espaces autour de la valeur', () => {
+    expect(parseHexColor('  #FCFCFA  ')).toEqual(parseHexColor('#fcfcfa'))
+  })
+
+  it.each([
+    ['chaîne vide', ''],
+    ['dièse manquant', 'ffffff'],
+    ['longueur invalide', '#12345'],
+    ['chiffre non hexadécimal', '#xyzxyz'],
+    ['notation fonctionnelle', 'rgb(255, 255, 255)'],
+    ['jeton CSS non résolu', 'var(--color-text)'],
+  ])('lève sur une valeur invalide — %s', (_cas, valeur) => {
+    expect(() => parseHexColor(valeur)).toThrow(/Couleur hexadécimale invalide/)
+  })
+})
+
+describe('relativeLuminance', () => {
+  it('vaut 0 pour le noir et 1 pour le blanc', () => {
+    expect(relativeLuminance(NOIR)).toBeCloseTo(0, 10)
+    expect(relativeLuminance(BLANC)).toBeCloseTo(1, 10)
+  })
+
+  it('pondère le vert plus fortement que le rouge, et le rouge plus que le bleu', () => {
+    const rouge = relativeLuminance('#ff0000')
+    const vert = relativeLuminance('#00ff00')
+    const bleu = relativeLuminance('#0000ff')
+
+    expect(vert).toBeGreaterThan(rouge)
+    expect(rouge).toBeGreaterThan(bleu)
+  })
+
+  it('reste dans l’intervalle 0-1 pour une couleur quelconque', () => {
+    const luminance = relativeLuminance('#0b4f79')
+
+    expect(luminance).toBeGreaterThan(0)
+    expect(luminance).toBeLessThan(1)
+  })
+})
+
+describe('contrastRatio', () => {
+  it('vaut 21:1 entre le noir et le blanc', () => {
+    expect(contrastRatio(NOIR, BLANC)).toBeCloseTo(CONTRASTE_MAXIMAL, 5)
+  })
+
+  it('vaut 1:1 pour une couleur comparée à elle-même', () => {
+    expect(contrastRatio('#0b4f79', '#0b4f79')).toBeCloseTo(1, 10)
+  })
+
+  it('ne dépend pas de l’ordre des arguments', () => {
+    expect(contrastRatio('#54585f', '#fcfcfa')).toBeCloseTo(contrastRatio('#fcfcfa', '#54585f'), 10)
+  })
+
+  it('ne dépasse jamais le contraste maximal', () => {
+    expect(contrastRatio(NOIR, BLANC)).toBeLessThanOrEqual(CONTRASTE_MAXIMAL)
+  })
+
+  it('propage l’erreur d’une couleur invalide au lieu de rendre un ratio', () => {
+    expect(() => contrastRatio('#zzzzzz', BLANC)).toThrow(/Couleur hexadécimale invalide/)
+  })
+})

--- a/front/tests/unitaire/donnees-structurees.spec.ts
+++ b/front/tests/unitaire/donnees-structurees.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * `buildSiteStructuredData` produit un graphe SÉRIALISABLE dont les deux nœuds — la
+ * personne et l'activité — sont RELIÉS par leurs `@id` au lieu d'être dupliqués, et qui
+ * n'émet AUCUNE propriété non établie. Les règles de véracité du CLAUDE.md valent pour
+ * le JSON-LD exactement comme pour le texte visible, alors même qu'il n'est lu que par
+ * des machines : c'est justement là qu'une donnée inventée passerait inaperçue.
+ *
+ * Cas limites couverts : EF SET est une compétence linguistique et doit se trouver dans
+ * `knowsLanguage`, JAMAIS dans `hasCredential` ; une certification sans justificatif est
+ * émise SANS `url` plutôt qu'avec un lien mort ; aucune note, avis, fourchette de prix,
+ * rue, zone desservie ni horaire n'apparaît nulle part dans le graphe, à quelque
+ * profondeur que ce soit ; le niveau CECRL « B2 » n'est pas émis, faute de propriété
+ * schema.org pour l'exprimer ; « Microsoft Ads » et l'ISTQB « Avancé » sont absents.
+ *
+ * Niveau : unitaire (fonction pure construite sur le contenu réel).
+ * Jeu de données : le contenu typé du dépôt (`identite`, `offres`, `certifications`,
+ * `formations`) — les valeurs attendues sont DÉRIVÉES de lui, jamais recopiées.
+ */
+import type { JsonLdNode } from '@/@shared/interfaces/types'
+import { buildSiteStructuredData, siteUrl } from '@/@shared/seo'
+import { certifications, formations, identite, offres } from '@/content'
+import { telephoneVersE164 } from '@/utils/telephone'
+
+const graphe = buildSiteStructuredData()
+
+/** Propriétés qu'aucun nœud ne doit porter : rien de tout cela n'est établi. */
+const PROPRIETES_INTERDITES = [
+  'aggregateRating',
+  'review',
+  'ratingValue',
+  'priceRange',
+  'streetAddress',
+  'postalCode',
+  'areaServed',
+  'openingHours',
+  'openingHoursSpecification',
+  'numberOfEmployees',
+] as const
+
+function noeudDeType(type: string): JsonLdNode {
+  const trouve = graphe['@graph'].find((noeud) => noeud['@type'] === type)
+  if (trouve === undefined) throw new Error(`Nœud « ${type} » absent du graphe.`)
+  return trouve
+}
+
+function chaine(noeud: JsonLdNode, cle: string): string {
+  const valeur = noeud[cle]
+  if (typeof valeur !== 'string') throw new Error(`« ${cle} » n’est pas une chaîne.`)
+  return valeur
+}
+
+function objet(noeud: JsonLdNode, cle: string): JsonLdNode {
+  const valeur = noeud[cle]
+  if (typeof valeur !== 'object' || valeur === null) {
+    throw new Error(`« ${cle} » n’est pas un objet.`)
+  }
+  return valeur as JsonLdNode
+}
+
+function liste(noeud: JsonLdNode, cle: string): readonly unknown[] {
+  const valeur = noeud[cle]
+  if (!Array.isArray(valeur)) throw new Error(`« ${cle} » n’est pas un tableau.`)
+  return valeur
+}
+
+/** Toutes les clés du graphe, à toute profondeur — pour vérifier une ABSENCE. */
+function toutesLesCles(valeur: unknown, accumulateur: Set<string> = new Set()): Set<string> {
+  if (Array.isArray(valeur)) {
+    for (const element of valeur) toutesLesCles(element, accumulateur)
+    return accumulateur
+  }
+  if (typeof valeur === 'object' && valeur !== null) {
+    for (const [cle, sousValeur] of Object.entries(valeur)) {
+      accumulateur.add(cle)
+      toutesLesCles(sousValeur, accumulateur)
+    }
+  }
+  return accumulateur
+}
+
+const personne = noeudDeType('Person')
+const activite = noeudDeType('ProfessionalService')
+const serialisation = JSON.stringify(graphe)
+
+describe('graphe de données structurées', () => {
+  it('est sérialisable et relisible à l’identique', () => {
+    expect(JSON.parse(serialisation)).toEqual(graphe)
+  })
+
+  it('déclare le contexte schema.org', () => {
+    expect(graphe['@context']).toBe('https://schema.org')
+  })
+
+  it('porte exactement deux nœuds : la personne et l’activité', () => {
+    expect(graphe['@graph']).toHaveLength(2)
+    expect(graphe['@graph'].map((noeud) => noeud['@type'])).toEqual([
+      'Person',
+      'ProfessionalService',
+    ])
+  })
+
+  it('relie les deux nœuds par leurs identifiants au lieu de les dupliquer', () => {
+    const identifiantPersonne = chaine(personne, '@id')
+    const identifiantActivite = chaine(activite, '@id')
+
+    expect(identifiantPersonne).toBe(`${siteUrl}/#person`)
+    expect(identifiantActivite).toBe(`${siteUrl}/#service`)
+    expect(objet(personne, 'worksFor')['@id']).toBe(identifiantActivite)
+    expect(objet(activite, 'founder')['@id']).toBe(identifiantPersonne)
+  })
+
+  it('n’émet aucune propriété non établie, à aucune profondeur', () => {
+    const cles = toutesLesCles(graphe)
+
+    for (const interdite of PROPRIETES_INTERDITES) {
+      expect(cles.has(interdite)).toBe(false)
+    }
+  })
+})
+
+describe('nœud Person', () => {
+  it('reprend l’identité du contenu typé', () => {
+    expect(chaine(personne, 'name')).toBe(identite.nom)
+    expect(chaine(personne, 'jobTitle')).toBe(identite.titreProfessionnel)
+    expect(chaine(personne, 'description')).toBe(identite.promesse)
+    expect(chaine(personne, 'url')).toBe(siteUrl)
+  })
+
+  it('publie les coordonnées du contenu, le téléphone converti en E.164', () => {
+    expect(chaine(personne, 'email')).toBe(identite.contact.email)
+    expect(chaine(personne, 'telephone')).toBe(telephoneVersE164(identite.contact.telephone))
+    expect(chaine(personne, 'telephone')).toMatch(/^\+33\d{9}$/)
+  })
+
+  it('ne localise que la ville et le pays, jamais une rue', () => {
+    const adresse = objet(personne, 'address')
+
+    expect(adresse['@type']).toBe('PostalAddress')
+    expect(adresse.addressLocality).toBe(identite.ville)
+    expect(adresse.addressCountry).toBe(identite.codePays)
+    expect(Object.keys(adresse).sort()).toEqual(['@type', 'addressCountry', 'addressLocality'])
+  })
+
+  it('n’expose que des profils publics vérifiés, tous en HTTPS', () => {
+    const profils = liste(personne, 'sameAs')
+
+    expect(profils).toEqual([...identite.profilsPublics])
+    for (const profil of profils) {
+      expect(String(profil).startsWith('https://')).toBe(true)
+    }
+    expect(profils).toContain('https://github.com/Jerome-Marichez')
+  })
+
+  it('dérive les domaines couverts des offres du site', () => {
+    expect(liste(personne, 'knowsAbout')).toEqual(offres.map((offre) => offre.titre))
+  })
+})
+
+describe('langues et certifications', () => {
+  it('émet chaque langue du contenu dans knowsLanguage', () => {
+    expect(liste(personne, 'knowsLanguage')).toEqual(
+      identite.langues.map((langue) => ({
+        '@type': 'Language',
+        name: langue.nom,
+        alternateName: langue.code,
+      })),
+    )
+  })
+
+  it('n’émet pas le niveau CECRL, faute de propriété schema.org pour l’exprimer', () => {
+    for (const langue of identite.langues) {
+      expect(serialisation).not.toContain(`"${langue.niveau}"`)
+    }
+  })
+
+  it('ne classe EF SET ni en certification ni en titre professionnel', () => {
+    expect(serialisation).not.toContain('EF SET')
+    for (const langue of identite.langues) {
+      if (langue.evaluePar !== null) expect(serialisation).not.toContain(langue.evaluePar)
+    }
+  })
+
+  it('émet les diplômes et les certifications du contenu, et rien de plus', () => {
+    const titres = liste(personne, 'hasCredential').map((credential) =>
+      chaine(credential as JsonLdNode, 'name'),
+    )
+
+    expect(titres).toEqual([
+      ...formations.map((formation) => formation.intitule),
+      ...certifications.map((certification) => certification.intitule),
+    ])
+  })
+
+  it('n’émet aucun lien de justificatif tant qu’aucune URL n’a été fournie', () => {
+    const credentials = liste(personne, 'hasCredential').map((valeur) => valeur as JsonLdNode)
+    const certifiees = credentials.filter(
+      (credential) => credential.credentialCategory === 'Certification professionnelle',
+    )
+
+    expect(certifiees).toHaveLength(certifications.length)
+    for (const [index, credential] of certifiees.entries()) {
+      const source = certifications[index]
+      const attenduAvecUrl = source?.justificatif.statut === 'disponible'
+      expect('url' in credential).toBe(attenduAvecUrl)
+    }
+  })
+
+  it('n’annonce ni Microsoft Ads ni un ISTQB de niveau avancé', () => {
+    expect(serialisation).not.toContain('Microsoft Ads')
+    expect(serialisation).not.toMatch(/ISTQB[^"]*Avanc/i)
+    expect(serialisation).not.toMatch(/Automatisation de [Tt]est/)
+  })
+})
+
+describe('nœud ProfessionalService', () => {
+  it('décrit l’activité avec la promesse du contenu', () => {
+    expect(chaine(activite, 'name')).toBe(identite.nom)
+    expect(chaine(activite, 'description')).toBe(identite.promesse)
+    expect(chaine(activite, 'url')).toBe(siteUrl)
+  })
+
+  it('publie un catalogue dérivé des offres, dans leur ordre éditorial', () => {
+    const catalogue = objet(activite, 'hasOfferCatalog')
+
+    expect(catalogue['@type']).toBe('OfferCatalog')
+    expect(
+      liste(catalogue, 'itemListElement').map((offre) =>
+        chaine(objet(offre as JsonLdNode, 'itemOffered'), 'name'),
+      ),
+    ).toEqual(offres.map((offre) => offre.titre))
+  })
+
+  it('décrit chaque service par son accroche éditoriale et le rattache au fournisseur', () => {
+    const elements = liste(objet(activite, 'hasOfferCatalog'), 'itemListElement')
+
+    for (const [index, element] of elements.entries()) {
+      const service = objet(element as JsonLdNode, 'itemOffered')
+      expect(service.description).toBe(offres[index]?.accroche)
+      expect(objet(service, 'provider')['@id']).toBe(chaine(activite, '@id'))
+    }
+  })
+
+  it('n’annonce l’URL d’aucune page d’offre tant qu’elle n’existe pas', () => {
+    const elements = liste(objet(activite, 'hasOfferCatalog'), 'itemListElement')
+
+    for (const element of elements) {
+      expect('url' in objet(element as JsonLdNode, 'itemOffered')).toBe(false)
+    }
+  })
+})

--- a/front/tests/unitaire/identite-telephone.spec.ts
+++ b/front/tests/unitaire/identite-telephone.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * un numéro français national se convertit en E.164 sans jamais produire une chaîne
+ * plausible mais injoignable, et les schémas d'identité REFUSENT réellement ce qu'ils
+ * prétendent refuser. Le `0` initial est un préfixe national d'acheminement : il
+ * disparaît derrière l'indicatif pays, il n'est pas « juste » un espace en moins.
+ *
+ * Cas limites couverts : numéro collé sans espaces, préfixe `00`, paire manquante ou en
+ * trop, numéro déjà en E.164 passé par erreur, séparateurs autres que l'espace, chaîne
+ * vide ; e-mail sans arobase ; profil public en HTTP au lieu de HTTPS ; code pays en
+ * minuscules ; description de site hors des bornes SEO ; clé inconnue rejetée par
+ * `z.strictObject`.
+ *
+ * Le motif qui VALIDE est celui qui autorise la CONVERSION : un format et son contrôle
+ * ne peuvent pas diverger puisqu'ils sont écrits une seule fois (`utils/telephone.ts`).
+ *
+ * Niveau : unitaire (fonction pure et schémas Zod).
+ * Jeu de données : le contenu réel `identite` du dépôt, et des valeurs limites écrites
+ * dans le test pour les refus.
+ */
+
+import { identite } from '@/content'
+import { contactSchema } from '@/schemas/contact.schema'
+import { identiteSchema } from '@/schemas/identite.schema'
+import { INDICATIF_FRANCE, TELEPHONE_NATIONAL_FR, telephoneVersE164 } from '@/utils/telephone'
+
+/** Contact valide de référence : chaque cas limite n'en fait varier qu'un champ. */
+const CONTACT_VALIDE = { email: 'contact@example.org', telephone: '07 71 65 15 88' } as const
+
+describe('telephoneVersE164', () => {
+  it('convertit un numéro national en E.164 en absorbant le préfixe d’acheminement', () => {
+    expect(telephoneVersE164('07 71 65 15 88')).toBe('+33771651588')
+  })
+
+  it('convertit le numéro réellement publié par le site', () => {
+    expect(telephoneVersE164(identite.contact.telephone)).toBe(
+      `${INDICATIF_FRANCE}${identite.contact.telephone.replace(/ /g, '').slice(1)}`,
+    )
+  })
+
+  it('produit toujours l’indicatif France suivi de neuf chiffres', () => {
+    expect(telephoneVersE164('01 23 45 67 89')).toMatch(/^\+33\d{9}$/)
+  })
+
+  it('ne conserve aucun espace dans le résultat', () => {
+    expect(telephoneVersE164('06 12 34 56 78')).not.toMatch(/\s/)
+  })
+
+  it.each([
+    ['numéro collé sans espaces', '0771651588'],
+    ['préfixe 00 non attribué', '00 71 65 15 88'],
+    ['paire manquante', '07 71 65 15'],
+    ['paire en trop', '07 71 65 15 88 99'],
+    ['chiffre isolé dans une paire', '07 71 65 15 8'],
+    ['déjà en E.164', '+33771651588'],
+    ['séparateurs par points', '07.71.65.15.88'],
+    ['séparateurs par tirets', '07-71-65-15-88'],
+    ['chaîne vide', ''],
+    ['texte', 'zéro sept soixante et onze'],
+  ])('refuse un %s plutôt que de produire un numéro injoignable', (_cas, valeur) => {
+    expect(() => telephoneVersE164(valeur)).toThrow(/Numéro français attendu/)
+  })
+
+  it('valide et convertit sur le même motif', () => {
+    expect(TELEPHONE_NATIONAL_FR.test(identite.contact.telephone)).toBe(true)
+    expect(() => telephoneVersE164(identite.contact.telephone)).not.toThrow()
+  })
+})
+
+describe('contactSchema', () => {
+  it('accepte les coordonnées réellement publiées', () => {
+    expect(() => contactSchema.parse(identite.contact)).not.toThrow()
+  })
+
+  it.each([
+    ['e-mail sans arobase', { email: 'contact.example.org' }],
+    ['e-mail sans domaine', { email: 'contact@' }],
+    ['e-mail vide', { email: '' }],
+    ['téléphone collé', { telephone: '0771651588' }],
+    ['téléphone international', { telephone: '+33 7 71 65 15 88' }],
+    ['téléphone tronqué', { telephone: '07 71 65' }],
+  ])('refuse un %s', (_cas, surcharge) => {
+    expect(() => contactSchema.parse({ ...CONTACT_VALIDE, ...surcharge })).toThrow()
+  })
+
+  it('refuse une clé inconnue plutôt que de l’ignorer', () => {
+    expect(() => contactSchema.parse({ ...CONTACT_VALIDE, adresse: '3 rue de Lille' })).toThrow()
+  })
+})
+
+describe('identiteSchema', () => {
+  it('accepte l’identité réellement publiée', () => {
+    expect(() => identiteSchema.parse(identite)).not.toThrow()
+  })
+
+  it.each([
+    ['profil public en HTTP', { profilsPublics: ['http://github.com/Jerome-Marichez'] }],
+    ['profil public qui n’est pas une URL', { profilsPublics: ['Jerome-Marichez'] }],
+    ['code pays en minuscules', { codePays: 'fr' }],
+    ['code pays sur trois lettres', { codePays: 'FRA' }],
+    ['description de site trop courte', { descriptionSite: 'Trop court.' }],
+    ['description de site trop longue', { descriptionSite: 'a'.repeat(161) }],
+    ['nom vide', { nom: '' }],
+  ])('refuse une %s', (_cas, surcharge) => {
+    expect(() => identiteSchema.parse({ ...identite, ...surcharge })).toThrow()
+  })
+
+  it('refuse une adresse postale, qui n’est pas une donnée établie', () => {
+    expect(() => identiteSchema.parse({ ...identite, adresse: '3 rue de Lille' })).toThrow()
+  })
+
+  it('n’expose que des profils publics en HTTPS', () => {
+    for (const profil of identite.profilsPublics) {
+      expect(profil.startsWith('https://')).toBe(true)
+    }
+  })
+
+  it('classe l’anglais sous les langues, avec son référentiel et son évaluateur', () => {
+    const anglais = identite.langues.find((langue) => langue.code === 'en')
+
+    expect(anglais?.nom).toBe('Anglais')
+    expect(anglais?.referentiel).toBe('CECRL')
+    expect(anglais?.evaluePar).toBe('EF SET')
+  })
+
+  it('donne à chaque langue une étiquette BCP 47 exploitable', () => {
+    for (const langue of identite.langues) {
+      expect(langue.code).toMatch(/^[a-z]{2}(-[A-Z]{2})?$/)
+      expect(langue.niveau.length).toBeGreaterThan(0)
+      expect(langue.referentiel.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/front/tests/unitaire/json-ld.spec.tsx
+++ b/front/tests/unitaire/json-ld.spec.tsx
@@ -1,0 +1,77 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * le composant qui injecte les données structurées émet du JSON STRICTEMENT VALIDE et
+ * refermable par aucun contenu. `dangerouslySetInnerHTML` est ici obligatoire — React
+ * échapperait les enfants textuels en entités HTML (`&quot;`), produisant un JSON que
+ * les moteurs ne relisent pas — donc l'échappement doit être vérifié, pas supposé.
+ *
+ * Comportement attendu : un `<script type="application/ld+json">` unique, dont le
+ * contenu se relit par `JSON.parse` à l'identique du graphe fourni.
+ *
+ * Cas limites couverts : le seul caractère capable de refermer prématurément la balise
+ * est `<` (dans `</script>`) — une chaîne du contenu qui en contiendrait un ne doit pas
+ * pouvoir sortir du script ; les guillemets ne sont pas transformés en entités HTML ;
+ * le graphe réel du site passe le même contrôle.
+ *
+ * Niveau : unitaire (React Testing Library, jsdom).
+ * Jeu de données : un graphe minimal portant la charge hostile, et le graphe réel du site.
+ */
+import { render } from '@testing-library/react'
+import { JsonLd } from '@/@shared/components/JsonLd'
+import type { JsonLdGraph } from '@/@shared/interfaces/types'
+import { buildSiteStructuredData } from '@/@shared/seo'
+
+/** Graphe portant une chaîne capable de refermer la balise si rien ne l'échappe. */
+const GRAPHE_HOSTILE: JsonLdGraph = {
+  '@context': 'https://schema.org',
+  '@graph': [{ '@type': 'Person', name: 'Jérôme </script><script>alert(1)</script>' }],
+}
+
+function contenuDuScript(conteneur: HTMLElement): string {
+  const script = conteneur.querySelector('script[type="application/ld+json"]')
+  if (script === null) throw new Error('Aucun script de données structurées rendu.')
+  return script.innerHTML
+}
+
+describe('JsonLd', () => {
+  it('rend un unique script de type application/ld+json', () => {
+    const { container } = render(<JsonLd data={buildSiteStructuredData()} />)
+
+    expect(container.querySelectorAll('script[type="application/ld+json"]')).toHaveLength(1)
+  })
+
+  it('émet le graphe réel du site, relisible par JSON.parse à l’identique', () => {
+    const graphe = buildSiteStructuredData()
+    const { container } = render(<JsonLd data={graphe} />)
+
+    expect(JSON.parse(contenuDuScript(container))).toEqual(graphe)
+  })
+
+  it('n’échappe pas les guillemets en entités HTML', () => {
+    const { container } = render(<JsonLd data={buildSiteStructuredData()} />)
+
+    expect(contenuDuScript(container)).not.toContain('&quot;')
+  })
+
+  it('empêche une chaîne du contenu de refermer la balise script', () => {
+    const { container } = render(<JsonLd data={GRAPHE_HOSTILE} />)
+    const contenu = contenuDuScript(container)
+
+    expect(contenu).not.toContain('</script>')
+    expect(contenu).toContain('\\u003c')
+  })
+
+  it('conserve la valeur exacte malgré l’échappement', () => {
+    const { container } = render(<JsonLd data={GRAPHE_HOSTILE} />)
+
+    expect(JSON.parse(contenuDuScript(container))).toEqual(GRAPHE_HOSTILE)
+  })
+
+  it('n’injecte aucun script exécutable dans le document', () => {
+    const { container } = render(<JsonLd data={GRAPHE_HOSTILE} />)
+
+    // Le seul script rendu est celui des données structurées, jamais un second
+    // qu'une chaîne du contenu aurait ouvert.
+    expect(container.querySelectorAll('script')).toHaveLength(1)
+  })
+})

--- a/front/tests/unitaire/metadonnees-seo.spec.ts
+++ b/front/tests/unitaire/metadonnees-seo.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * `buildPageMetadata` est le seul endroit où une page décrit son référencement, et il
+ * doit produire UNE SEULE écriture de son URL : la canonique, `og:url` et l'URL absolue
+ * du chemin sont la même chaîne. Une canonique fausse ne casse aucun test « visible » —
+ * elle fait juste disparaître la page des résultats de recherche. D'où ce test.
+ *
+ * Comportement attendu : le gabarit de titre (« %s — Jérôme Marichez ») est appliqué à
+ * l'Open Graph et à la carte Twitter, que Next.js n'atteint pas, mais pas au champ
+ * `title` que Next.js compose lui-même ; `absoluteTitle` remplace le gabarit au lieu de
+ * le suffixer ; `absoluteUrl` ne laisse jamais de barre finale.
+ *
+ * Cas limites couverts (refus attendus, validés par Zod AU BUILD) : description trop
+ * courte (< 50) ou trop longue (> 160), titre trop long (> 60) ou trop court (< 3),
+ * chemin sans barre initiale, avec barre finale, en majuscules, avec double barre, avec
+ * paramètre de requête, et clé inconnue rejetée par `z.strictObject`.
+ *
+ * Niveau : unitaire (fonctions pures).
+ * Jeu de données : le contenu réel du dépôt (`identite`) et l'origine réelle du site —
+ * aucune URL n'est recopiée en dur, sans quoi le test ne vérifierait que sa propre copie.
+ */
+
+import {
+  absoluteUrl,
+  applyTitleTemplate,
+  buildPageMetadata,
+  buildRootMetadata,
+  siteLocale,
+  siteName,
+  siteTitle,
+  siteUrl,
+  titleTemplate,
+} from '@/@shared/seo'
+import { identite } from '@/content'
+
+/** Entrée valide de référence : chaque cas limite n'en fait varier qu'un champ. */
+const PAGE_VALIDE = {
+  title: 'SEA',
+  description:
+    'Acquisition payante pilotée par la donnée : taggage, entrepôt multi-source et arbitrage des budgets sur la rentabilité réelle.',
+  path: '/services/sea',
+} as const
+
+describe('absoluteUrl', () => {
+  it('résout un chemin contre l’origine du site', () => {
+    expect(absoluteUrl('/services/sea')).toBe(`${siteUrl}/services/sea`)
+  })
+
+  it('ne laisse aucune barre finale sur la racine', () => {
+    expect(absoluteUrl('/')).toBe(siteUrl)
+    expect(absoluteUrl('/').endsWith('/')).toBe(false)
+  })
+
+  it('normalise un chemin sans barre initiale plutôt que de le résoudre en relatif', () => {
+    expect(absoluteUrl('services/sea')).toBe(absoluteUrl('/services/sea'))
+  })
+})
+
+describe('applyTitleTemplate', () => {
+  it('applique le gabarit du site au titre de la page', () => {
+    expect(applyTitleTemplate('SEA')).toBe(titleTemplate.replace('%s', 'SEA'))
+  })
+
+  it('nomme Jérôme Marichez dans le gabarit', () => {
+    expect(applyTitleTemplate('SEA')).toContain(identite.nom)
+  })
+})
+
+describe('buildRootMetadata', () => {
+  const racine = buildRootMetadata()
+
+  it('déclare l’origine de résolution des URL relatives', () => {
+    expect(racine.metadataBase?.toString()).toBe(new URL(siteUrl).toString())
+  })
+
+  it('porte le titre par défaut et le gabarit hérité par les pages filles', () => {
+    expect(racine.title).toEqual({ default: siteTitle, template: titleTemplate })
+  })
+
+  it('décrit le site avec la description du contenu typé', () => {
+    expect(racine.description).toBe(identite.descriptionSite)
+  })
+
+  it('déclare la canonique de l’accueil, sans barre finale', () => {
+    expect(racine.alternates?.canonical).toBe(absoluteUrl('/'))
+  })
+
+  it('publie un Open Graph cohérent avec la canonique', () => {
+    expect(racine.openGraph?.url).toBe(absoluteUrl('/'))
+    expect(racine.openGraph?.siteName).toBe(siteName)
+    expect(racine.openGraph?.locale).toBe(siteLocale)
+  })
+
+  it('autorise l’indexation du site', () => {
+    expect(racine.robots).toEqual({ index: true, follow: true })
+  })
+
+  it('empêche la transformation automatique des nombres en liens téléphoniques', () => {
+    expect(racine.formatDetection).toEqual({ telephone: false, email: false, address: false })
+  })
+})
+
+describe('buildPageMetadata — page valide', () => {
+  const metadonnees = buildPageMetadata(PAGE_VALIDE)
+
+  it('écrit la même URL dans la canonique et dans og:url', () => {
+    const attendue = absoluteUrl(PAGE_VALIDE.path)
+
+    expect(metadonnees.alternates?.canonical).toBe(attendue)
+    expect(metadonnees.openGraph?.url).toBe(attendue)
+  })
+
+  it('laisse Next.js appliquer le gabarit au titre de l’onglet', () => {
+    expect(metadonnees.title).toBe(PAGE_VALIDE.title)
+  })
+
+  it('applique le gabarit à la main pour l’Open Graph et la carte Twitter', () => {
+    const titreComplet = applyTitleTemplate(PAGE_VALIDE.title)
+
+    expect(metadonnees.openGraph?.title).toBe(titreComplet)
+    expect(metadonnees.twitter?.title).toBe(titreComplet)
+  })
+
+  it('reprend la description de la page partout', () => {
+    expect(metadonnees.description).toBe(PAGE_VALIDE.description)
+    expect(metadonnees.openGraph?.description).toBe(PAGE_VALIDE.description)
+    expect(metadonnees.twitter?.description).toBe(PAGE_VALIDE.description)
+  })
+
+  it('déclare une carte Twitter et une locale explicites', () => {
+    // `toMatchObject` plutôt qu'un accès direct : `card` n'est porté que par certaines
+    // variantes de l'union `Twitter` de Next.js, et l'assertion doit rester exacte.
+    expect(metadonnees.twitter).toMatchObject({ card: 'summary_large_image' })
+    expect(metadonnees.openGraph?.locale).toBe(siteLocale)
+  })
+
+  it('accepte la racine du site comme chemin', () => {
+    const accueil = buildPageMetadata({ ...PAGE_VALIDE, path: '/' })
+
+    expect(accueil.alternates?.canonical).toBe(siteUrl)
+  })
+})
+
+describe('buildPageMetadata — titre absolu', () => {
+  it('remplace le gabarit au lieu de le suffixer', () => {
+    const metadonnees = buildPageMetadata({ ...PAGE_VALIDE, absoluteTitle: true, path: '/' })
+
+    expect(metadonnees.title).toEqual({ absolute: PAGE_VALIDE.title })
+    expect(metadonnees.openGraph?.title).toBe(PAGE_VALIDE.title)
+    expect(metadonnees.twitter?.title).toBe(PAGE_VALIDE.title)
+  })
+
+  it('reste suffixé par défaut, sans déclaration explicite', () => {
+    expect(buildPageMetadata(PAGE_VALIDE).openGraph?.title).toBe(
+      applyTitleTemplate(PAGE_VALIDE.title),
+    )
+  })
+})
+
+describe('buildPageMetadata — entrées refusées au build', () => {
+  it.each([
+    ['description trop courte', { description: 'Trop court pour un extrait de résultat.' }],
+    ['description trop longue', { description: `${'a'.repeat(161)}` }],
+    ['titre trop long', { title: 'a'.repeat(61) }],
+    ['titre trop court', { title: 'ab' }],
+    ['chemin sans barre initiale', { path: 'services/sea' }],
+    ['chemin avec barre finale', { path: '/services/sea/' }],
+    ['chemin en majuscules', { path: '/Services/SEA' }],
+    ['chemin à double barre', { path: '/services//sea' }],
+    ['chemin avec paramètre de requête', { path: '/services/sea?utm_source=x' }],
+    ['chemin avec espace', { path: '/services/sea et plus' }],
+    ['URL absolue en guise de chemin', { path: 'https://example.org/services/sea' }],
+  ])('refuse une %s', (_cas, surcharge) => {
+    expect(() => buildPageMetadata({ ...PAGE_VALIDE, ...surcharge })).toThrow()
+  })
+
+  it('refuse une clé inconnue plutôt que de l’ignorer en silence', () => {
+    expect(() =>
+      buildPageMetadata({ ...PAGE_VALIDE, canonical: 'https://example.org' } as never),
+    ).toThrow()
+  })
+
+  it('accepte exactement 160 caractères de description et 60 de titre', () => {
+    expect(() =>
+      buildPageMetadata({ ...PAGE_VALIDE, description: 'a'.repeat(160), title: 'a'.repeat(60) }),
+    ).not.toThrow()
+  })
+})

--- a/front/tests/unitaire/navigation-derivee.spec.ts
+++ b/front/tests/unitaire/navigation-derivee.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26 ;
+ * consolidation des trois propositions de test de navigation, dont une seule subsiste) :
+ * les libellés de la navigation sont DÉRIVÉS du contenu éditorial, jamais recopiés, et
+ * l'URL d'une offre est construite sur sa CLÉ, jamais sur son titre.
+ *
+ * Le test compare `siteNavigation` à `offres` plutôt qu'à des chaînes attendues : écrire
+ * « Ingénierie Web », « Data & IA » et « SEA » ici ferait de ce test une troisième copie
+ * des libellés — exactement le défaut qu'il doit interdire (issue #11 : l'en-tête
+ * annonçait « Data et IA » quand la carte annonçait « Data & IA »).
+ *
+ * Cas limites couverts : ajouter une offre au contenu doit l'ajouter à la navigation
+ * sans toucher au fichier de navigation (vérifié par la relation, pas par une liste) ;
+ * « Parcours » et « Contact » ne dérivent d'aucune offre et restent les SEULES entrées
+ * littérales ; les offres passent avant elles ; un titre qui contient une esperluette ou
+ * un accent ne doit jamais se retrouver dans une URL.
+ *
+ * Niveau : unitaire (données pures).
+ * Jeu de données : le contenu réel des offres du dépôt.
+ */
+import { MAIN_CONTENT_ID, siteNavigation } from '@/@shared/config/navigation'
+import { cheminOffre } from '@/@shared/config/routes'
+import { offres } from '@/content'
+
+/** Les entrées qui n'ont aucune source éditoriale : elles seules sont écrites à la main. */
+const ENTREES_HORS_OFFRES = [
+  { href: '/parcours', label: 'Parcours' },
+  { href: '/contact', label: 'Contact' },
+] as const
+
+describe('cheminOffre', () => {
+  it('construit le chemin d’une offre sur sa clé', () => {
+    for (const offre of offres) {
+      expect(cheminOffre(offre.cle)).toBe(`/services/${offre.cle}`)
+    }
+  })
+
+  it('ne produit que des chemins absolus utilisables tels quels dans une URL', () => {
+    for (const offre of offres) {
+      const chemin = cheminOffre(offre.cle)
+
+      expect(chemin.startsWith('/services/')).toBe(true)
+      expect(chemin).toBe(encodeURI(chemin))
+      expect(chemin).not.toMatch(/[\s&]/)
+    }
+  })
+})
+
+describe('navigation principale', () => {
+  it('commence par les offres, dans l’ordre du contenu éditorial', () => {
+    expect(siteNavigation.slice(0, offres.length)).toEqual(
+      offres.map((offre) => ({ href: cheminOffre(offre.cle), label: offre.titre })),
+    )
+  })
+
+  it('reprend le titre de chaque offre sans le réécrire', () => {
+    for (const [index, offre] of offres.entries()) {
+      expect(siteNavigation[index]?.label).toBe(offre.titre)
+    }
+  })
+
+  it('construit chaque lien sur la clé de l’offre, jamais sur son titre', () => {
+    for (const [index, offre] of offres.entries()) {
+      const href = siteNavigation[index]?.href
+
+      expect(href).toBe(`/services/${offre.cle}`)
+      expect(href?.split('/').pop()).toBe(offre.cle)
+    }
+  })
+
+  it('ne laisse aucun titre éditorial fuir dans une URL', () => {
+    for (const lien of siteNavigation) {
+      expect(lien.href).toMatch(/^\/[a-z0-9/-]*$/)
+    }
+  })
+
+  it('termine par les deux entrées sans source éditoriale, dans cet ordre', () => {
+    expect(siteNavigation.slice(offres.length)).toEqual([...ENTREES_HORS_OFFRES])
+  })
+
+  it('ne contient rien d’autre que les offres et ces deux entrées', () => {
+    expect(siteNavigation).toHaveLength(offres.length + ENTREES_HORS_OFFRES.length)
+  })
+
+  it('donne à chaque entrée un libellé explicite hors contexte (WCAG 2.4.4)', () => {
+    for (const lien of siteNavigation) {
+      expect(lien.label.trim().length).toBeGreaterThan(1)
+      expect(lien.label).not.toMatch(/^(ici|lire la suite|en savoir plus)$/i)
+    }
+  })
+
+  it('ne déclare jamais deux fois la même destination', () => {
+    const destinations = siteNavigation.map((lien) => lien.href)
+
+    expect(new Set(destinations).size).toBe(destinations.length)
+  })
+})
+
+describe('cible du lien d’évitement', () => {
+  it('nomme le conteneur de contenu principal', () => {
+    expect(MAIN_CONTENT_ID).toBe('contenu')
+  })
+
+  it('reste un identifiant HTML valide', () => {
+    expect(MAIN_CONTENT_ID).toMatch(/^[a-z][a-z0-9-]*$/)
+  })
+})

--- a/front/tests/unitaire/offre-data-ia.spec.ts
+++ b/front/tests/unitaire/offre-data-ia.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * l'ORDRE des axes de l'offre « Data & IA » est le message, pas une mise en page.
+ * L'offre s'ouvre sur la FIABILITÉ des données, puis sur leur QUALIFICATION selon
+ * l'usage visé, et SEULEMENT ENSUITE sur les deux volets. Cet ordre distingue Jérôme de
+ * qui vend l'IA d'abord et découvre ensuite que la donnée du client est inexploitable :
+ * l'inverser pour gagner en effet d'annonce changerait le discours (précisions de
+ * Jérôme MARICHEZ, 2026-08-08 — issue #16).
+ *
+ * Le découpage en volets est une DONNÉE (`IAxeOffre.volet`), pas une convention de
+ * nommage ni un regroupement calculé par le rendu : un axe sans `volet` appartient au
+ * socle commun aux deux volets.
+ *
+ * Cas limites couverts : les axes d'un même volet restent contigus (sans quoi le rendu
+ * devrait regrouper, donc réordonner) ; l'offre est entièrement sur devis et ne publie
+ * AUCUN montant chiffré ; le RAG est revendiqué comme technique maison, sans framework.
+ *
+ * Niveau : unitaire (données pures).
+ * Jeu de données : le contenu réel de l'offre Data & IA du dépôt.
+ */
+import { offreDataIa } from '@/content'
+
+const cles = offreDataIa.axes.map((axe) => axe.cle)
+const volets = offreDataIa.axes.map((axe) => axe.volet)
+
+describe('offre Data & IA — identité', () => {
+  it('porte la clé et le titre arbitrés', () => {
+    expect(offreDataIa.cle).toBe('data-ia')
+    expect(offreDataIa.titre).toBe('Data & IA')
+  })
+
+  it('se termine sur une décision, pas sur une liste d’outils', () => {
+    expect(offreDataIa.decisionPermise).toMatch(/vous décidez/i)
+  })
+})
+
+describe('ordre de lecture des axes', () => {
+  it('ouvre sur la fiabilité des données, avant toute promesse d’IA', () => {
+    expect(cles[0]).toBe('fiabilite-donnees')
+  })
+
+  it('enchaîne sur la qualification selon l’usage visé', () => {
+    expect(cles[1]).toBe('qualification-donnees')
+  })
+
+  it('place les deux axes de préalable avant tout axe rattaché à un volet', () => {
+    const premierAxeDeVolet = volets.findIndex((volet) => volet !== undefined)
+
+    expect(premierAxeDeVolet).toBeGreaterThan(1)
+  })
+
+  it('traite la fiabilité comme un prérequis, jamais comme un correctif', () => {
+    const fiabilite = offreDataIa.axes.find((axe) => axe.cle === 'fiabilite-donnees')
+
+    expect(fiabilite?.description).toMatch(/prérequis/)
+    expect(fiabilite?.description).toMatch(/jamais un correctif/)
+  })
+
+  it('distingue trois usages dans la qualification des données', () => {
+    const qualification = offreDataIa.axes.find((axe) => axe.cle === 'qualification-donnees')
+
+    expect(qualification?.description).toMatch(/marketing/i)
+    expect(qualification?.description).toMatch(/LLM/)
+    expect(qualification?.description).toMatch(/prédictifs/)
+  })
+})
+
+describe('les deux volets sont portés par la donnée', () => {
+  const voletsNommes = [...new Set(volets.filter((volet): volet is string => volet !== undefined))]
+
+  it('déclare exactement deux volets nommés', () => {
+    expect(voletsNommes).toHaveLength(2)
+    expect(voletsNommes).toEqual(['Agents autonomes', 'Projets data supervisés et non supervisés'])
+  })
+
+  it('laisse au socle commun les axes sans volet', () => {
+    const socle = offreDataIa.axes.filter((axe) => axe.volet === undefined).map((axe) => axe.cle)
+
+    expect(socle).toEqual([
+      'fiabilite-donnees',
+      'qualification-donnees',
+      'mlops-cloud',
+      'conformite',
+      'devis',
+    ])
+  })
+
+  it('garde contigus les axes d’un même volet, pour que le rendu n’ait rien à regrouper', () => {
+    const sequence = volets.filter((volet): volet is string => volet !== undefined)
+    const apparitions = sequence.filter((volet, index) => volet !== sequence[index - 1])
+
+    expect(new Set(apparitions).size).toBe(apparitions.length)
+  })
+
+  it('rattache chaque volet à au moins deux axes', () => {
+    for (const volet of voletsNommes) {
+      expect(offreDataIa.axes.filter((axe) => axe.volet === volet).length).toBeGreaterThanOrEqual(2)
+    }
+  })
+})
+
+describe('véracité propre à l’offre', () => {
+  it('revendique un RAG maison, sans framework tiers', () => {
+    const rag = offreDataIa.axes.find((axe) => axe.cle === 'rag-documentaire')
+
+    expect(rag?.description).toMatch(/PostgreSQL/)
+    expect(rag?.description).toMatch(/sans framework tiers/)
+  })
+
+  it('est entièrement sur devis et ne publie aucun montant', () => {
+    const devis = offreDataIa.axes.find((axe) => axe.cle === 'devis')
+
+    expect(devis?.description).toMatch(/entièrement sur devis/)
+    expect(JSON.stringify(offreDataIa)).not.toMatch(/\d\s?(€|EUR)/)
+  })
+
+  it('nomme Prézage et Llama 3, autorisés, sans publier de chiffre couvert par le NDA', () => {
+    const adaptation = offreDataIa.axes.find((axe) => axe.cle === 'adaptation-modeles')
+
+    expect(adaptation?.description).toMatch(/Llama 3/)
+    expect(adaptation?.description).toMatch(/Prézage/)
+    expect(adaptation?.preuve).not.toMatch(/\d+\s?%/)
+  })
+})

--- a/front/tests/unitaire/parite-themes.spec.ts
+++ b/front/tests/unitaire/parite-themes.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * les deux thèmes déclarent EXACTEMENT le même jeu de jetons `--color-*`. C'est la
+ * promesse écrite en tête de `tokens.css` (« Les deux blocs déclarent EXACTEMENT les
+ * mêmes jetons de couleur »), et c'est elle qui rend la vérification de contraste
+ * exhaustive : un jeton présent d'un seul côté sortirait du contrôle sans bruit.
+ *
+ * Ce test attrape la régression la plus probable du socle de design : ajouter une
+ * couleur au thème clair et oublier le sombre — ou l'inverse.
+ *
+ * Cas limites couverts : le bloc `prefers-color-scheme: dark`, qui applique le thème
+ * sombre par défaut, doit déclarer les mêmes jetons ET les mêmes valeurs que le bloc
+ * `[data-theme="dark"]` — sinon la préférence système et le forçage explicite
+ * afficheraient deux thèmes différents ; aucun jeton de couleur ne peut porter la même
+ * valeur dans les deux thèmes sans que ce soit visible (contrôle de non-copie) ; toute
+ * valeur de couleur est bien une couleur hexadécimale lisible par le calcul de contraste.
+ *
+ * Niveau : unitaire (lecture textuelle, aucun navigateur).
+ * Jeu de données : le vrai `tokens.css` du dépôt.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { THEME_SELECTORS } from '@/@shared/config/contrast-pairs'
+import { parseHexColor } from '@/@shared/utils/color'
+import { extractCustomProperties } from '@/@shared/utils/css-custom-properties'
+
+const CHEMIN_TOKENS = join(__dirname, '..', '..', 'src', '@shared', 'styles', 'tokens.css')
+const tokens = readFileSync(CHEMIN_TOKENS, 'utf8')
+
+/** Bloc appliqué quand l'utilisateur n'a rien forcé et que son système est en sombre. */
+const SELECTEUR_PREFERENCE_SYSTEME = ':root:not([data-theme="light"])'
+
+function jetonsCouleur(selecteur: string): ReadonlyMap<string, string> {
+  const proprietes = extractCustomProperties(tokens, selecteur)
+  return new Map([...proprietes].filter(([nom]) => nom.startsWith('color-')))
+}
+
+const clair = jetonsCouleur(THEME_SELECTORS.clair)
+const sombre = jetonsCouleur(THEME_SELECTORS.sombre)
+const preferenceSysteme = jetonsCouleur(SELECTEUR_PREFERENCE_SYSTEME)
+
+const nomsTries = (jetons: ReadonlyMap<string, string>): readonly string[] =>
+  [...jetons.keys()].sort()
+
+describe('parité des thèmes clair et sombre', () => {
+  it('déclare des jetons de couleur dans les deux thèmes', () => {
+    expect(clair.size).toBeGreaterThan(0)
+    expect(sombre.size).toBeGreaterThan(0)
+  })
+
+  it('déclare le même jeu de jetons --color-* dans les deux thèmes', () => {
+    expect(nomsTries(sombre)).toEqual(nomsTries(clair))
+  })
+
+  it('ne laisse aucun jeton de couleur sans contrepartie dans l’autre thème', () => {
+    for (const nom of clair.keys()) {
+      expect(sombre.has(nom)).toBe(true)
+    }
+    for (const nom of sombre.keys()) {
+      expect(clair.has(nom)).toBe(true)
+    }
+  })
+
+  it('donne à chaque jeton une couleur hexadécimale exploitable par le calcul de contraste', () => {
+    for (const [nom, valeur] of [...clair, ...sombre]) {
+      expect(() => parseHexColor(valeur)).not.toThrow()
+      expect(nom.startsWith('color-')).toBe(true)
+    }
+  })
+
+  it('recalcule réellement les valeurs pour le thème sombre', () => {
+    // Deux thèmes qui partageraient toutes leurs valeurs ne seraient qu'un seul thème.
+    const identiques = [...clair].filter(([nom, valeur]) => sombre.get(nom) === valeur)
+
+    expect(identiques).toEqual([])
+  })
+})
+
+describe('préférence système (prefers-color-scheme: dark)', () => {
+  it('déclare les mêmes jetons que le thème sombre forcé', () => {
+    expect(nomsTries(preferenceSysteme)).toEqual(nomsTries(sombre))
+  })
+
+  it('déclare les mêmes valeurs que le thème sombre forcé', () => {
+    for (const [nom, valeur] of sombre) {
+      expect(preferenceSysteme.get(nom)).toBe(valeur)
+    }
+  })
+})

--- a/front/tests/unitaire/proprietes-personnalisees-css.spec.ts
+++ b/front/tests/unitaire/proprietes-personnalisees-css.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * l'utilitaire qui extrait les jetons d'une feuille de style attrape LE BON bloc de
+ * règles. Sans ce test, celui des contrastes pourrait passer à vide : une extraction
+ * qui renvoie une table vide ne fait échouer aucune comparaison qu'on n'a pas écrite.
+ *
+ * Comportement attendu : `extractRuleBlock` rend le contenu du bloc `{ … }` qui suit
+ * immédiatement le sélecteur, accolades équilibrées ; `extractCustomProperties` rend
+ * les déclarations `--nom: valeur` de ce bloc, commentaires retirés, nom sans tirets.
+ *
+ * Cas limites couverts : `:root` ne doit JAMAIS attraper `:root[data-theme="dark"]`,
+ * y compris quand le bloc sombre est écrit en premier ; un sélecteur absent lève une
+ * erreur au lieu de rendre une table vide ; un bloc non refermé lève ; les blocs
+ * imbriqués (media query) sont équilibrés ; les commentaires ne produisent pas de faux
+ * jetons ; une déclaration sans point-virgule final est lue quand même ; les valeurs à
+ * virgules (`font-family`, `clamp`) ne sont pas tronquées.
+ *
+ * Niveau : unitaire (fonctions pures).
+ * Jeu de données : des feuilles de style minimales écrites dans le test pour les cas
+ * limites, et le vrai `tokens.css` du dépôt pour le cas nominal.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { THEME_SELECTORS } from '@/@shared/config/contrast-pairs'
+import { extractCustomProperties, extractRuleBlock } from '@/@shared/utils/css-custom-properties'
+
+const CHEMIN_TOKENS = join(__dirname, '..', '..', 'src', '@shared', 'styles', 'tokens.css')
+const tokens = readFileSync(CHEMIN_TOKENS, 'utf8')
+
+/** Le bloc sombre est écrit AVANT le clair : le piège que le sélecteur doit éviter. */
+const CSS_ORDRE_INVERSE = `
+:root[data-theme="dark"] {
+  --color-text: #ffffff;
+}
+
+:root {
+  --color-text: #000000;
+}
+`
+
+describe('extractRuleBlock', () => {
+  it('rend le contenu du bloc qui suit le sélecteur', () => {
+    const bloc = extractRuleBlock(':root { --a: 1; }', ':root')
+
+    expect(bloc.trim()).toBe('--a: 1;')
+  })
+
+  it('distingue « :root » de « :root[data-theme="dark"] » même écrit après lui', () => {
+    const clair = extractRuleBlock(CSS_ORDRE_INVERSE, ':root')
+    const sombre = extractRuleBlock(CSS_ORDRE_INVERSE, ':root[data-theme="dark"]')
+
+    expect(clair).toContain('#000000')
+    expect(clair).not.toContain('#ffffff')
+    expect(sombre).toContain('#ffffff')
+    expect(sombre).not.toContain('#000000')
+  })
+
+  it('tolère les espaces entre le sélecteur et son accolade', () => {
+    expect(extractRuleBlock(':root\n  {\n  --a: 1;\n}', ':root')).toContain('--a: 1')
+  })
+
+  it('équilibre les accolades des blocs imbriqués', () => {
+    const media = extractRuleBlock(
+      '@media (prefers-color-scheme: dark) {\n  :root { --a: 1; }\n}\n:root { --a: 2; }',
+      '@media (prefers-color-scheme: dark)',
+    )
+
+    expect(media).toContain('--a: 1')
+    expect(media).not.toContain('--a: 2')
+  })
+
+  it('lève sur un sélecteur absent plutôt que de rendre un bloc vide', () => {
+    expect(() => extractRuleBlock(':root { --a: 1; }', '.inexistant')).toThrow(
+      /Bloc CSS introuvable/,
+    )
+  })
+
+  it('lève quand le sélecteur n’est jamais suivi d’une accolade', () => {
+    expect(() => extractRuleBlock('/* :root sans bloc */', ':root')).toThrow(/introuvable/)
+  })
+
+  it('lève sur un bloc dont l’accolade fermante manque', () => {
+    expect(() => extractRuleBlock(':root { --a: 1;', ':root')).toThrow(/accolade fermante/)
+  })
+})
+
+describe('extractCustomProperties', () => {
+  it('rend les propriétés du bloc, nom sans les deux tirets', () => {
+    const proprietes = extractCustomProperties(
+      ':root { --color-text: #16181c; --space-sm: 1rem; }',
+      ':root',
+    )
+
+    expect(proprietes.get('color-text')).toBe('#16181c')
+    expect(proprietes.get('space-sm')).toBe('1rem')
+    expect(proprietes.has('--color-text')).toBe(false)
+  })
+
+  it('ignore les commentaires du bloc', () => {
+    const proprietes = extractCustomProperties(
+      ':root { /* --color-piege: #ff0000; */ --color-text: #000000; }',
+      ':root',
+    )
+
+    expect(proprietes.has('color-piege')).toBe(false)
+    expect(proprietes.get('color-text')).toBe('#000000')
+    expect(proprietes.size).toBe(1)
+  })
+
+  it('lit la dernière déclaration même sans point-virgule final', () => {
+    expect(extractCustomProperties(':root { --a: 1rem }', ':root').get('a')).toBe('1rem')
+  })
+
+  it('ne tronque pas une valeur qui contient des virgules ou des parenthèses', () => {
+    const proprietes = extractCustomProperties(
+      ':root { --font-size-base: clamp(1rem, 0.975rem + 0.125vw, 1.125rem); }',
+      ':root',
+    )
+
+    expect(proprietes.get('font-size-base')).toBe('clamp(1rem, 0.975rem + 0.125vw, 1.125rem)')
+  })
+
+  it('ne mélange pas les deux thèmes du vrai tokens.css', () => {
+    const clair = extractCustomProperties(tokens, THEME_SELECTORS.clair)
+    const sombre = extractCustomProperties(tokens, THEME_SELECTORS.sombre)
+
+    expect(clair.get('color-background')).toBe('#fcfcfa')
+    expect(sombre.get('color-background')).toBe('#0e1013')
+    expect(clair.get('color-background')).not.toBe(sombre.get('color-background'))
+  })
+
+  it('lit un nombre substantiel de jetons dans le vrai tokens.css', () => {
+    const clair = extractCustomProperties(tokens, THEME_SELECTORS.clair)
+
+    // Le thème clair porte les couleurs ET l'échelle typographique, d'espacement, etc.
+    expect(clair.size).toBeGreaterThan(30)
+  })
+})

--- a/front/tests/unitaire/routes-sitemap.spec.ts
+++ b/front/tests/unitaire/routes-sitemap.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * la découverte de routes ne connaît QUE l'arborescence réelle de `src/app/`, et le
+ * sitemap n'est que sa projection. Un sitemap faux est pire qu'absent : il envoie les
+ * moteurs sur des 404 et laisse les vraies pages hors index, sans qu'aucun test visible
+ * ne s'en aperçoive.
+ *
+ * Table de vérité attendue : un dossier ne devient une route que s'il porte un fichier
+ * `page.*` ; un groupe de routes `(vitrine)` est traversé SANS ajouter de segment ; un
+ * dossier privé `_prive`, un emplacement parallèle `@modal`, une route interceptée
+ * `(.)apercu` et un segment dynamique `[slug]` ne produisent AUCUNE URL indexable ; un
+ * dossier qui ne porte qu'un `route.ts` n'est pas une page.
+ *
+ * Cas limites couverts : extensions `page.ts`/`page.js` acceptées au même titre que
+ * `page.tsx` ; ordre de sortie stable (tri) ; racine rendue « / » et non « » ; chaque
+ * URL du sitemap est absolue et sans barre finale ; ni `priority` ni `changeFrequency`
+ * ne sont inventés.
+ *
+ * Niveau : unitaire. Aucune doublure de module : c'est le VRAI `routes.server.ts` qui
+ * tourne, sur une VRAIE arborescence de fichiers créée pour le test dans un dossier
+ * temporaire — le système de fichiers est une frontière, pas un module métier.
+ *
+ * Jeu de données : l'arborescence temporaire décrite ci-dessous, et l'arborescence
+ * réelle du dépôt pour le cas nominal.
+ */
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { absoluteUrl, siteUrl } from '@/@shared/seo'
+import { listSiteRoutes } from '@/@shared/seo/routes.server'
+import robots from '@/app/robots'
+import sitemap from '@/app/sitemap'
+
+/** Arborescence de test : à gauche le fichier créé, à droite la route attendue (ou aucune). */
+const FICHIERS_PAGES = [
+  'src/app/page.tsx',
+  'src/app/parcours/page.tsx',
+  'src/app/(vitrine)/contact/page.tsx',
+  'src/app/services/sea/page.js',
+  'src/app/mentions-legales/page.ts',
+  'src/app/_prive/page.tsx',
+  'src/app/@modal/page.tsx',
+  'src/app/(.)apercu/page.tsx',
+  'src/app/[slug]/page.tsx',
+  'src/app/api/contact/route.ts',
+] as const
+
+const ROUTES_ATTENDUES = [
+  '/',
+  '/contact',
+  '/mentions-legales',
+  '/parcours',
+  '/services/sea',
+] as const
+
+describe('listSiteRoutes — table de vérité sur une arborescence réelle', () => {
+  const repertoireInitial = process.cwd()
+  let racineTemporaire = ''
+  let routes: readonly { path: string; lastModified: Date }[] = []
+
+  beforeAll(async () => {
+    racineTemporaire = mkdtempSync(join(tmpdir(), 'routes-site-'))
+    for (const fichier of FICHIERS_PAGES) {
+      const chemin = join(racineTemporaire, fichier)
+      mkdirSync(dirname(chemin), { recursive: true })
+      writeFileSync(chemin, 'export default function Page() { return null }\n')
+    }
+
+    // Le module calcule son répertoire d'app à partir de `process.cwd()` au chargement :
+    // on déplace le répertoire de travail, puis on charge le VRAI module.
+    process.chdir(racineTemporaire)
+    jest.resetModules()
+    const module = await import('@/@shared/seo/routes.server')
+    routes = module.listSiteRoutes()
+  })
+
+  afterAll(() => {
+    process.chdir(repertoireInitial)
+    if (racineTemporaire !== '') rmSync(racineTemporaire, { recursive: true, force: true })
+  })
+
+  it('découvre exactement les routes indexables, triées', () => {
+    expect(routes.map((route) => route.path)).toEqual([...ROUTES_ATTENDUES])
+  })
+
+  it('traverse un groupe de routes sans ajouter son nom à l’URL', () => {
+    const chemins = routes.map((route) => route.path)
+
+    expect(chemins).toContain('/contact')
+    expect(chemins.some((chemin) => chemin.includes('vitrine'))).toBe(false)
+  })
+
+  it.each([
+    ['dossier privé', '_prive'],
+    ['emplacement parallèle', '@modal'],
+    ['route interceptée', 'apercu'],
+    ['segment dynamique', 'slug'],
+    ['gestionnaire de route sans page', 'api'],
+  ])('n’indexe pas un %s', (_cas, fragment) => {
+    expect(routes.some((route) => route.path.includes(fragment))).toBe(false)
+  })
+
+  it('rend la racine « / » et non une chaîne vide', () => {
+    expect(routes.map((route) => route.path)).toContain('/')
+  })
+
+  it('date chaque route du fichier de page qui la porte', () => {
+    const parcours = routes.find((route) => route.path === '/parcours')
+    const attendue = statSync(join(racineTemporaire, 'src/app/parcours/page.tsx')).mtime
+
+    expect(parcours?.lastModified.getTime()).toBe(attendue.getTime())
+  })
+})
+
+describe('listSiteRoutes — arborescence réelle du dépôt', () => {
+  const routes = listSiteRoutes()
+
+  it('découvre au moins la page d’accueil', () => {
+    expect(routes.map((route) => route.path)).toContain('/')
+  })
+
+  it('ne produit que des chemins absolus, sans barre finale', () => {
+    for (const route of routes) {
+      expect(route.path.startsWith('/')).toBe(true)
+      expect(route.path === '/' || !route.path.endsWith('/')).toBe(true)
+    }
+  })
+
+  it('ne découvre jamais deux fois la même route', () => {
+    const chemins = routes.map((route) => route.path)
+
+    expect(new Set(chemins).size).toBe(chemins.length)
+  })
+
+  it('rend un ordre stable d’un appel à l’autre', () => {
+    expect(listSiteRoutes().map((route) => route.path)).toEqual(routes.map((route) => route.path))
+  })
+})
+
+describe('sitemap.xml', () => {
+  const entrees = sitemap()
+  const routes = listSiteRoutes()
+
+  it('publie une entrée par route réellement servie', () => {
+    expect(entrees.map((entree) => entree.url)).toEqual(
+      routes.map((route) => absoluteUrl(route.path)),
+    )
+  })
+
+  it('n’écrit que des URL absolues sur l’origine du site', () => {
+    for (const entree of entrees) {
+      expect(entree.url.startsWith(`${siteUrl}`)).toBe(true)
+      expect(entree.url.endsWith('/')).toBe(false)
+    }
+  })
+
+  it('reprend la date de dernière modification de chaque route', () => {
+    expect(entrees.map((entree) => entree.lastModified)).toEqual(
+      routes.map((route) => route.lastModified),
+    )
+  })
+
+  it('n’invente ni priorité ni fréquence de changement', () => {
+    for (const entree of entrees) {
+      expect(entree.priority).toBeUndefined()
+      expect(entree.changeFrequency).toBeUndefined()
+    }
+  })
+
+  it('est déclaré statique : la lecture du système de fichiers a lieu au build', async () => {
+    const module = await import('@/app/sitemap')
+
+    expect(module.dynamic).toBe('force-static')
+  })
+})
+
+describe('robots.txt', () => {
+  const regles = robots()
+
+  it('autorise l’indexation de tout le site', () => {
+    expect(regles.rules).toEqual([{ userAgent: '*', allow: '/' }])
+  })
+
+  it('déclare le sitemap en URL absolue, comme l’exige la spécification', () => {
+    expect(regles.sitemap).toBe(`${siteUrl}/sitemap.xml`)
+  })
+
+  it('déclare l’hôte du site', () => {
+    expect(regles.host).toBe(siteUrl)
+  })
+})

--- a/front/tests/unitaire/socle-structure.spec.tsx
+++ b/front/tests/unitaire/socle-structure.spec.tsx
@@ -1,0 +1,179 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #26) :
+ * les composants de structure du socle rendent la sémantique qu'ils promettent —
+ * celle dont dépendent les technologies d'assistance, et qu'aucune relecture visuelle
+ * ne permet de vérifier.
+ *
+ * Comportement attendu : `SkipLink` rend une ancre vers le contenu principal (WCAG
+ * 2.4.1) ; `Section` rend une région NOMMÉE PAR SON PROPRE TITRE via `aria-labelledby`,
+ * sans libellé maintenu en double ; `Container` borne la largeur de lecture ;
+ * `SiteFooter` rend la navigation DÉRIVÉE du contenu, la même liste que celle de
+ * l'en-tête — les deux ne peuvent donc pas diverger.
+ *
+ * Cas limites couverts : niveau de titre non par défaut d'une section, section sans
+ * phrase d'introduction, largeur de conteneur non par défaut, libellé personnalisé du
+ * lien d'évitement, et le fait que le pied de page ne recopie aucun libellé d'offre.
+ *
+ * NON COUVERT ICI, ET DIT FRANCHEMENT : `SiteHeader` rend `NavLink`, un composant
+ * client qui lit la route courante (`usePathname`) pour poser `aria-current="page"`.
+ * Hors contexte de routeur, ce comportement ne s'observe pas sans doublure de module —
+ * interdite ici. Il relève du niveau e2e (Cypress), qui ne tourne que sur les PR vers
+ * `main`.
+ *
+ * Niveau : unitaire (React Testing Library, jsdom).
+ * Jeu de données : le contenu réel des offres, via `siteNavigation`.
+ */
+import { render, screen } from '@testing-library/react'
+import { Container } from '@/@shared/components/Container'
+import { Section } from '@/@shared/components/Section'
+import { SiteFooter } from '@/@shared/components/SiteFooter'
+import { SkipLink } from '@/@shared/components/SkipLink'
+import { MAIN_CONTENT_ID, siteNavigation } from '@/@shared/config/navigation'
+
+describe('SkipLink', () => {
+  it('pointe vers le conteneur de contenu principal', () => {
+    render(<SkipLink targetId={MAIN_CONTENT_ID} />)
+
+    const lien = screen.getByRole('link', { name: 'Aller au contenu principal' })
+    expect(lien.getAttribute('href')).toBe(`#${MAIN_CONTENT_ID}`)
+  })
+
+  it('accepte un libellé explicite', () => {
+    render(<SkipLink targetId="contenu">Aller au contenu</SkipLink>)
+
+    expect(screen.getByRole('link', { name: 'Aller au contenu' })).not.toBeNull()
+  })
+
+  it('reste une ancre, donc focusable et dans le flux', () => {
+    render(<SkipLink targetId="contenu" />)
+
+    const lien = screen.getByRole('link')
+    expect(lien.tagName).toBe('A')
+    expect(lien.getAttribute('tabindex')).toBeNull()
+  })
+})
+
+describe('Container', () => {
+  it('applique la largeur par défaut', () => {
+    const { container } = render(<Container>Contenu</Container>)
+
+    expect(container.firstElementChild?.className).toBe('container default')
+  })
+
+  it.each(['narrow', 'default', 'wide'] as const)('applique la largeur « %s »', (largeur) => {
+    const { container } = render(<Container width={largeur}>Contenu</Container>)
+
+    expect(container.firstElementChild?.className).toBe(`container ${largeur}`)
+  })
+
+  it('combine une classe additionnelle sans écraser les siennes', () => {
+    const { container } = render(<Container className="inner">Contenu</Container>)
+
+    expect(container.firstElementChild?.className).toBe('container default inner')
+  })
+})
+
+describe('Section', () => {
+  it('nomme la région par son propre titre', () => {
+    render(
+      <Section id="offres" title="Mes offres">
+        Contenu
+      </Section>,
+    )
+
+    const region = screen.getByRole('region', { name: 'Mes offres' })
+    const titre = screen.getByRole('heading', { name: 'Mes offres' })
+
+    expect(region.getAttribute('id')).toBe('offres')
+    expect(region.getAttribute('aria-labelledby')).toBe(titre.getAttribute('id'))
+    expect(titre.getAttribute('id')).toBe('offres-titre')
+  })
+
+  it('titre en h2 par défaut, et suit le niveau demandé', () => {
+    const { unmount } = render(
+      <Section id="a" title="Titre A">
+        Contenu
+      </Section>,
+    )
+    expect(screen.getByRole('heading', { name: 'Titre A' }).tagName).toBe('H2')
+    unmount()
+
+    render(
+      <Section headingLevel={3} id="b" title="Titre B">
+        Contenu
+      </Section>,
+    )
+    expect(screen.getByRole('heading', { name: 'Titre B' }).tagName).toBe('H3')
+  })
+
+  it('n’affiche une phrase d’introduction que si elle est fournie', () => {
+    const { unmount } = render(
+      <Section id="a" lead="Une phrase." title="Titre">
+        Contenu
+      </Section>,
+    )
+    expect(screen.getByText('Une phrase.')).not.toBeNull()
+    unmount()
+
+    render(
+      <Section id="b" title="Titre">
+        Contenu
+      </Section>,
+    )
+    expect(screen.queryByText('Une phrase.')).toBeNull()
+  })
+
+  it('sert d’ancre aux liens internes de la page', () => {
+    render(
+      <Section id="contact" title="Me contacter">
+        Contenu
+      </Section>,
+    )
+
+    expect(screen.getByRole('region', { name: 'Me contacter' }).getAttribute('id')).toBe('contact')
+  })
+})
+
+describe('SiteFooter', () => {
+  it('rend la navigation dérivée du contenu, dans son ordre', () => {
+    render(<SiteFooter />)
+
+    const navigation = screen.getByRole('navigation', { name: 'Navigation de pied de page' })
+    const liens = [...navigation.querySelectorAll('a')]
+
+    expect(liens.map((lien) => lien.textContent)).toEqual(
+      siteNavigation.map((entree) => entree.label),
+    )
+    expect(liens.map((lien) => lien.getAttribute('href'))).toEqual(
+      siteNavigation.map((entree) => entree.href),
+    )
+  })
+
+  it('ne recopie aucun libellé : la liste vient de la même source que l’en-tête', () => {
+    render(<SiteFooter />)
+
+    const navigation = screen.getByRole('navigation', { name: 'Navigation de pied de page' })
+    expect(navigation.querySelectorAll('a')).toHaveLength(siteNavigation.length)
+  })
+
+  it('nomme sa navigation, pour la distinguer de celle de l’en-tête', () => {
+    render(<SiteFooter />)
+
+    expect(screen.getByRole('navigation').getAttribute('aria-label')).toBe(
+      'Navigation de pied de page',
+    )
+  })
+
+  it('propose un appel à l’action vers le contact', () => {
+    render(<SiteFooter />)
+
+    expect(screen.getByRole('link', { name: 'Me contacter' }).getAttribute('href')).toBe('/contact')
+  })
+
+  it('n’affiche aucune année qui se périmerait', () => {
+    const { container } = render(<SiteFooter />)
+
+    expect(container.textContent).toContain('© Jérôme Marichez')
+    expect(container.textContent).not.toMatch(/©\s*\d{4}/)
+  })
+})


### PR DESCRIPTION
## Contexte

Closes #26

Huit lots ont été livrés sans qu'aucun comportement métier ne soit verrouillé
automatiquement. Ce lot pose les tests des **domaines stables**, en consolidant les
propositions accumulées au fil des PR précédentes plutôt qu'en les recopiant.

**Délégation explicite de Jérôme MARICHEZ, 2026-08-08** : « oui fait les 21 tests ».
C'est la dérogation prévue par le `CLAUDE.md` (`TESTS_WRITABLE_BY_ASSISTANT=1`), qui
autorise l'assistant à écrire les fichiers de test. La contrepartie imposée par la même
règle est tenue : **chaque fichier porte en tête un bloc `Intention : …`** — comportement
attendu, cas limites, niveau visé, jeu de données utilisé.

## Ce qui est posé

**16 fichiers, 351 tests ajoutés**, tous exécutés et verts.

| Domaine | Fichier | Ce qui est verrouillé |
|---|---|---|
| Contrastes | `contrastes-jetons.spec.ts` | 24 couples × 2 thèmes, valeurs lues dans le vrai `tokens.css` |
| Lecture des jetons | `proprietes-personnalisees-css.spec.ts` | `:root` n'attrape pas `:root[data-theme="dark"]`, même écrit après lui ; sélecteur absent → **lève** |
| Calcul de contraste | `couleur-contraste.spec.ts` | Bornes WCAG 21:1 et 1:1, luminance relative, refus de toute valeur non hexadécimale |
| Parité des thèmes | `parite-themes.spec.ts` | Même jeu de `--color-*` ; bloc `prefers-color-scheme` aligné sur le sombre forcé |
| Composants | `card.spec.tsx`, `action-link.spec.tsx`, `socle-structure.spec.tsx` | Niveaux de titre, zones optionnelles, `rel="noopener noreferrer"`, ouverture annoncée **dans le nom accessible**, région nommée par son titre, pied de page dérivé du contenu |
| Données structurées | `donnees-structurees.spec.ts`, `json-ld.spec.tsx` | Graphe sérialisable, `Person` ↔ `ProfessionalService` reliés par `@id`, **aucune propriété non établie** à aucune profondeur, EF SET en `knowsLanguage` jamais en `hasCredential` |
| Métadonnées | `metadonnees-seo.spec.ts` | Canonique = `og:url`, gabarit de titre, `absoluteTitle`, refus d'une description hors bornes ou d'un chemin mal formé |
| Routes et sitemap | `routes-sitemap.spec.ts` | Table de vérité complète de la découverte, sitemap projeté des routes réelles, `robots.txt` |
| Navigation dérivée | `navigation-derivee.spec.ts` | Libellés **dérivés** du contenu (comparaison relationnelle) ; URL construite sur la **clé**, jamais sur le titre |
| Identité | `identite-telephone.spec.ts` | Conversion E.164, motif unique partagé validation/conversion, refus des schémas Zod |
| Contenu | `contenu-schemas.spec.ts`, `contenu-veracite.spec.ts` | Conformité Zod du jeu de données réel, **lien de certification mort impossible**, termes interdits, absence de « nous », SEO non vendu |
| Offre Data & IA | `offre-data-ia.spec.ts` | L'**ordre des axes est le message** ; les volets sont une donnée, pas une mise en forme |

## Sortie réelle d'exécution

```
$ make test
cd front && npx jest tests/unitaire --passWithNoTests
Test Suites: 17 passed, 17 total
Tests:       353 passed, 353 total
Time:        3.519 s

cd back && npx jest tests/unitaire --passWithNoTests
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total

cd front && npx jest tests/integration --passWithNoTests
No tests found, exiting with code 0
cd back && npx jest tests/integration --passWithNoTests
No tests found, exiting with code 0
```

353 tests front = **351 posés par ce lot** + 2 du `exemple.spec.ts` préexistant, conservé.

`make lint`, `make typecheck` et `make build` passent également en local (build front :
5 pages statiques générées, `/`, `/_not-found`, `/robots.txt`, `/sitemap.xml`).

## Consolidation — ce qui a été écarté, et pourquoi

- **Périmé** : le test qui interdisait « Universitat » et « Barcelona » dans le contenu
  publié. Jérôme MARICHEZ a arbitré l'inverse le 2026-08-08 — l'Universitat de Barcelona
  est nommée comme **éditrice** de la publication arXiv. Le test posé vérifie désormais
  l'inverse : la mention **doit** être présente, accompagnée de « implémentée moi-même »,
  et c'est « en collaboration avec » qui reste interdit.
- **Redondant** : trois propositions de test de navigation. Une seule subsiste, celle qui
  compare `siteNavigation` à `offres` — écrire les libellés en dur dans le test en aurait
  fait une troisième copie, exactement le défaut à interdire (issue #11).
- **Redondant** : trois propositions touchaient au graphe JSON-LD. Fondues en un seul
  fichier.
- **Hors périmètre (deuxième vague)** : page d'accueil (`AccueilView`, contenu accueil,
  `preuves.service`, e2e accueil) et grille tarifaire — réécritures en cours. Le corpus du
  test de véracité les exclut explicitement.
- **Obsolète** : `seo-sea` est devenu `sea`. Chaque import et chaque clé a été vérifié
  contre le code réel de `origin/dev` après rebase sur la PR #21.
- **Reporté au niveau e2e** : lien d'évitement ramené dans le champ visuel, ordre de
  tabulation, absence de défilement horizontal à 320 px. jsdom ne calcule aucune mise en
  page. Les e2e Cypress ne tournent que sur les PR vers `main`.

## Défauts du code révélés

**Aucun.** Les 351 assertions passent contre le code existant. Deux vérifications
méritent d'être signalées comme *résultats*, pas comme corrections :

- les **48 combinaisons de contraste** (24 couples × 2 thèmes) tiennent leur seuil. La
  marge la plus faible est `--color-border-strong` sur `--color-surface-muted` en thème
  clair : **3,13:1** pour un minimum de 3:1. Elle est mince — le test la garde désormais ;
- la **parité des thèmes** est exacte, y compris pour le bloc `prefers-color-scheme: dark`
  qui duplique le thème sombre : mêmes clés **et** mêmes valeurs.

Un seul ajustement a été nécessaire, sur un test et non sur le code : `metadata.twitter.card`
n'est pas typé sur toutes les variantes de l'union `Twitter` de Next.js. L'assertion est
passée par `toMatchObject`, qui vérifie exactement la même valeur.

## Contraintes respectées

- **Aucune doublure de module** : ni `jest.mock`, ni `vi.mock`, ni `__mocks__`, ni
  `mockResolvedValue`. Les vrais modules collaborent sur le contenu réel du dépôt. La
  découverte de routes tourne sur une **vraie arborescence de fichiers** créée dans un
  dossier temporaire, le répertoire de travail étant déplacé le temps du test puis restauré
  — le système de fichiers est une frontière, pas un module métier.
- **Aucune modification du code applicatif** (`git diff` vide sur `front/src`, `back`,
  `shared`).
- Aucun seuil abaissé, aucun `skip`, aucun `--no-verify`, aucun `continue-on-error`.
- Aucune dépendance ajoutée : `@testing-library/jest-dom` n'est pas installé, les
  assertions utilisent les requêtes RTL et le DOM natif.

## Ce qui reste non couvert — dit franchement

Détaillé dans `docs/testing.md` : page d'accueil et grille tarifaire (deuxième vague),
`SiteHeader` (rend `NavLink`, composant client lisant `usePathname` — non observable sans
doublure, donc e2e), accessibilité de mise en page (e2e), niveaux intégration / système /
e2e / acceptation encore vides côté front, et `buildRootMetadata` en conditions de
production (`NEXT_PUBLIC_SITE_URL` absente en test — les assertions portent sur la
relation entre canonique, `og:url` et sitemap, jamais sur un domaine en dur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Lkzawdu7WwjAQxgKY2ar
