### PR TITLE
test: deuxieme vague (accueil, tarifs, acceptation)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,13 @@ test-system: ## Tests système back (vrai serveur HTTP via listen(0))
 test-mutation: ## Tests de mutation (Stryker) — qualité des tests unitaires/intégration
 	cd front && npx stryker run
 	cd back && npx stryker run
+# Un MOTIF, et non un dossier : depuis Node 22, les arguments positionnels de
+# « node --test » sont des motifs de fichiers. Un chemin de dossier est alors chargé
+# comme module et lève MODULE_NOT_FOUND — que le dossier contienne des tests ou non
+# (vérifié sur Node 26). Le motif est protégé des guillemets : c'est Node qui l'étend,
+# pas le shell, dont le « ** » n'est pas récursif.
 test-acceptance: ## Tests d'acceptation / UAT (runner Node natif)
-	node --test tests/acceptance/
+	node --test "tests/acceptance/**/*.test.js"
 storybook: ## Storybook en local (http://localhost:6006) — après npx storybook@latest init
 	@if [ -d front ]; then cd front && npm run storybook; else npm run storybook; fi
 

--- a/front/tests/unitaire/accueil-structure.spec.tsx
+++ b/front/tests/unitaire/accueil-structure.spec.tsx
@@ -1,0 +1,265 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #29) :
+ * la page d'accueil RENDUE tient les garanties que la donnée seule ne prouve pas.
+ *
+ * 1. Un seul `h1`, et c'est l'accroche : le plan du document a une racine unique.
+ * 2. Aucun saut de niveau de titre (h1 → h3 sans h2). Un lecteur d'écran restitue le
+ *    plan par ces niveaux ; un saut lui fait annoncer une sous-section qui n'existe pas.
+ * 3. La mention du caractère illustratif du fil rouge est réellement RENDUE, pas
+ *    seulement présente dans les données — un avertissement obligatoire dans le schéma
+ *    mais jamais affiché ne protégerait personne, et c'est exactement le défaut qu'une
+ *    relecture des seules données laisse passer.
+ * 4. Les trois pôles restent ATTEIGNABLES depuis l'accueil, par des routes dérivées de
+ *    la clé de l'offre (`cheminOffre`), jamais écrites en dur dans le contenu.
+ * 5. Aucun libellé de lien identique ne mène à deux destinations différentes (WCAG
+ *    2.4.4) : restitués hors contexte par un lecteur d'écran, deux liens homonymes
+ *    seraient indiscernables. L'inverse — deux libellés distincts vers une même
+ *    destination — reste licite et n'est pas interdit ici.
+ *
+ * Cas limites couverts : titres rendus par des composants différents (`Accroche` et
+ * `AppelContact` composent leur région à la main, les autres passent par `Section`) ;
+ * régions toutes nommées ; rattachement d'un maillon affiché par TITRE d'offre et jamais
+ * par clé ; aucun lien sans nom accessible.
+ *
+ * Niveau : unitaire (React Testing Library, jsdom) — la vue et les services réels
+ * collaborent, aucune doublure de module.
+ * Jeu de données : le contenu réel du dépôt, celui que sert la page « / ».
+ */
+import { render, screen } from '@testing-library/react'
+import { cheminOffre } from '@/@shared/config/routes'
+import { accueil, offres } from '@/content'
+import { AccueilView } from '@/views/accueil/AccueilView'
+
+/** Texte accessible d'un élément, espaces normalisés comme le fait un lecteur d'écran. */
+const nom = (element: Element): string => (element.textContent ?? '').replace(/\s+/g, ' ').trim()
+
+const rendu = () => render(<AccueilView />).container
+
+describe('plan du document', () => {
+  it('ne porte qu’un seul h1, et c’est l’accroche', () => {
+    const container = rendu()
+    const h1 = container.querySelectorAll('h1')
+
+    expect(h1).toHaveLength(1)
+    expect(nom(h1[0] as Element)).toBe(accueil.accroche.titre)
+  })
+
+  it('n’enchaîne aucun saut de niveau de titre', () => {
+    const container = rendu()
+    const niveaux = [...container.querySelectorAll('h1, h2, h3, h4, h5, h6')].map((titre) =>
+      Number(titre.tagName.slice(1)),
+    )
+
+    expect(niveaux[0]).toBe(1)
+    for (const [index, niveau] of niveaux.entries()) {
+      if (index > 0) {
+        expect(niveau).toBeLessThanOrEqual((niveaux[index - 1] as number) + 1)
+      }
+    }
+  })
+
+  it('descend jusqu’au niveau 3 — les sections ont bien des sous-titres', () => {
+    const container = rendu()
+
+    expect(container.querySelectorAll('h3').length).toBeGreaterThan(0)
+  })
+
+  it('nomme chacune des sept régions de la page', () => {
+    rendu()
+    const regions = screen.getAllByRole('region')
+
+    expect(regions).toHaveLength(7)
+    for (const region of regions) {
+      expect(region.getAttribute('aria-labelledby')).toBeTruthy()
+    }
+  })
+
+  it('reprend le titre de chaque section dans le nom de sa région', () => {
+    rendu()
+
+    for (const titre of [
+      accueil.accroche.titre,
+      accueil.chaine.titre,
+      accueil.pointsEntree.titre,
+      accueil.pourquoi.titre,
+      accueil.offres.titre,
+      accueil.preuves.titre,
+      accueil.contact.titre,
+    ]) {
+      expect(screen.getByRole('region', { name: titre })).not.toBeNull()
+    }
+  })
+})
+
+describe('la mention illustrative est rendue, pas seulement déclarée', () => {
+  it('affiche le texte exact de l’avertissement', () => {
+    rendu()
+
+    expect(screen.getByText(accueil.chaine.avertissement)).not.toBeNull()
+  })
+
+  it('affiche l’étiquette « scénario illustratif »', () => {
+    rendu()
+
+    expect(screen.getByText(accueil.chaine.libelleAvertissement)).not.toBeNull()
+  })
+
+  it('place l’avertissement AVANT le premier maillon du scénario', () => {
+    const container = rendu()
+    const avertissement = screen.getByText(accueil.chaine.avertissement)
+    const premierMaillon = screen.getByRole('heading', {
+      name: accueil.chaine.maillons[0]?.titre,
+    })
+    const position = avertissement.compareDocumentPosition(premierMaillon)
+
+    expect(container.contains(avertissement)).toBe(true)
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('rend le scénario dans une liste ordonnée — l’ordre est l’information', () => {
+    rendu()
+    const etapes = screen.getAllByRole('listitem')
+    const rangs = accueil.chaine.maillons.map(
+      (_maillon, index) => `${accueil.chaine.libelleEtape} ${index + 1}`,
+    )
+
+    expect(etapes.length).toBeGreaterThanOrEqual(accueil.chaine.maillons.length)
+    for (const rang of rangs) {
+      expect(screen.getByText(rang)).not.toBeNull()
+    }
+  })
+
+  it('affiche le rattachement d’un maillon par le TITRE de l’offre, jamais par sa clé', () => {
+    const container = rendu()
+    const texte = nom(container)
+
+    for (const offre of offres) {
+      expect(texte).not.toContain(offre.cle)
+    }
+    expect(screen.getAllByText(offres[1]?.titre as string).length).toBeGreaterThan(0)
+  })
+})
+
+describe('les trois pôles restent atteignables', () => {
+  it('publie au moins un lien vers chacune des trois offres', () => {
+    const container = rendu()
+    const destinations = [...container.querySelectorAll('a')].map((lien) =>
+      lien.getAttribute('href'),
+    )
+
+    for (const offre of offres) {
+      expect(destinations).toContain(cheminOffre(offre.cle))
+    }
+  })
+
+  it('dérive la destination de la clé de l’offre, jamais d’un chemin écrit à la main', () => {
+    const container = rendu()
+    const versServices = [...container.querySelectorAll('a')]
+      .map((lien) => lien.getAttribute('href') ?? '')
+      .filter((href) => href.startsWith('/services/'))
+    const attendues = offres.map((offre) => cheminOffre(offre.cle))
+
+    expect(versServices.length).toBeGreaterThanOrEqual(offres.length)
+    for (const href of versServices) {
+      expect(attendues).toContain(href)
+    }
+  })
+
+  it('atteint les trois offres depuis la seule section des points d’entrée', () => {
+    const cibles = new Set(
+      accueil.pointsEntree.points.flatMap((point) =>
+        point.liens.map((lien) => cheminOffre(lien.offre)),
+      ),
+    )
+
+    expect([...cibles].sort()).toEqual(offres.map((offre) => cheminOffre(offre.cle)).sort())
+  })
+
+  it('mène aussi au contact, action attendue de la page', () => {
+    const container = rendu()
+    const destinations = [...container.querySelectorAll('a')].map((lien) =>
+      lien.getAttribute('href'),
+    )
+
+    expect(destinations).toContain(accueil.contact.action.href)
+  })
+})
+
+describe('libellés de liens — WCAG 2.4.4', () => {
+  it('donne un nom accessible à chaque lien', () => {
+    const container = rendu()
+
+    for (const lien of container.querySelectorAll('a')) {
+      expect(nom(lien)).not.toBe('')
+    }
+  })
+
+  it('ne fait jamais mener un même libellé à deux destinations différentes', () => {
+    const container = rendu()
+    const destinationsParLibelle = new Map<string, Set<string>>()
+
+    for (const lien of container.querySelectorAll('a')) {
+      const libelle = nom(lien).toLowerCase()
+      const destinations = destinationsParLibelle.get(libelle) ?? new Set<string>()
+      destinations.add(lien.getAttribute('href') ?? '')
+      destinationsParLibelle.set(libelle, destinations)
+    }
+
+    const homonymes = [...destinationsParLibelle.entries()]
+      .filter(([, destinations]) => destinations.size > 1)
+      .map(([libelle, destinations]) => `« ${libelle} » → ${[...destinations].join(' et ')}`)
+
+    expect(homonymes).toEqual([])
+    expect(destinationsParLibelle.size).toBeGreaterThan(1)
+  })
+
+  it('distingue les trois liens d’offre par le titre de l’offre, pas par leur position', () => {
+    rendu()
+
+    for (const offre of offres) {
+      const lien = screen.getByRole('link', {
+        name: `${accueil.offres.libelleLien} ${offre.titre}`,
+      })
+
+      expect(lien.getAttribute('href')).toBe(cheminOffre(offre.cle))
+    }
+  })
+
+  it('garde des libellés complets et non composés dans les points d’entrée', () => {
+    rendu()
+
+    for (const point of accueil.pointsEntree.points) {
+      for (const lien of point.liens) {
+        expect(screen.getByRole('link', { name: lien.libelle }).getAttribute('href')).toBe(
+          cheminOffre(lien.offre),
+        )
+      }
+    }
+  })
+})
+
+describe('les énoncés affichés viennent des offres, jamais de l’accueil', () => {
+  it('affiche chaque preuve avec le texte écrit dans son offre d’origine', () => {
+    rendu()
+
+    for (const reference of accueil.preuves.references) {
+      const offre = offres.find((candidate) => candidate.cle === reference.offre)
+      const axe = offre?.axes.find((candidate) => candidate.cle === reference.axe)
+
+      expect(axe?.preuve).toBeTruthy()
+      expect(screen.getByText(axe?.preuve as string)).not.toBeNull()
+    }
+  })
+
+  it('n’écrit aucun énoncé de preuve dans le contenu de l’accueil', () => {
+    const enonces = offres
+      .flatMap((offre) => offre.axes)
+      .map((axe) => axe.preuve)
+      .filter((preuve): preuve is string => preuve !== null)
+    const contenuAccueil = JSON.stringify(accueil)
+
+    for (const enonce of enonces) {
+      expect(contenuAccueil).not.toContain(enonce)
+    }
+  })
+})

--- a/front/tests/unitaire/accueil-veracite.spec.ts
+++ b/front/tests/unitaire/accueil-veracite.spec.ts
@@ -1,0 +1,268 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #29) :
+ * le fil rouge e-commerce de la page d'accueil est un SCÉNARIO ILLUSTRATIF, et rien
+ * n'autorise à le lire comme une étude de cas. Jérôme n'a aucune référence client
+ * publiable et n'a jamais mené cette chaîne entière chez un même e-commerçant — le
+ * taggage relève de la période Acetelecom / MailingVox, l'e-commerce de la période
+ * Verhoeven Joaillier. L'avertissement qui le dit est donc OBLIGATOIRE ET NON VIDE dans
+ * le schéma : l'exigence est dans le type, pas dans la vigilance du prochain rédacteur.
+ *
+ * Le schéma est vérifié pour ce qu'il REFUSE, jamais seulement pour ce qu'il accepte :
+ * un schéma qui accepte tout ne protège rien. Le contenu étant validé au chargement du
+ * module, un refus casse le BUILD et n'atteint jamais la production.
+ *
+ * Cas limites couverts : avertissement absent (clé retirée) ; avertissement vide ;
+ * étiquette d'avertissement vide ; clé inconnue glissée dans la section (`strictObject`) ;
+ * chaîne réduite à un seul maillon ; maillon rattaché à aucune offre ; clé d'offre hors
+ * des trois publiées ; point d'entrée sans lien ni étape ; section de preuves sans
+ * référence ; libellé d'action vide, qui rendrait un lien sans nom accessible.
+ *
+ * LIMITE DITE FRANCHEMENT : `z.string().min(1)` refuse la chaîne vide, pas une chaîne
+ * d'espaces. Le caractère substantiel de l'avertissement n'est donc pas garanti par le
+ * schéma — il est vérifié ici sur le contenu réel, et sa présence à l'écran l'est par
+ * `accueil-structure.spec.tsx`.
+ *
+ * Niveau : unitaire (schéma et données pures).
+ * Jeu de données : le contenu réel de l'accueil, et des variantes invalides dérivées de
+ * lui pour chaque refus.
+ */
+import { accueil } from '@/content'
+import { accueilSchema } from '@/schemas/accueil.schema'
+
+/** Copie profonde du contenu réel : chaque variante part de la donnée publiée. */
+const copie = (): Record<string, unknown> =>
+  JSON.parse(JSON.stringify(accueil)) as Record<string, unknown>
+
+/** Contenu réel dont la seule section « chaîne » est altérée. */
+const avecChaine = (modification: Record<string, unknown>): Record<string, unknown> => {
+  const donnees = copie()
+  donnees.chaine = { ...(donnees.chaine as Record<string, unknown>), ...modification }
+
+  return donnees
+}
+
+/** Contenu réel dont la section « chaîne » perd une clé. */
+const sansCleDeChaine = (cle: string): Record<string, unknown> => {
+  const donnees = copie()
+  const chaine = { ...(donnees.chaine as Record<string, unknown>) }
+  delete chaine[cle]
+  donnees.chaine = chaine
+
+  return donnees
+}
+
+const maillonsPublies = accueil.chaine.maillons
+const PUBLIE = JSON.stringify(accueil)
+const FIL_ROUGE = JSON.stringify(accueil.chaine)
+
+describe('conformité du contenu réel', () => {
+  it('valide la page d’accueil publiée', () => {
+    expect(() => accueilSchema.parse(accueil)).not.toThrow()
+  })
+
+  it('conserve les huit sections attendues, dans l’ordre de lecture de la page', () => {
+    expect(Object.keys(accueil)).toEqual([
+      'meta',
+      'accroche',
+      'chaine',
+      'pointsEntree',
+      'pourquoi',
+      'offres',
+      'preuves',
+      'contact',
+    ])
+  })
+})
+
+describe('l’avertissement « scénario illustratif » est obligatoire', () => {
+  it('refuse une chaîne dont l’avertissement a été retiré', () => {
+    expect(() => accueilSchema.parse(sansCleDeChaine('avertissement'))).toThrow()
+  })
+
+  it('refuse un avertissement vide', () => {
+    expect(() => accueilSchema.parse(avecChaine({ avertissement: '' }))).toThrow()
+  })
+
+  it('refuse une étiquette d’avertissement vide', () => {
+    expect(() => accueilSchema.parse(avecChaine({ libelleAvertissement: '' }))).toThrow()
+  })
+
+  it('refuse une chaîne dont l’étiquette d’avertissement a été retirée', () => {
+    expect(() => accueilSchema.parse(sansCleDeChaine('libelleAvertissement'))).toThrow()
+  })
+
+  it('accepte le contenu réel, avertissement compris', () => {
+    expect(() => accueilSchema.parse(avecChaine({}))).not.toThrow()
+  })
+})
+
+describe('l’avertissement publié dit ce qui n’a pas eu lieu', () => {
+  it('porte un texte substantiel, pas une chaîne d’espaces', () => {
+    expect(accueil.chaine.avertissement.trim().length).toBeGreaterThan(80)
+  })
+
+  it('annonce le scénario comme illustratif dans son étiquette', () => {
+    expect(accueil.chaine.libelleAvertissement).toMatch(/illustratif/i)
+  })
+
+  it('nie explicitement le client et la mission, plutôt que de rester vague', () => {
+    expect(accueil.chaine.avertissement).toMatch(/aucun client/i)
+    expect(accueil.chaine.avertissement).toMatch(/aucune mission/i)
+  })
+
+  it('dit que la chaîne entière n’a pas été menée chez un même e-commerçant', () => {
+    expect(accueil.chaine.avertissement).toMatch(/pas mené cette chaîne entière/i)
+  })
+
+  it('renvoie les compétences aux offres, où elles sont attestées', () => {
+    expect(accueil.chaine.avertissement).toMatch(/attestées offre par offre/i)
+  })
+})
+
+describe('le fil rouge ne se laisse pas lire comme une référence client', () => {
+  it.each(['Truffle', 'Verhoeven', 'Acetelecom', 'MailingVox', 'Prézage', 'Sms En Masse'])(
+    'ne nomme jamais « %s » dans la chaîne',
+    (entreprise) => {
+      expect(FIL_ROUGE).not.toContain(entreprise)
+    },
+  )
+
+  it('ne rattache aucun résultat chiffré au scénario', () => {
+    for (const maillon of maillonsPublies) {
+      expect(maillon.illustration).not.toMatch(/\d+\s?%/)
+      expect(maillon.illustration).not.toMatch(/\d\s?(€|EUR\b)/)
+    }
+  })
+
+  it('ne raconte pas le scénario au passé composé, qui le donnerait pour advenu', () => {
+    for (const maillon of maillonsPublies) {
+      expect(maillon.illustration).not.toMatch(/\b(j’ai|j'ai|nous avons)\b/i)
+    }
+  })
+
+  it('ne dit jamais « chez un client »', () => {
+    expect(FIL_ROUGE.toLowerCase()).not.toContain('chez un client')
+  })
+})
+
+describe('véracité générale de l’accueil publié', () => {
+  it('parle à la première personne du singulier, jamais au « nous »', () => {
+    expect(PUBLIE).not.toMatch(/\bnous\b/i)
+  })
+
+  it('ne publie aucun montant : la tarification vit dans l’offre SEA', () => {
+    expect(PUBLIE).not.toContain('€')
+    expect(PUBLIE).not.toContain('TTC')
+    expect(PUBLIE).not.toMatch(/\bHT\b/)
+  })
+
+  it('n’annonce aucun délai de réponse, aucun engagement de ce type n’étant établi', () => {
+    expect(PUBLIE).not.toMatch(/sous\s+\d+\s?(h\b|heures|jours)/i)
+  })
+
+  it('énonce le constat sur un dispositif, jamais sur des personnes', () => {
+    expect(accueil.pourquoi.conclusion).toMatch(/périmètre/i)
+    expect(accueil.pourquoi.conclusion).toMatch(/pas de compétence/i)
+  })
+})
+
+describe('le schéma refuse ce que le typage refuse', () => {
+  it('refuse une clé inconnue glissée dans la section « chaîne »', () => {
+    expect(() => accueilSchema.parse(avecChaine({ etudeDeCas: 'Boutique X' }))).toThrow()
+  })
+
+  it('refuse une chaîne réduite à un seul maillon', () => {
+    expect(() => accueilSchema.parse(avecChaine({ maillons: [maillonsPublies[0]] }))).toThrow()
+  })
+
+  it('refuse un maillon rattaché à aucune offre', () => {
+    const orphelin = { ...maillonsPublies[0], offres: [] }
+
+    expect(() =>
+      accueilSchema.parse(avecChaine({ maillons: [orphelin, maillonsPublies[1]] })),
+    ).toThrow()
+  })
+
+  it('refuse une clé d’offre hors des trois publiées', () => {
+    const fantome = { ...maillonsPublies[0], offres: ['seo'] }
+
+    expect(() =>
+      accueilSchema.parse(avecChaine({ maillons: [fantome, maillonsPublies[1]] })),
+    ).toThrow()
+  })
+
+  it.each(['titre', 'role', 'illustration', 'sortie', 'libelleSortie'])(
+    'refuse un maillon dont « %s » est vide',
+    (champ) => {
+      const vide = { ...maillonsPublies[0], [champ]: '' }
+
+      expect(() =>
+        accueilSchema.parse(avecChaine({ maillons: [vide, maillonsPublies[1]] })),
+      ).toThrow()
+    },
+  )
+
+  it('refuse une page d’accueil offrant un seul point d’entrée', () => {
+    const donnees = copie()
+    const section = donnees.pointsEntree as Record<string, unknown>
+    donnees.pointsEntree = { ...section, points: [accueil.pointsEntree.points[0]] }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+
+  it('refuse un point d’entrée qui ne mène nulle part', () => {
+    const donnees = copie()
+    const section = donnees.pointsEntree as Record<string, unknown>
+    const [premier, second] = accueil.pointsEntree.points
+    donnees.pointsEntree = { ...section, points: [{ ...premier, liens: [] }, second] }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+
+  it('refuse un point d’entrée sans chemin d’étapes', () => {
+    const donnees = copie()
+    const section = donnees.pointsEntree as Record<string, unknown>
+    const [premier, second] = accueil.pointsEntree.points
+    donnees.pointsEntree = { ...section, points: [{ ...premier, etapes: [] }, second] }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+
+  it('refuse une section de preuves sans aucune référence', () => {
+    const donnees = copie()
+    donnees.preuves = { ...(donnees.preuves as Record<string, unknown>), references: [] }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+
+  it('refuse un « pourquoi » sans preuve à l’appui', () => {
+    const donnees = copie()
+    donnees.pourquoi = { ...(donnees.pourquoi as Record<string, unknown>), references: [] }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+
+  it('refuse un constat réduit à une seule colonne, qui n’opposerait rien', () => {
+    const donnees = copie()
+    const section = donnees.pourquoi as Record<string, unknown>
+    donnees.pourquoi = { ...section, colonnes: [accueil.pourquoi.colonnes[0]] }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+
+  it('refuse une action dont le libellé est vide, qui rendrait un lien sans nom', () => {
+    const donnees = copie()
+    const section = donnees.contact as Record<string, unknown>
+    donnees.contact = { ...section, action: { href: '/contact', libelle: '' } }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+
+  it('refuse une référence de preuve dont l’axe est vide', () => {
+    const donnees = copie()
+    const section = donnees.preuves as Record<string, unknown>
+    donnees.preuves = { ...section, references: [{ offre: 'sea', axe: '' }] }
+
+    expect(() => accueilSchema.parse(donnees)).toThrow()
+  })
+})

--- a/front/tests/unitaire/chaine-service.spec.ts
+++ b/front/tests/unitaire/chaine-service.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #29) :
+ * `resoudreMaillons` rattache chaque maillon de la chaîne aux offres qui le couvrent en
+ * LISANT leur titre dans le catalogue, jamais en le recopiant dans le contenu de
+ * l'accueil. C'est la même règle que pour la navigation dérivée : une recopie avait déjà
+ * fait diverger « Data et IA » de « Data & IA » (issue #11). Le contenu de l'accueil ne
+ * porte donc que des CLÉS, et le titre affiché suit le catalogue partout où il change.
+ *
+ * L'ORDRE de déclaration est conservé — l'ordre des maillons EST la chaîne : le site,
+ * la donnée structurée et l'entrepôt, le taggage, le SEA. Le réordonner changerait le
+ * discours de la page, pas seulement sa mise en page.
+ *
+ * Une clé d'offre inconnue ÉCHOUE bruyamment. Le contenu étant résolu au rendu serveur,
+ * donc au build, l'erreur survient à la compilation plutôt que devant un visiteur sous
+ * la forme d'un maillon rattaché à une offre qui n'existe pas.
+ *
+ * Cas limites couverts : catalogue dont les titres diffèrent de ceux du dépôt (preuve
+ * que le titre est LU et non écrit en dur) ; clé inconnue ; catalogue vide ; liste de
+ * maillons vide ; maillon rattaché à DEUX offres — l'entrepôt, pivot qui alimente
+ * l'acquisition et les projets data ; non-mutation du contenu source.
+ *
+ * Niveau : unitaire (service pur).
+ * Jeu de données : le contenu réel du dépôt (`accueil.chaine.maillons`, `offres`), et
+ * des catalogues dérivés de lui pour les cas de refus.
+ */
+import { accueil, offres } from '@/content'
+import type { IMaillonChaine } from '@/interfaces/maillon-chaine'
+import type { IOffre } from '@/interfaces/offre'
+import type { CleOffre } from '@/interfaces/types'
+import { resoudreMaillons } from '@/services/chaine.service'
+
+const maillons = accueil.chaine.maillons
+const resolus = resoudreMaillons(maillons, offres)
+
+/** Titre réel d'une offre du dépôt, cherché relationnellement et jamais écrit ici. */
+const titreDe = (cle: CleOffre): string => {
+  const offre = offres.find((candidate) => candidate.cle === cle)
+  if (offre === undefined) {
+    throw new Error(`Le dépôt ne publie aucune offre « ${cle} ».`)
+  }
+
+  return offre.titre
+}
+
+/** Le catalogue réel, dont seuls les TITRES sont remplacés par des marqueurs. */
+const CATALOGUE_RENOMME: readonly IOffre[] = offres.map((offre) => ({
+  ...offre,
+  titre: `Titre venu du catalogue — ${offre.cle}`,
+}))
+
+const MAILLON_MINIMAL: IMaillonChaine = {
+  cle: 'maillon-de-controle',
+  titre: 'Maillon de contrôle',
+  role: 'Rôle de contrôle.',
+  illustration: 'Illustration de contrôle.',
+  libelleSortie: 'Ce qu’il passe à l’étape suivante',
+  sortie: 'Sortie de contrôle.',
+  offres: ['sea'],
+}
+
+describe('resoudreMaillons — le titre est lu, jamais recopié', () => {
+  it('remplace chaque clé par le titre réel de l’offre correspondante', () => {
+    for (const [index, maillon] of maillons.entries()) {
+      expect(resolus[index]?.offres).toEqual(maillon.offres.map(titreDe))
+    }
+  })
+
+  it('suit le catalogue reçu quand les titres y changent', () => {
+    const renommes = resoudreMaillons(maillons, CATALOGUE_RENOMME)
+
+    for (const [index, maillon] of maillons.entries()) {
+      expect(renommes[index]?.offres).toEqual(
+        maillon.offres.map((cle) => `Titre venu du catalogue — ${cle}`),
+      )
+    }
+  })
+
+  it('ne laisse aucune clé d’offre dans le résultat', () => {
+    const clesPubliees = offres.map((offre) => offre.cle)
+
+    for (const resolu of resolus) {
+      for (const titre of resolu.offres) {
+        expect(clesPubliees).not.toContain(titre)
+      }
+    }
+  })
+
+  it('n’écrit aucun titre d’offre dans les données de rattachement de l’accueil', () => {
+    const titresPublies = offres.map((offre) => offre.titre)
+
+    for (const maillon of maillons) {
+      for (const cle of maillon.offres) {
+        expect(titresPublies).not.toContain(cle)
+      }
+    }
+  })
+})
+
+describe('resoudreMaillons — l’ordre est la chaîne', () => {
+  it('conserve l’ordre de déclaration des maillons', () => {
+    expect(resolus.map((resolu) => resolu.cle)).toEqual(maillons.map((maillon) => maillon.cle))
+  })
+
+  it('déroule la chaîne du site jusqu’au SEA, en passant par l’entrepôt puis le taggage', () => {
+    expect(maillons.map((maillon) => maillon.cle)).toEqual(['site', 'entrepot', 'taggage', 'sea'])
+  })
+
+  it('conserve l’ordre des offres à l’intérieur d’un maillon', () => {
+    const inverse = resoudreMaillons(
+      [{ ...MAILLON_MINIMAL, offres: ['data-ia', 'ingenierie-web', 'sea'] }],
+      offres,
+    )
+
+    expect(inverse[0]?.offres).toEqual([
+      titreDe('data-ia'),
+      titreDe('ingenierie-web'),
+      titreDe('sea'),
+    ])
+  })
+
+  it('rend une liste vide pour une chaîne vide, sans lever', () => {
+    expect(resoudreMaillons([], offres)).toEqual([])
+  })
+})
+
+describe('resoudreMaillons — tout le reste du maillon est repris tel quel', () => {
+  it('ne modifie ni le rôle, ni l’illustration, ni la sortie, ni son libellé', () => {
+    for (const [index, maillon] of maillons.entries()) {
+      const resolu = resolus[index]
+
+      expect(resolu?.cle).toBe(maillon.cle)
+      expect(resolu?.titre).toBe(maillon.titre)
+      expect(resolu?.role).toBe(maillon.role)
+      expect(resolu?.illustration).toBe(maillon.illustration)
+      expect(resolu?.libelleSortie).toBe(maillon.libelleSortie)
+      expect(resolu?.sortie).toBe(maillon.sortie)
+    }
+  })
+
+  it('laisse le contenu source intact — il porte toujours des clés après résolution', () => {
+    resoudreMaillons(maillons, offres)
+
+    for (const maillon of accueil.chaine.maillons) {
+      for (const cle of maillon.offres) {
+        expect(offres.some((offre) => offre.cle === cle)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('resoudreMaillons — une clé inconnue échoue au lieu de publier un rattachement faux', () => {
+  it('lève sur une clé d’offre que le catalogue ne publie pas', () => {
+    const inconnue = [
+      { ...MAILLON_MINIMAL, offres: ['offre-fantome' as CleOffre] },
+    ] as readonly IMaillonChaine[]
+
+    expect(() => resoudreMaillons(inconnue, offres)).toThrow(/offre-fantome/)
+  })
+
+  it('nomme le maillon fautif dans le message, pour que l’édition sache où corriger', () => {
+    const inconnue = [
+      { ...MAILLON_MINIMAL, offres: ['offre-fantome' as CleOffre] },
+    ] as readonly IMaillonChaine[]
+
+    expect(() => resoudreMaillons(inconnue, offres)).toThrow(/maillon-de-controle/)
+  })
+
+  it('lève dès qu’une seule clé d’un maillon est inconnue, même si les autres résolvent', () => {
+    const partiel = [
+      { ...MAILLON_MINIMAL, offres: ['sea', 'offre-fantome' as CleOffre] },
+    ] as readonly IMaillonChaine[]
+
+    expect(() => resoudreMaillons(partiel, offres)).toThrow()
+  })
+
+  it('lève sur un catalogue vide, plutôt que de rendre un rattachement sans titre', () => {
+    expect(() => resoudreMaillons(maillons, [])).toThrow()
+  })
+
+  it('résout sans lever sur le contenu réel du dépôt', () => {
+    expect(() => resoudreMaillons(accueil.chaine.maillons, offres)).not.toThrow()
+  })
+})
+
+describe('l’entrepôt est le pivot de la chaîne', () => {
+  const entrepot = resolus.find((resolu) => resolu.cle === 'entrepot')
+
+  it('existe dans la chaîne publiée', () => {
+    expect(entrepot).toBeDefined()
+  })
+
+  it('est rattaché à exactement deux offres', () => {
+    expect(entrepot?.offres).toHaveLength(2)
+  })
+
+  it('alimente l’acquisition ET les projets data et IA, dans cet ordre', () => {
+    expect(entrepot?.offres).toEqual([titreDe('sea'), titreDe('data-ia')])
+  })
+
+  it('est le seul maillon rattaché à plus d’une offre', () => {
+    const multiples = resolus.filter((resolu) => resolu.offres.length > 1)
+
+    expect(multiples.map((resolu) => resolu.cle)).toEqual(['entrepot'])
+  })
+
+  it('laisse chaque autre maillon couvert par au moins une offre', () => {
+    for (const resolu of resolus) {
+      expect(resolu.offres.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('fait couvrir les trois offres du site par la chaîne entière', () => {
+    const couvertes = new Set(maillons.flatMap((maillon) => maillon.offres))
+
+    expect([...couvertes].sort()).toEqual(offres.map((offre) => offre.cle).sort())
+  })
+})

--- a/front/tests/unitaire/grille-tarifaire-sea.spec.ts
+++ b/front/tests/unitaire/grille-tarifaire-sea.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #29) :
+ * les TROIS lignes publiées de la grille SEA sont exactement celles validées par Jérôme
+ * MARICHEZ le 2026-08-08. C'est le premier engagement commercial chiffré du site : les
+ * valeurs ne se déduisent pas, ne s'arrondissent pas et ne s'« harmonisent » pas. Un
+ * arrondi silencieux — 300 devenu 350, 1 200 devenu 1 000 — engagerait Jérôme vis-à-vis
+ * d'un prospect sans que personne ne s'en aperçoive : ce test le fait échouer en CI.
+ *
+ * La grille est aussi vérifiée dans sa FORME éditoriale : deux lignes portent le même
+ * intitulé et deux conditions différentes — la même prestation n'a pas le même prix
+ * selon que Jérôme a conçu le site ou non, et le prospect identifie son cas AVANT de
+ * lire un montant. La preuve qui appuie l'argument est une RÉFÉRENCE, jamais un texte
+ * recopié : les chiffres du parcours restent écrits à un seul endroit.
+ *
+ * Cas limites couverts : la ligne « incluse » ne porte AUCUNE autre propriété que sa
+ * nature — pas de mention fiscale, pas de borne, pas de périodicité ; l'offre Data & IA
+ * n'a aucune grille, et cette absence est une information, pas un oubli ; l'argument ne
+ * nomme aucune agence et ne généralise pas sur la profession.
+ *
+ * Niveau : unitaire (données pures).
+ * Jeu de données : la grille tarifaire réelle du dépôt et le catalogue des offres.
+ */
+import { grillesTarifaires, grilleTarifaireSea, offres } from '@/content'
+import { grilleTarifaireSchema } from '@/schemas/grille-tarifaire.schema'
+import { formaterMontant } from '@/utils/tarif'
+
+const lignes = grilleTarifaireSea.lignes
+const ligneDe = (cle: string) => lignes.find((ligne) => ligne.cle === cle)
+
+describe('la grille publiée est celle de l’offre SEA', () => {
+  it('est conforme à son schéma', () => {
+    expect(() => grilleTarifaireSchema.parse(grilleTarifaireSea)).not.toThrow()
+  })
+
+  it('est rattachée à l’offre SEA du catalogue', () => {
+    expect(grilleTarifaireSea.offre).toBe('sea')
+    expect(offres.some((offre) => offre.cle === grilleTarifaireSea.offre)).toBe(true)
+  })
+
+  it('est la seule grille publiée du site', () => {
+    expect(grillesTarifaires).toHaveLength(1)
+    expect(grillesTarifaires[0]).toBe(grilleTarifaireSea)
+  })
+
+  it('laisse Data & IA sans grille — un projet data se chiffre au périmètre', () => {
+    expect(grillesTarifaires.some((grille) => grille.offre === 'data-ia')).toBe(false)
+    expect(grillesTarifaires.some((grille) => grille.offre === 'ingenierie-web')).toBe(false)
+  })
+})
+
+describe('les trois lignes validées, dans leur ordre de lecture', () => {
+  it('publie exactement trois lignes', () => {
+    expect(lignes).toHaveLength(3)
+  })
+
+  it('les ordonne du cas inclus au forfait de gestion', () => {
+    expect(lignes.map((ligne) => ligne.cle)).toEqual([
+      'mise-en-place-site-concu',
+      'mise-en-place-site-existant',
+      'gestion-du-compte',
+    ])
+  })
+
+  it('donne des clés uniques', () => {
+    expect(new Set(lignes.map((ligne) => ligne.cle)).size).toBe(lignes.length)
+  })
+
+  it('porte le même intitulé sur les deux mises en place, et deux conditions distinctes', () => {
+    const concu = ligneDe('mise-en-place-site-concu')
+    const existant = ligneDe('mise-en-place-site-existant')
+
+    expect(concu?.intitule).toBe('Mise en place de la solution data-driven')
+    expect(existant?.intitule).toBe(concu?.intitule)
+    expect(existant?.condition).not.toBe(concu?.condition)
+  })
+
+  it('énonce chaque condition à la première personne du singulier', () => {
+    expect(ligneDe('mise-en-place-site-concu')?.condition).toBe('si j’ai conçu le site')
+    expect(ligneDe('mise-en-place-site-existant')?.condition).toBe(
+      'sur un site existant, que je n’ai pas conçu',
+    )
+    expect(ligneDe('gestion-du-compte')?.condition).toBe('ensuite, une fois la solution en place')
+  })
+})
+
+describe('les montants validés, au chiffre près', () => {
+  it('inclut la mise en place quand j’ai conçu le site, sans aucun chiffre', () => {
+    const montant = ligneDe('mise-en-place-site-concu')?.montant
+
+    expect(montant).toEqual({ nature: 'inclus' })
+    expect(Object.keys(montant ?? {})).toEqual(['nature'])
+  })
+
+  it('publie la fourchette du site existant exactement telle qu’elle a été validée', () => {
+    expect(ligneDe('mise-en-place-site-existant')?.montant).toEqual({
+      nature: 'fourchette',
+      minimum: 300,
+      maximum: 1200,
+      mentionFiscale: 'TTC',
+      periodicite: 'une-seule-fois',
+      variableSelon: 'le périmètre',
+    })
+  })
+
+  it('facture la gestion du compte au forfait mensuel, sur devis', () => {
+    expect(ligneDe('gestion-du-compte')?.montant).toEqual({
+      nature: 'sur-devis',
+      periodicite: 'mensuel',
+    })
+  })
+
+  it('rend les trois lignes au mot près', () => {
+    expect(lignes.map((ligne) => formaterMontant(ligne.montant))).toEqual([
+      'Incluse',
+      '300 à 1 200 € TTC, une seule fois, selon le périmètre',
+      'Forfait mensuel, sur devis',
+    ])
+  })
+
+  it('ne publie qu’une seule ligne chiffrée, et elle est TTC', () => {
+    const chiffrees = lignes.filter((ligne) => ligne.montant.nature === 'fourchette')
+
+    expect(chiffrees).toHaveLength(1)
+    for (const ligne of chiffrees) {
+      expect(formaterMontant(ligne.montant)).toContain('TTC')
+    }
+  })
+})
+
+describe('l’argument et sa preuve', () => {
+  it('désigne sa preuve au lieu de la recopier', () => {
+    expect(grilleTarifaireSea.preuve).toEqual({ offre: 'sea', axe: 'sea-pilotage' })
+  })
+
+  it('pointe une preuve qui existe réellement et qui est publiable', () => {
+    const offre = offres.find((candidate) => candidate.cle === grilleTarifaireSea.preuve.offre)
+    const axe = offre?.axes.find((candidate) => candidate.cle === grilleTarifaireSea.preuve.axe)
+
+    expect(axe).toBeDefined()
+    expect(axe?.preuve).not.toBeNull()
+  })
+
+  it('ne recopie dans l’argument aucun énoncé de preuve écrit dans les offres', () => {
+    const enonces = offres
+      .flatMap((offre) => offre.axes)
+      .map((axe) => axe.preuve)
+      .filter((preuve): preuve is string => preuve !== null)
+
+    for (const enonce of enonces) {
+      expect(grilleTarifaireSea.argument).not.toContain(enonce)
+    }
+  })
+
+  it('s’énonce à la première personne, depuis l’expérience vécue', () => {
+    expect(grilleTarifaireSea.argument).toMatch(/j’ai vu/i)
+    expect(grilleTarifaireSea.argument).not.toMatch(/\bnous\b/i)
+  })
+
+  it('porte le constat sur un accès à la donnée, jamais sur la compétence d’autrui', () => {
+    expect(grilleTarifaireSea.argument).toMatch(/pas une affaire de compétence/i)
+    expect(grilleTarifaireSea.argument).toMatch(/affaire d’accès/i)
+  })
+
+  it.each(['Google Ads', 'agence', 'concurrent', 'incompétent'])(
+    'ne nomme ni ne vise « %s » dans l’argument',
+    (terme) => {
+      expect(grilleTarifaireSea.argument.toLowerCase()).not.toContain(terme.toLowerCase())
+    },
+  )
+
+  it('ne publie aucun chiffre dans l’argument — les montants vivent dans les lignes', () => {
+    expect(grilleTarifaireSea.argument).not.toMatch(/\d\s?(€|EUR\b)/)
+  })
+})
+
+describe('aucun montant ne fuit hors de la grille', () => {
+  it('n’écrit aucun prix TTC dans le catalogue des offres', () => {
+    expect(JSON.stringify(offres)).not.toContain('TTC')
+  })
+
+  it('n’écrit les bornes de la fourchette qu’ici, jamais dans une offre', () => {
+    const catalogue = JSON.stringify(offres)
+
+    expect(catalogue).not.toContain('300 à 1 200')
+    expect(catalogue).not.toContain('1 200 €')
+  })
+})

--- a/front/tests/unitaire/preuves-service.spec.ts
+++ b/front/tests/unitaire/preuves-service.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #29) :
+ * UN SEUL test de `preuves.service`, vérifié contre le code réel. Plusieurs lots en
+ * avaient proposé un ; l'accueil a été entièrement réécrit depuis, et un
+ * `chaine.service` coexiste désormais avec ce service — les propositions antérieures
+ * décrivaient un état du dépôt qui n'existe plus. Celui-ci fait foi.
+ *
+ * Ce que le service garantit : une preuve affichée sur la page d'accueil est TOUJOURS
+ * celle écrite dans la page d'offre correspondante. Le texte n'est jamais recopié, donc
+ * jamais susceptible de diverger, et jamais saisi hors de `content/offres/`, où se fait
+ * la relecture de véracité. La page d'accueil ne peut donc pas affirmer quelque chose
+ * que la page d'offre ne dit pas.
+ *
+ * Le service ÉCHOUE bruyamment sur trois erreurs d'édition, et c'est là son intérêt :
+ * offre inconnue, axe inconnu, et — le cas qui compte — axe dont la preuve vaut `null`.
+ * Une affirmation sans preuve ne s'affiche pas : plutôt qu'un blanc dans la page, le
+ * build casse. Les résolutions ayant lieu au rendu serveur, l'erreur survient à la
+ * compilation, jamais devant un visiteur.
+ *
+ * Cas limites couverts : `preuve: null` (légitime dans une offre, fatal en référence) ;
+ * offre inexistante ; axe inexistant dans une offre existante ; liste vide ; ordre de
+ * déclaration ; unicité des clés de rendu ; non-mutation du catalogue.
+ *
+ * Niveau : unitaire (service pur).
+ * Jeu de données : les références réelles de l'accueil et le catalogue réel des offres.
+ */
+import { accueil, offres } from '@/content'
+import type { IReferencePreuve } from '@/interfaces/reference-preuve'
+import type { CleOffre } from '@/interfaces/types'
+import { resoudrePreuves } from '@/services/preuves.service'
+
+const referencesPubliees = accueil.preuves.references
+const resolues = resoudrePreuves(referencesPubliees, offres)
+
+/** L'axe réel désigné par une référence, cherché relationnellement. */
+const axeDe = (reference: IReferencePreuve) =>
+  offres
+    .find((offre) => offre.cle === reference.offre)
+    ?.axes.find((axe) => axe.cle === reference.axe)
+
+/** Une référence vers un axe dont la preuve vaut `null` — cas légitime dans une offre. */
+const referenceSansPreuve = (): IReferencePreuve => {
+  for (const offre of offres) {
+    const axe = offre.axes.find((candidate) => candidate.preuve === null)
+    if (axe !== undefined) {
+      return { offre: offre.cle, axe: axe.cle }
+    }
+  }
+
+  throw new Error('Le catalogue ne contient plus aucun axe sans preuve : le cas limite a disparu.')
+}
+
+describe('resoudrePreuves — le texte vient de l’offre, jamais de l’accueil', () => {
+  it('résout toutes les références publiées par l’accueil', () => {
+    expect(resolues).toHaveLength(referencesPubliees.length)
+  })
+
+  it('reprend l’énoncé exactement tel qu’il est écrit dans l’offre', () => {
+    for (const [index, reference] of referencesPubliees.entries()) {
+      expect(resolues[index]?.enonce).toBe(axeDe(reference)?.preuve)
+    }
+  })
+
+  it('reprend le titre de l’axe, non sa clé', () => {
+    for (const [index, reference] of referencesPubliees.entries()) {
+      expect(resolues[index]?.titre).toBe(axeDe(reference)?.titre)
+      expect(resolues[index]?.titre).not.toBe(reference.axe)
+    }
+  })
+
+  it('étiquette chaque preuve par le TITRE de son offre, jamais par sa clé', () => {
+    const clesPubliees = offres.map((offre) => offre.cle)
+
+    for (const [index, reference] of referencesPubliees.entries()) {
+      const offre = offres.find((candidate) => candidate.cle === reference.offre)
+
+      expect(resolues[index]?.offre).toBe(offre?.titre)
+      expect(clesPubliees).not.toContain(resolues[index]?.offre)
+    }
+  })
+
+  it('suit le catalogue quand un énoncé y change', () => {
+    const catalogueRetouche = offres.map((offre) => ({
+      ...offre,
+      axes: offre.axes.map((axe) => ({
+        ...axe,
+        preuve: axe.preuve === null ? null : `Énoncé venu du catalogue — ${axe.cle}`,
+      })),
+    }))
+    const retouchees = resoudrePreuves(referencesPubliees, catalogueRetouche)
+
+    for (const [index, reference] of referencesPubliees.entries()) {
+      expect(retouchees[index]?.enonce).toBe(`Énoncé venu du catalogue — ${reference.axe}`)
+    }
+  })
+
+  it('n’écrit aucun énoncé de preuve dans les références de l’accueil', () => {
+    expect(JSON.stringify(referencesPubliees)).not.toContain('€')
+    for (const reference of referencesPubliees) {
+      expect(Object.keys(reference).sort()).toEqual(['axe', 'offre'])
+    }
+  })
+})
+
+describe('resoudrePreuves — clés de rendu et ordre', () => {
+  it('dérive la clé de la référence, offre et axe joints', () => {
+    for (const [index, reference] of referencesPubliees.entries()) {
+      expect(resolues[index]?.cle).toBe(`${reference.offre}-${reference.axe}`)
+    }
+  })
+
+  it('produit des clés uniques, utilisables comme clés de liste', () => {
+    expect(new Set(resolues.map((preuve) => preuve.cle)).size).toBe(resolues.length)
+  })
+
+  it('conserve l’ordre de déclaration — c’est un choix éditorial', () => {
+    expect(resolues.map((preuve) => preuve.titre)).toEqual(
+      referencesPubliees.map((reference) => axeDe(reference)?.titre),
+    )
+  })
+
+  it('rend une liste vide sans lever', () => {
+    expect(resoudrePreuves([], offres)).toEqual([])
+  })
+
+  it('laisse le catalogue intact', () => {
+    const avant = JSON.stringify(offres)
+    resoudrePreuves(referencesPubliees, offres)
+
+    expect(JSON.stringify(offres)).toBe(avant)
+  })
+})
+
+describe('resoudrePreuves — une référence cassée échoue au lieu d’afficher un blanc', () => {
+  it('lève sur une offre inconnue', () => {
+    const fantome = [{ offre: 'seo' as CleOffre, axe: 'sea-pilotage' }]
+
+    expect(() => resoudrePreuves(fantome, offres)).toThrow(/offre inconnue/i)
+  })
+
+  it('lève sur un axe inconnu dans une offre existante', () => {
+    const fantome = [{ offre: 'sea' as CleOffre, axe: 'axe-inexistant' }]
+
+    expect(() => resoudrePreuves(fantome, offres)).toThrow(/axe inconnu/i)
+  })
+
+  it('nomme l’offre dans le message d’un axe inconnu, pour situer la correction', () => {
+    const fantome = [{ offre: 'sea' as CleOffre, axe: 'axe-inexistant' }]
+
+    expect(() => resoudrePreuves(fantome, offres)).toThrow(/SEA/)
+  })
+
+  it('lève sur un axe dont la preuve vaut null — une affirmation sans preuve ne s’affiche pas', () => {
+    expect(() => resoudrePreuves([referenceSansPreuve()], offres)).toThrow(
+      /aucune preuve publiable/i,
+    )
+  })
+
+  it('lève dès qu’une seule référence d’une liste est cassée', () => {
+    const melange = [...referencesPubliees, { offre: 'sea' as CleOffre, axe: 'axe-inexistant' }]
+
+    expect(() => resoudrePreuves(melange, offres)).toThrow()
+  })
+
+  it('lève sur un catalogue vide', () => {
+    expect(() => resoudrePreuves(referencesPubliees, [])).toThrow()
+  })
+
+  it('résout sans lever le contenu réel de l’accueil, preuves et « pourquoi »', () => {
+    expect(() => resoudrePreuves(accueil.preuves.references, offres)).not.toThrow()
+    expect(() => resoudrePreuves(accueil.pourquoi.references, offres)).not.toThrow()
+  })
+})
+
+describe('ce que l’accueil choisit de prouver', () => {
+  it('représente les trois offres dès les trois premières preuves', () => {
+    const troisPremieres = referencesPubliees.slice(0, 3).map((reference) => reference.offre)
+
+    expect([...new Set(troisPremieres)].sort()).toEqual(offres.map((offre) => offre.cle).sort())
+  })
+
+  it('ne répète dans les preuves aucun axe déjà porté par la section « pourquoi »', () => {
+    const dejaPortes = new Set(
+      accueil.pourquoi.references.map((reference) => `${reference.offre}-${reference.axe}`),
+    )
+
+    for (const reference of referencesPubliees) {
+      expect(dejaPortes.has(`${reference.offre}-${reference.axe}`)).toBe(false)
+    }
+  })
+
+  it('fait apparaître le développement en IA augmentée, imposé partout où le site parle de code', () => {
+    expect(referencesPubliees.some((reference) => reference.axe === 'ia-augmentee')).toBe(true)
+  })
+
+  it('appuie la section « pourquoi » sur le pilotage des campagnes', () => {
+    const pourquoi = resoudrePreuves(accueil.pourquoi.references, offres)
+
+    expect(pourquoi.map((preuve) => preuve.cle)).toContain('sea-sea-pilotage')
+    for (const preuve of pourquoi) {
+      expect(preuve.enonce.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/front/tests/unitaire/tarif-montant.spec.ts
+++ b/front/tests/unitaire/tarif-montant.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #29) :
+ * un montant publié ne peut PAS se détacher de sa mention fiscale, et une ligne sans
+ * montant ne peut PAS afficher de chiffre. C'est le premier engagement commercial
+ * chiffré du site : un prix ambigu se paie au premier échange avec un prospect.
+ *
+ * La garantie tient en deux moitiés, et les deux sont vérifiées ici :
+ * - `Montant` interdit d'ÉCRIRE un chiffre sans mention fiscale — le schéma Zod le
+ *   rejoue au chargement pour ce que le typage ne peut pas rattraper (donnée construite
+ *   dynamiquement, contournement d'un `as`) ;
+ * - `formaterMontant` interdit de l'AFFICHER sans elle : le chiffre et sa mention
+ *   sortent d'un seul et même gabarit, dans la même chaîne, jamais reléguée en note de
+ *   bas de page par une mise en page ou perdue par un rendu partiel.
+ *
+ * Cas limites couverts, côté schéma : borne haute INFÉRIEURE à la borne basse ; bornes
+ * ÉGALES — une fourchette dont les deux bornes coïncident n'est pas une estimation mais
+ * un prix ferme déguisé ; fourchette sans `mentionFiscale` ; mention fiscale `HT`,
+ * contraire à l'arbitrage du 2026-08-08 ; `mentionFiscale` ou `minimum` glissés sur une
+ * ligne SANS montant (`inclus`, `sur-devis`) ; montant nul, négatif ou à centimes ; clé
+ * en majuscules ; condition d'application vide.
+ *
+ * Cas limites couverts, côté mise en forme : les deux périodicités pour chacune des
+ * natures concernées ; groupement des milliers ; et la propriété qui compte —
+ * tout texte de montant contenant un chiffre contient sa mention TTC, tout texte n'en
+ * contenant pas ne contient aucun chiffre.
+ *
+ * Niveau : unitaire (schéma et fonction pure).
+ * Jeu de données : la grille réelle du dépôt, et des montants dérivés d'elle pour les
+ * refus. Aucun chiffre n'est inventé au-delà de ceux nécessaires au groupement des
+ * milliers, qui ne sont pas des prix publiés.
+ */
+import { grilleTarifaireSea } from '@/content'
+import type { Montant } from '@/interfaces/types'
+import { montantSchema, tarifSchema } from '@/schemas/tarif.schema'
+import { formaterMontant } from '@/utils/tarif'
+
+/** La fourchette réellement publiée, lue dans la grille et jamais réécrite ici. */
+const fourchettePubliee = grilleTarifaireSea.lignes
+  .map((ligne) => ligne.montant)
+  .find((montant): montant is Extract<Montant, { nature: 'fourchette' }> => {
+    return montant.nature === 'fourchette'
+  })
+
+const LIGNE_VALIDE = {
+  cle: 'mise-en-place-site-existant',
+  intitule: 'Mise en place de la solution data-driven',
+  condition: 'sur un site existant, que je n’ai pas conçu',
+  montant: { ...fourchettePubliee },
+}
+
+describe('formaterMontant — les trois cas de la grille validée', () => {
+  it('rend « Incluse » pour une prestation comprise dans une autre', () => {
+    expect(formaterMontant({ nature: 'inclus' })).toBe('Incluse')
+  })
+
+  it('colle le chiffre, sa mention, son rythme et ce qui le fait varier', () => {
+    expect(formaterMontant(fourchettePubliee as Montant)).toBe(
+      '300 à 1 200 € TTC, une seule fois, selon le périmètre',
+    )
+  })
+
+  it('rend « Forfait mensuel, sur devis » pour un montant non chiffré mensuel', () => {
+    expect(formaterMontant({ nature: 'sur-devis', periodicite: 'mensuel' })).toBe(
+      'Forfait mensuel, sur devis',
+    )
+  })
+
+  it('rend « Forfait unique, sur devis » pour un montant non chiffré ponctuel', () => {
+    expect(formaterMontant({ nature: 'sur-devis', periodicite: 'une-seule-fois' })).toBe(
+      'Forfait unique, sur devis',
+    )
+  })
+
+  it('dit « par mois » à la suite d’un prix mensuel, et non « Forfait mensuel »', () => {
+    const mensuel = { ...fourchettePubliee, periodicite: 'mensuel' } as Montant
+
+    expect(formaterMontant(mensuel)).toContain('par mois')
+    expect(formaterMontant(mensuel)).not.toContain('Forfait')
+  })
+})
+
+describe('formaterMontant — groupement des milliers', () => {
+  it.each([
+    [300, '300'],
+    [1200, '1 200'],
+    [12000, '12 000'],
+    [120000, '120 000'],
+    [1200000, '1 200 000'],
+  ])('groupe %s en « %s »', (maximum, attendu) => {
+    const montant = { ...fourchettePubliee, minimum: 1, maximum } as Montant
+
+    expect(formaterMontant(montant)).toContain(`${attendu} € TTC`)
+  })
+
+  it('groupe par espace ordinaire, jamais par une espace insécable invisible', () => {
+    const montant = { ...fourchettePubliee, minimum: 1, maximum: 12000 } as Montant
+
+    expect(formaterMontant(montant)).not.toMatch(/[  ]/)
+  })
+})
+
+describe('la mention fiscale ne se détache jamais du chiffre', () => {
+  it.each(grilleTarifaireSea.lignes.map((ligne) => [ligne.cle, ligne] as const))(
+    'ligne « %s » : tout chiffre affiché porte sa mention TTC',
+    (_cle, ligne) => {
+      const texte = formaterMontant(ligne.montant)
+
+      if (/\d/.test(texte)) {
+        expect(texte).toContain('TTC')
+        expect(texte).toContain('€')
+      }
+    },
+  )
+
+  it.each(grilleTarifaireSea.lignes.map((ligne) => [ligne.cle, ligne] as const))(
+    'ligne « %s » : sans montant chiffré, aucun chiffre n’est affiché',
+    (_cle, ligne) => {
+      const texte = formaterMontant(ligne.montant)
+
+      if (ligne.montant.nature !== 'fourchette') {
+        expect(texte).not.toMatch(/\d/)
+        expect(texte).not.toContain('€')
+        expect(texte).not.toContain('TTC')
+      }
+    },
+  )
+
+  it('affiche la mention DANS la même chaîne que le prix, jamais après une coupure', () => {
+    const texte = formaterMontant(fourchettePubliee as Montant)
+    const positionMention = texte.indexOf('TTC')
+    const positionDernierChiffre = texte.search(/\d(?!.*\d)/s)
+
+    expect(positionMention).toBeGreaterThan(positionDernierChiffre)
+    expect(positionMention - positionDernierChiffre).toBeLessThanOrEqual(4)
+  })
+
+  it('publie au moins une ligne chiffrée — sans quoi la propriété serait vide', () => {
+    const chiffrees = grilleTarifaireSea.lignes.filter(
+      (ligne) => ligne.montant.nature === 'fourchette',
+    )
+
+    expect(chiffrees.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('le schéma refuse au chargement ce que le typage refuse à la compilation', () => {
+  it('accepte la fourchette réellement publiée', () => {
+    expect(() => montantSchema.parse(fourchettePubliee)).not.toThrow()
+  })
+
+  it('refuse une borne haute inférieure à la borne basse', () => {
+    expect(() =>
+      montantSchema.parse({ ...fourchettePubliee, minimum: 1200, maximum: 300 }),
+    ).toThrow(/borne haute/i)
+  })
+
+  it('refuse deux bornes égales — un prix ferme déguisé en estimation', () => {
+    expect(() => montantSchema.parse({ ...fourchettePubliee, minimum: 300, maximum: 300 })).toThrow(
+      /borne haute/i,
+    )
+  })
+
+  it('refuse un montant chiffré sans mention fiscale', () => {
+    const { mentionFiscale: _retiree, ...sansMention } = {
+      ...fourchettePubliee,
+    } as Record<string, unknown>
+
+    expect(() => montantSchema.parse(sansMention)).toThrow()
+  })
+
+  it('refuse une mention fiscale hors taxes, contraire à l’arbitrage rendu', () => {
+    expect(() => montantSchema.parse({ ...fourchettePubliee, mentionFiscale: 'HT' })).toThrow()
+  })
+
+  it('refuse une mention fiscale sur une ligne incluse, qui n’a aucun montant à taxer', () => {
+    expect(() => montantSchema.parse({ nature: 'inclus', mentionFiscale: 'TTC' })).toThrow()
+  })
+
+  it('refuse une mention fiscale sur une ligne sur devis', () => {
+    expect(() =>
+      montantSchema.parse({ nature: 'sur-devis', periodicite: 'mensuel', mentionFiscale: 'TTC' }),
+    ).toThrow()
+  })
+
+  it('refuse un chiffre glissé sur une ligne sans montant', () => {
+    expect(() => montantSchema.parse({ nature: 'inclus', minimum: 300 })).toThrow()
+  })
+
+  it('refuse une fourchette sans ce qui la fait varier', () => {
+    expect(() => montantSchema.parse({ ...fourchettePubliee, variableSelon: '' })).toThrow()
+  })
+
+  it('refuse une fourchette sans périodicité, qui laisserait croire à un abonnement', () => {
+    const { periodicite: _retiree, ...sansRythme } = {
+      ...fourchettePubliee,
+    } as Record<string, unknown>
+
+    expect(() => montantSchema.parse(sansRythme)).toThrow()
+  })
+
+  it.each([0, -300, 300.5])(
+    'refuse un montant « %s », qui n’est pas un prix publiable',
+    (borne) => {
+      expect(() => montantSchema.parse({ ...fourchettePubliee, minimum: borne })).toThrow()
+    },
+  )
+
+  it('refuse une nature de montant qui n’existe pas', () => {
+    expect(() => montantSchema.parse({ nature: 'gratuit' })).toThrow()
+  })
+})
+
+describe('le schéma d’une ligne tarifaire', () => {
+  it('accepte une ligne conforme à celle publiée', () => {
+    expect(() => tarifSchema.parse(LIGNE_VALIDE)).not.toThrow()
+  })
+
+  it('refuse une condition d’application vide, qui ferait deviner le prospect', () => {
+    expect(() => tarifSchema.parse({ ...LIGNE_VALIDE, condition: '' })).toThrow()
+  })
+
+  it('refuse un intitulé vide', () => {
+    expect(() => tarifSchema.parse({ ...LIGNE_VALIDE, intitule: '' })).toThrow()
+  })
+
+  it.each(['Mise-En-Place', 'mise en place', 'mise_en_place', ''])(
+    'refuse la clé « %s », hors du format minuscules-chiffres-tirets',
+    (cle) => {
+      expect(() => tarifSchema.parse({ ...LIGNE_VALIDE, cle })).toThrow()
+    },
+  )
+
+  it('refuse une clé inconnue ajoutée à la ligne', () => {
+    expect(() => tarifSchema.parse({ ...LIGNE_VALIDE, remise: '10 %' })).toThrow()
+  })
+})

--- a/tests/acceptance/montant-abandonne.test.js
+++ b/tests/acceptance/montant-abandonne.test.js
@@ -1,0 +1,167 @@
+/**
+ * Intention (écriture déléguée par Jérôme MARICHEZ le 2026-08-08 — issue #29) :
+ * le montant évoqué en première intention pour la mise en place SEA, puis ABANDONNÉ au
+ * profit de la fourchette, ne doit réapparaître dans AUCUNE source versionnée du dépôt.
+ * Pas dans le contenu, pas dans la documentation, pas dans un commentaire, pas dans un
+ * fichier de test — pas même pour expliquer qu'il a été abandonné.
+ *
+ * Pourquoi ce niveau et pas un test unitaire : la garantie ne porte sur aucun module.
+ * Elle porte sur le DÉPÔT pris comme un tout, tel qu'un lecteur — ou un moteur de
+ * recherche sur le dépôt public — peut le lire. C'est une exigence d'acceptation :
+ * la grille validée est la seule chose que le dépôt dit du prix.
+ *
+ * Ce qui rendrait ce test inutile, et qui est donc vérifié aussi : un balayage qui ne
+ * lirait rien passerait à vide. Le test contrôle donc qu'il a bien parcouru le dépôt et
+ * qu'il RETROUVE les deux bornes réellement publiées. S'il ne les trouve plus, c'est
+ * son propre balayage qui est cassé, et il le dit.
+ *
+ * Cas limites couverts : le montant abandonné cherché comme simple suite de caractères,
+ * donc attrapé même collé à un symbole monétaire, à une mention fiscale ou inséré dans
+ * un nombre plus long ; les fichiers encore non suivis mais déjà présents dans l'arbre
+ * de travail (`--others`), pour qu'un ajout soit refusé AVANT son premier commit ; les
+ * bornes publiées cherchées avec des bornes de chiffres, pour que « 12000 » ne passe
+ * pas pour « 1200 ».
+ *
+ * Exclusion assumée : `package-lock.json`. Ce sont des empreintes d'intégrité générées
+ * par npm, pas du contenu rédigé — une collision de trois chiffres dans une empreinte
+ * ne dirait rien du prix publié.
+ *
+ * Niveau : acceptation (runner Node natif, `make test-acceptance`).
+ * Jeu de données : les sources réellement versionnées du dépôt.
+ */
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const { readFileSync } = require('node:fs')
+const { join } = require('node:path')
+const { describe, it } = require('node:test')
+
+/**
+ * Le montant abandonné, composé chiffre par chiffre.
+ *
+ * Il n'est écrit nulle part en clair, pas même ici : ce fichier fait lui-même partie des
+ * sources balayées, et un test qui contiendrait la valeur qu'il interdit se trouverait
+ * lui-même. La composition n'est donc pas une coquetterie, c'est ce qui rend le test
+ * applicable à lui-même.
+ */
+const MONTANT_ABANDONNE = [4, 9, 9].join('')
+
+/** Fichiers exclus du balayage, et eux seuls. */
+const EXCLUS = /(^|\/)package-lock\.json$/
+
+const racine = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
+
+/**
+ * Sources versionnées, plus celles déjà posées dans l'arbre de travail et non ignorées :
+ * un montant réintroduit doit être refusé avant même son premier commit.
+ */
+const sources = execFileSync(
+  'git',
+  ['ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+  { cwd: racine, encoding: 'utf8' },
+)
+  .split('\0')
+  .filter((chemin) => chemin !== '' && !EXCLUS.test(chemin))
+
+const lus = sources.map((chemin) => ({
+  chemin,
+  contenu: readFileSync(join(racine, chemin), 'utf8'),
+}))
+
+/** Fichiers contenant une suite de chiffres prise comme nombre entier isolé. */
+const contenant = (nombre) => {
+  const motif = new RegExp(`(?<!\\d)${nombre}(?!\\d)`)
+
+  return lus.filter((source) => motif.test(source.contenu)).map((source) => source.chemin)
+}
+
+describe('le balayage du dépôt est réel', () => {
+  it('parcourt les sources versionnées du dépôt', () => {
+    assert.ok(
+      lus.length > 100,
+      `Balayage suspect : ${lus.length} fichiers lus. Le dépôt en compte davantage.`,
+    )
+  })
+
+  it('lit bien le contenu des fichiers, et pas seulement leur nom', () => {
+    const grille = lus.find((source) => source.chemin.endsWith('content/offres/sea-tarifs.ts'))
+
+    assert.ok(grille, 'La grille tarifaire n’a pas été trouvée : le balayage est incomplet.')
+    assert.match(grille.contenu, /mentionFiscale/)
+  })
+
+  it('retrouve la borne basse publiée — sinon le test passerait à vide', () => {
+    assert.notDeepEqual(contenant(300), [])
+  })
+
+  it('retrouve la borne haute publiée — sinon le test passerait à vide', () => {
+    assert.notDeepEqual(contenant(1200), [])
+  })
+})
+
+describe('le montant abandonné ne réapparaît nulle part', () => {
+  it('n’est présent dans aucune source versionnée', () => {
+    const fautifs = lus
+      .filter((source) => source.contenu.includes(MONTANT_ABANDONNE))
+      .map((source) => source.chemin)
+
+    assert.deepEqual(
+      fautifs,
+      [],
+      `Le montant abandonné en cours de négociation réapparaît dans : ${fautifs.join(', ')}. ` +
+        'Seule la fourchette validée fait foi — voir front/src/content/offres/sea-tarifs.ts.',
+    )
+  })
+
+  it('n’est pas davantage présent dans le fichier de ce test', () => {
+    const moi = lus.find((source) => source.chemin.endsWith('montant-abandonne.test.js'))
+
+    assert.ok(moi, 'Ce fichier de test n’est pas balayé : la garantie ne s’applique pas à lui.')
+    assert.ok(!moi.contenu.includes(MONTANT_ABANDONNE))
+  })
+})
+
+/**
+ * Un prix, c'est-à-dire l'une des bornes publiées SUIVIE d'un symbole monétaire ou d'une
+ * mention fiscale.
+ *
+ * La borne basse ne peut pas être cherchée seule hors du contenu éditorial : « 300 » est
+ * aussi la limite de lignes par fichier source, citée dans le CLAUDE.md, le README et la
+ * documentation. Un nombre nu n'est pas un prix ; un nombre suivi d'un « € » en est un.
+ */
+const PRIX_PUBLIE = /(?<!\d)(300|1[ {2}]?200)\s*(€|EUR\b|TTC)/
+
+describe('les bornes publiées ne sont écrites qu’une fois', () => {
+  const GRILLE = 'front/src/content/offres/sea-tarifs.ts'
+  const contenuEditorial = (chemins) =>
+    chemins.filter((chemin) => chemin.startsWith('front/src/content/'))
+
+  it('n’écrit la borne basse que dans la grille tarifaire', () => {
+    assert.deepEqual(contenuEditorial(contenant(300)), [GRILLE])
+  })
+
+  it('n’écrit la borne haute que dans la grille tarifaire', () => {
+    assert.deepEqual(contenuEditorial(contenant(1200)), [GRILLE])
+  })
+
+  it('ne recopie la borne haute dans aucune documentation', () => {
+    const documentation = contenant(1200).filter((chemin) => chemin.endsWith('.md'))
+
+    assert.deepEqual(documentation, [])
+  })
+
+  it('n’écrit un prix en toutes lettres ni dans l’application ni dans la documentation', () => {
+    // Les tests, eux, ont le droit d'écrire le prix attendu : c'est même leur objet —
+    // ils vérifient que la mise en forme calculée produit exactement cette chaîne.
+    const prixEcrits = lus
+      .filter((source) => !source.chemin.includes('tests/'))
+      .filter((source) => PRIX_PUBLIE.test(source.contenu))
+      .map((source) => source.chemin)
+
+    assert.deepEqual(
+      prixEcrits,
+      [],
+      `Un prix est écrit en toutes lettres dans : ${prixEcrits.join(', ')}. ` +
+        'Le chiffre et sa mention sortent de front/src/utils/tarif.ts, jamais d’une saisie.',
+    )
+  })
+})


### PR DESCRIPTION
Closes #29

Deuxième vague des tests délégués, sur les domaines exclus de la première parce qu'ils étaient alors en cours de réécriture : la page d'accueil et la grille tarifaire.

**Délégation explicite de Jérôme MARICHEZ** le 2026-08-08 (« oui fait les 21 tests »), correspondant à la dérogation `TESTS_WRITABLE_BY_ASSISTANT=1` prévue par le `CLAUDE.md`. Chaque fichier porte son bloc `Intention`.

## Résultats

| | Avant | Après |
|---|---|---|
| Tests unitaires front | 361 | **533** |
| `make test-acceptance` | en échec | **10 tests, 3 suites, 0 échec** |

## Un diagnostic corrigé

`make test-acceptance` **n'échouait pas faute de test**. Depuis Node 22, l'argument positionnel de `node --test` est un **motif de fichiers**, pas un dossier : un chemin de dossier est chargé comme module et lève `MODULE_NOT_FOUND`, que le dossier contienne des tests ou non. La cible était donc cassée par construction depuis l'initialisation du projet — c'est un défaut du bootstrap, à remonter.

Correction : `node --test "tests/acceptance/**/*.test.js"`, motif protégé par des guillemets pour que ce soit Node qui l'étende et non le shell, dont le `**` n'est pas récursif.

## Vérification par mutation

Faite à la main après l'interruption de l'agent, parce qu'une suite qui passe ne prouve rien tant qu'on ne l'a pas vue échouer.

| Mutation | Résultat |
|---|---|
| Avertissement « scénario illustratif » vidé | `ZodError` **au chargement du module** — la suite ne s'exécute pas et le build échoue |
| Montant abandonné réintroduit dans le contenu | le test d'acceptation échoue |

Le premier résultat est plus strict que prévu : un scénario e-commerce sans mention illustrative ne peut pas être publié, le contenu n'est même pas chargeable.

## Périmètre

Aucune doublure de module, aucun `skip`, **aucune modification du code applicatif**. Les trois pages d'offre sont hors périmètre, elles sont créées en parallèle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Lkzawdu7WwjAQxgKY2ar