### PR TITLE
feat: les trois pages d'offre

### DIFF
--- a/front/src/@shared/seo/index.ts
+++ b/front/src/@shared/seo/index.ts
@@ -15,4 +15,4 @@ export {
   siteUrl,
   titleTemplate,
 } from './site'
-export { buildSiteStructuredData } from './structured-data'
+export { buildOffreStructuredData, buildSiteStructuredData } from './structured-data'

--- a/front/src/@shared/seo/structured-data.ts
+++ b/front/src/@shared/seo/structured-data.ts
@@ -14,7 +14,9 @@
 // Jérôme MARICHEZ, déjà publiques sur ses CV, dont il a explicitement demandé la
 // publication. Elles proviennent du contenu typé, jamais d'une chaîne écrite ici.
 import { certifications, formations, identite, offres } from '@/content'
+import type { IOffre } from '@/interfaces/offre'
 import { telephoneVersE164 } from '@/utils/telephone'
+import { cheminOffre } from '../config/routes'
 import type { JsonLdGraph, JsonLdNode } from '../interfaces/types'
 import { absoluteUrl, siteUrl } from './site'
 
@@ -154,5 +156,73 @@ export function buildSiteStructuredData(): JsonLdGraph {
   return {
     '@context': 'https://schema.org',
     '@graph': [personne(), activite()],
+  }
+}
+
+/**
+ * Les axes de l'offre, décrits un à un.
+ *
+ * Chaque axe est bien un service rendu dans le cadre de l'offre : le catalogue reprend
+ * son titre et sa description tels qu'écrits dans `content/offres/`, sans les reformuler.
+ * Aucun prix n'y figure — voir `serviceDeLOffre` ci-dessous.
+ */
+function catalogueAxes(offre: IOffre): JsonLdNode {
+  return {
+    '@type': 'OfferCatalog',
+    name: offre.titre,
+    itemListElement: offre.axes.map((axe) => ({
+      '@type': 'Offer',
+      itemOffered: {
+        '@type': 'Service',
+        name: axe.titre,
+        description: axe.description,
+      },
+    })),
+  }
+}
+
+/**
+ * Le `Service` décrivant UNE offre — l'entité propre à sa page.
+ *
+ * `provider` pointe l'`@id` du `ProfessionalService` du layout racine au lieu de le
+ * redécrire : les moteurs recomposent un seul graphe pour le document, et l'activité
+ * n'y est déclarée qu'une fois (règle du CLAUDE.md — `Person` et `ProfessionalService`
+ * décrivent le site entier, une page ne décrit que ce qui lui est propre).
+ *
+ * Ce qui n'est PAS émis, et pourquoi :
+ *
+ * - aucun prix, aucune `offers`, aucun `priceSpecification` — y compris pour SEA, seule
+ *   offre à publier une grille. Un prix en JSON-LD engage une devise, une validité et
+ *   des conditions de livraison qu'aucun arbitrage n'a fixées ; la grille dit « incluse
+ *   si j'ai conçu le site » et « sur devis », qui ne se traduisent pas en `price`. Le
+ *   texte visible reste la seule publication des montants, et `utils/tarif.ts` la seule
+ *   façon de les mettre en forme ;
+ * - ni `areaServed`, ni `aggregateRating`, ni `review` : rien de tout cela n'est établi,
+ *   et une donnée structurée fausse est une affirmation fausse (docs/seo.md).
+ */
+function serviceDeLOffre(offre: IOffre): JsonLdNode {
+  const url = absoluteUrl(cheminOffre(offre.cle))
+  return {
+    '@type': 'Service',
+    '@id': `${url}#offre`,
+    name: offre.titre,
+    description: offre.accroche,
+    serviceType: offre.titre,
+    url,
+    provider: { '@id': SERVICE_ID },
+    hasOfferCatalog: catalogueAxes(offre),
+  }
+}
+
+/**
+ * Graphe d'une page d'offre. Injecté par la vue, en plus de celui du layout.
+ *
+ * Construit intégralement à partir de l'offre typée reçue en argument : ajouter une
+ * quatrième offre au contenu lui donne son `Service` sans qu'une ligne d'ici change.
+ */
+export function buildOffreStructuredData(offre: IOffre): JsonLdGraph {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [serviceDeLOffre(offre)],
   }
 }

--- a/front/src/app/services/data-ia/page.tsx
+++ b/front/src/app/services/data-ia/page.tsx
@@ -1,0 +1,13 @@
+// src/app/services/data-ia/page.tsx — jeromemarichez2026
+// app/ ne fait QUE du routage : le gabarit vit dans src/views/offre/.
+// Ce fichier déclare la route, ses métadonnées, et rend le gabarit avec son offre.
+import type { Metadata } from 'next'
+import { offreDataIa } from '@/content'
+import { metadonneesOffre } from '@/views/offre/metadonnees'
+import { OffreView } from '@/views/offre/OffreView'
+
+export const metadata: Metadata = metadonneesOffre(offreDataIa)
+
+export default function DataIaPage() {
+  return <OffreView offre={offreDataIa} />
+}

--- a/front/src/app/services/ingenierie-web/page.tsx
+++ b/front/src/app/services/ingenierie-web/page.tsx
@@ -1,0 +1,13 @@
+// src/app/services/ingenierie-web/page.tsx — jeromemarichez2026
+// app/ ne fait QUE du routage : le gabarit vit dans src/views/offre/.
+// Ce fichier déclare la route, ses métadonnées, et rend le gabarit avec son offre.
+import type { Metadata } from 'next'
+import { offreIngenierieWeb } from '@/content'
+import { metadonneesOffre } from '@/views/offre/metadonnees'
+import { OffreView } from '@/views/offre/OffreView'
+
+export const metadata: Metadata = metadonneesOffre(offreIngenierieWeb)
+
+export default function IngenierieWebPage() {
+  return <OffreView offre={offreIngenierieWeb} />
+}

--- a/front/src/app/services/sea/page.tsx
+++ b/front/src/app/services/sea/page.tsx
@@ -1,0 +1,13 @@
+// src/app/services/sea/page.tsx — jeromemarichez2026
+// app/ ne fait QUE du routage : le gabarit vit dans src/views/offre/.
+// Ce fichier déclare la route, ses métadonnées, et rend le gabarit avec son offre.
+import type { Metadata } from 'next'
+import { offreSea } from '@/content'
+import { metadonneesOffre } from '@/views/offre/metadonnees'
+import { OffreView } from '@/views/offre/OffreView'
+
+export const metadata: Metadata = metadonneesOffre(offreSea)
+
+export default function SeaPage() {
+  return <OffreView offre={offreSea} />
+}

--- a/front/src/content/index.ts
+++ b/front/src/content/index.ts
@@ -10,6 +10,7 @@ export { certifications } from './certifications'
 export { experiences } from './experiences'
 export { formations } from './formations'
 export { identite } from './identite'
+export { offrePage } from './offre-page'
 export {
   grillesTarifaires,
   grilleTarifaireSea,

--- a/front/src/content/offre-page.ts
+++ b/front/src/content/offre-page.ts
@@ -1,0 +1,40 @@
+// offre-page.ts — jeromemarichez2026
+// Libellés du gabarit des trois pages d'offre (issue #22).
+//
+// PÉRIMÈTRE STRICT : ce fichier ne porte que la CHARPENTE — intitulés de section et
+// étiquettes. Il ne dit rien d'une offre en particulier. Tout ce qui décrit une offre
+// (accroche, axes, preuves, décision permise, grille tarifaire) vient de
+// `content/offres/`, qui n'a pas été touché : le contenu fait foi, la page l'affiche.
+//
+// Véracité — points tenus ici :
+// - aucune affirmation, aucun chiffre, aucune durée : rien ici ne peut être faux, parce
+//   que rien ici n'avance quoi que ce soit. Les preuves sont dans les offres ;
+// - première personne du singulier (CLAUDE.md) : « je », jamais « nous » ;
+// - aucun délai de réponse annoncé, aucun engagement de disponibilité : aucun n'est
+//   établi (même règle que `content/accueil.ts`) ;
+// - aucun montant : les seuls chiffres publiables du site sont dans `sea-tarifs.ts` et
+//   n'en sortent que par `utils/tarif.ts` ;
+// - aucun emoji, aucun superlatif.
+//
+// AUCUN LIBELLÉ N'EST REPRIS DE `content/accueil.ts`. « Ce que vous décidez » y existe
+// déjà comme étiquette de carte ; le reprendre à l'identique aurait écrit deux fois le
+// même texte, ce que le projet s'interdit. Sur une page d'offre la décision n'est pas
+// une étiquette mais une SECTION, et elle porte donc un intitulé qui lui est propre.
+import type { IOffrePage } from '../interfaces/offre-page'
+import { offrePageSchema } from '../schemas/offre-page.schema'
+
+const donnees = {
+  titreAxes: 'Ce que couvre l’offre',
+  libellePreuve: 'Preuve',
+  titreDecision: 'Ce que cette offre vous permet de décider',
+  titreTarifs: 'Tarifs',
+  libellePreuveTarifs: 'Ce qui appuie cet argument',
+  contact: {
+    titre: 'Parlons de votre projet',
+    lead: 'Décrivez votre besoin en quelques lignes : je vous dis ce que cette offre couvre dans votre cas, et ce qu’elle ne couvre pas.',
+    action: { href: '/contact', libelle: 'Me contacter' },
+  },
+} satisfies IOffrePage
+
+/** Validé au chargement : une donnée non conforme échoue au build, pas en production. */
+export const offrePage: IOffrePage = offrePageSchema.parse(donnees)

--- a/front/src/interfaces/groupe-axes.ts
+++ b/front/src/interfaces/groupe-axes.ts
@@ -1,0 +1,28 @@
+// groupe-axes.ts — jeromemarichez2026
+// Entité de rendu : une suite d'axes contigus partageant le même volet.
+// Produite par services/axes.service.ts, consommée par la vue d'offre.
+import type { IAxeOffre } from './axe-offre'
+
+/**
+ * Un groupe d'axes, tel qu'il se lit sur une page d'offre.
+ *
+ * Le groupe est obtenu en parcourant `IOffre.axes` DANS SON ORDRE et en ouvrant un
+ * nouveau groupe à chaque changement de `volet` — jamais en rassemblant tous les axes
+ * d'un même volet où qu'ils se trouvent. La nuance est le message de l'offre
+ * « Data & IA » : ses deux premiers axes (fiabilité puis qualification des données)
+ * précèdent volontairement toute promesse d'IA, et ses trois derniers (MLOps,
+ * conformité, sur devis) la suivent. Un regroupement par valeur les aurait fait
+ * remonter ou descendre, c'est-à-dire aurait réécrit le discours.
+ *
+ * `volet` vaut `null` pour le socle commun — les axes qui n'appartiennent à aucun
+ * volet nommé. C'est le cas de la totalité des axes des offres qui n'en distinguent
+ * aucun.
+ */
+export interface IGroupeAxes {
+  /** Clé stable pour le rendu de liste, dérivée du premier axe du groupe. */
+  readonly cle: string
+  /** Nom du volet, ou `null` pour le socle commun. */
+  readonly volet: string | null
+  /** Les axes du groupe, dans l'ordre du contenu. Jamais vide. */
+  readonly axes: readonly IAxeOffre[]
+}

--- a/front/src/interfaces/offre-page.ts
+++ b/front/src/interfaces/offre-page.ts
@@ -1,0 +1,44 @@
+// offre-page.ts — jeromemarichez2026
+// Entité éditoriale : les libellés propres au GABARIT des pages d'offre.
+//
+// Ce jeu de libellés est commun aux trois pages : il décrit la charpente — comment
+// s'appellent les sections, comment s'annonce une preuve — jamais ce que dit une offre.
+// Tout ce qui distingue une offre d'une autre vient de `content/offres/`, qui fait foi.
+//
+// Aucune vue n'écrit de texte éditorial (docs/architecture.md — « le contenu éditorial
+// est de la donnée, pas du JSX ») : corriger « Ce que couvre l'offre » ne demande donc
+// jamais de toucher au rendu, et le correctif vaut pour les trois pages à la fois.
+import type { IAppelAction } from './appel-action'
+
+/** Appel à contact fermant chaque page d'offre. */
+interface ISectionContactOffre {
+  readonly titre: string
+  readonly lead: string
+  readonly action: IAppelAction
+}
+
+/**
+ * Libellés du gabarit des pages d'offre.
+ *
+ * Aucun de ces champs ne porte d'affirmation : ce sont des intitulés de section et des
+ * étiquettes. Les affirmations — et les preuves qui les appuient — vivent toutes dans
+ * `content/offres/`, seul corpus relu contre les règles de véracité du CLAUDE.md.
+ */
+export interface IOffrePage {
+  /** Titre de la section qui énumère les axes de travail de l'offre. */
+  readonly titreAxes: string
+  /**
+   * Étiquette annonçant la preuve d'un axe.
+   *
+   * La ligne éditoriale impose qu'une affirmation porte sa preuve : l'étiquette rend
+   * ce statut visible, au lieu de laisser le chiffre se confondre avec la description.
+   */
+  readonly libellePreuve: string
+  /** Titre de la section portant `IOffre.decisionPermise`. */
+  readonly titreDecision: string
+  /** Titre de la section portant la grille tarifaire, quand l'offre en publie une. */
+  readonly titreTarifs: string
+  /** Étiquette introduisant la preuve chiffrée qui appuie l'argument de la grille. */
+  readonly libellePreuveTarifs: string
+  readonly contact: ISectionContactOffre
+}

--- a/front/src/schemas/offre-page.schema.ts
+++ b/front/src/schemas/offre-page.schema.ts
@@ -1,0 +1,25 @@
+// offre-page.schema.ts — jeromemarichez2026
+// Schéma Zod de l'entité IOffrePage. Validé au chargement du module : un libellé vide
+// échoue au BUILD, jamais en production. Convention : docs/architecture.md.
+import { z } from 'zod'
+
+const appelActionSchema = z.strictObject({
+  href: z.string().min(1),
+  // Un libellé vide rendrait un lien sans nom accessible : interdit par le typage.
+  libelle: z.string().min(1),
+})
+
+export const offrePageSchema = z.strictObject({
+  titreAxes: z.string().min(1),
+  libellePreuve: z.string().min(1),
+  titreDecision: z.string().min(1),
+  titreTarifs: z.string().min(1),
+  libellePreuveTarifs: z.string().min(1),
+  contact: z.strictObject({
+    titre: z.string().min(1),
+    lead: z.string().min(1),
+    action: appelActionSchema,
+  }),
+})
+
+export type OffrePageValide = z.infer<typeof offrePageSchema>

--- a/front/src/schemas/page-seo.schema.ts
+++ b/front/src/schemas/page-seo.schema.ts
@@ -7,6 +7,17 @@
 // chemin mal formé casse la compilation, il n'atteint pas la production.
 import { z } from 'zod'
 
+/**
+ * Longueur maximale d'une meta description, exportée parce qu'elle sert AILLEURS.
+ *
+ * Les pages d'offre dérivent leur description de l'accroche de l'offre et doivent donc
+ * connaître la borne à laquelle elles seront jugées. Écrire « 160 » une seconde fois
+ * dans le code de dérivation aurait créé deux vérités : celle qui coupe et celle qui
+ * refuse. Un jour où l'une bouge sans l'autre, le build casse sur des pages valides —
+ * ou pire, laisse passer une description tronquée pour rien.
+ */
+export const LONGUEUR_MAX_DESCRIPTION = 160
+
 export const pageSeoSchema = z.strictObject({
   /**
    * Part du titre propre à la page. Le gabarit du layout ajoute « — Jérôme Marichez » :
@@ -15,7 +26,7 @@ export const pageSeoSchema = z.strictObject({
    */
   title: z.string().min(3).max(60),
   /** Meta description : bornée pour les mêmes raisons que `descriptionSite`. */
-  description: z.string().min(50).max(160),
+  description: z.string().min(50).max(LONGUEUR_MAX_DESCRIPTION),
   /**
    * Chemin absolu de la page depuis la racine du site, sans domaine, sans paramètre et
    * sans barre oblique finale — `/` pour l'accueil, `/services/sea` sinon.

--- a/front/src/services/axes.service.ts
+++ b/front/src/services/axes.service.ts
@@ -1,0 +1,46 @@
+// axes.service.ts — jeromemarichez2026
+// Logique métier : découper les axes d'une offre en groupes de volets.
+// Aucune logique de rendu ici (docs/architecture.md — services/ vs hooks).
+import type { IAxeOffre } from '../interfaces/axe-offre'
+import type { IGroupeAxes } from '../interfaces/groupe-axes'
+
+/**
+ * Groupe les axes par volet, EN PRÉSERVANT L'ORDRE DU CONTENU.
+ *
+ * L'algorithme est un découpage en suites contiguës : on parcourt les axes une fois et
+ * on ouvre un nouveau groupe dès que le volet change. Aucun tri, aucun rassemblement.
+ *
+ * C'est un choix de fond, pas une facilité d'implémentation. L'offre « Data & IA »
+ * ouvre sur la fiabilité puis la qualification des données, AVANT ses deux volets, et
+ * se referme sur MLOps, conformité et « sur devis », APRÈS eux. Un regroupement par
+ * valeur — rassembler tout le socle d'un côté, tout l'agent de l'autre — produirait
+ * trois blocs au lieu de quatre et déplacerait ces axes : l'offre s'ouvrirait ou se
+ * fermerait sur autre chose que ce que le contenu a décidé. L'ordre du tableau `axes`
+ * EST le message (content/offres/data-ia.ts), et il traverse le rendu intact.
+ *
+ * Une offre qui ne distingue aucun volet — Ingénierie Web, SEA — produit un groupe
+ * unique de volet `null` : le gabarit n'a donc aucun cas particulier à connaître.
+ */
+export function grouperAxesParVolet(axes: readonly IAxeOffre[]): readonly IGroupeAxes[] {
+  const groupes: IGroupeAxes[] = []
+  let courant: { volet: string | null; axes: IAxeOffre[] } | null = null
+
+  for (const axe of axes) {
+    const volet = axe.volet ?? null
+
+    if (courant === null || courant.volet !== volet) {
+      courant = { volet, axes: [] }
+      groupes.push({
+        // Dérivée du premier axe du groupe : unique par construction, puisqu'une clé
+        // d'axe est unique au sein de son offre (IAxeOffre.cle).
+        cle: axe.cle,
+        volet,
+        axes: courant.axes,
+      })
+    }
+
+    courant.axes.push(axe)
+  }
+
+  return groupes
+}

--- a/front/src/utils/extrait.ts
+++ b/front/src/utils/extrait.ts
@@ -1,0 +1,52 @@
+// extrait.ts — jeromemarichez2026
+// Utilitaire transverse : réduire un texte éditorial à la longueur d'une meta
+// description. Pur, sans état, sans métier — convention `src/utils/` du CLAUDE.md.
+//
+// POURQUOI CE MODULE EXISTE. Les pages d'offre déclarent leur description SEO à partir
+// de l'accroche de l'offre, seul texte du contenu typé qui décrive l'offre en une
+// phrase. Or `pageSeoSchema` borne une description à 160 caractères — au-delà, les
+// moteurs tronquent — et deux des trois accroches dépassent cette borne.
+//
+// Le choix fait ici est de DÉRIVER plutôt que d'écrire. Rédiger trois descriptions à la
+// main aurait produit un quatrième jeu de texte éditorial, non relu contre les règles de
+// véracité du CLAUDE.md et libre de diverger de l'accroche qu'il résume. La troncature,
+// elle, ne peut affirmer que ce que l'accroche affirme déjà : c'est le même texte, plus
+// court. Le jour où `IOffre` portera une description SEO propre, écrite et arbitrée par
+// Jérôme MARICHEZ, ce module cessera d'être appelé par les pages d'offre — voir la PR
+// de l'issue #22.
+//
+// Aucun texte éditorial n'est écrit ici : seul le signe de troncature l'est.
+
+/** Marque visible d'une phrase coupée. Un seul caractère, pas trois points. */
+const ELLIPSE = '…'
+
+/**
+ * Réduit un texte à `longueurMaximale` caractères au plus, sans couper de mot.
+ *
+ * Rendu inchangé si le texte tient déjà : c'est le cas nominal, et il ne doit rien
+ * coûter — l'accroche de l'offre SEA passe ainsi telle quelle, ellipse comprise.
+ *
+ * Sinon, le texte est coupé à la dernière frontière de mot qui laisse la place à
+ * l'ellipse, puis la ponctuation et les espaces de fin sont retirés : une description
+ * ne se termine pas sur « et… » précédé d'une virgule orpheline.
+ *
+ * La coupure se fait sur les mots et jamais sur les phrases. Couper à la phrase aurait
+ * paru plus propre, mais aurait rendu la longueur du résultat imprévisible : l'accroche
+ * de « Data & IA » se serait réduite à sa première phrase — 73 caractères — en perdant
+ * précisément les deux volets qui font la valeur de la page en résultat de recherche.
+ * Une règle unique, appliquée aux trois offres, reste préférable à deux comportements
+ * dont le déclenchement dépend d'une ponctuation.
+ */
+export function extraireDescription(texte: string, longueurMaximale: number): string {
+  const source = texte.trim()
+  if (source.length <= longueurMaximale) return source
+
+  // On garde la place de l'ellipse dans le budget : le résultat doit tenir la borne,
+  // signe de troncature compris.
+  const coupe = source.slice(0, longueurMaximale - ELLIPSE.length)
+  const derniereEspace = coupe.lastIndexOf(' ')
+  const mots = derniereEspace > 0 ? coupe.slice(0, derniereEspace) : coupe
+
+  // Retire la ponctuation faible et les espaces laissés en bout de coupe.
+  return `${mots.replace(/[\s,;:—–-]+$/u, '')}${ELLIPSE}`
+}

--- a/front/src/views/offre/OffreView.tsx
+++ b/front/src/views/offre/OffreView.tsx
@@ -1,0 +1,66 @@
+// OffreView.tsx — jeromemarichez2026
+// LE GABARIT DES TROIS PAGES D'OFFRE. Un seul, trois contenus.
+//
+// Cette vue ne connaît aucune offre en particulier : elle reçoit une `IOffre` et
+// n'en lit que des champs du modèle. C'est ce qui rend la promesse de l'issue #22
+// vérifiable — ajouter une quatrième offre à `content/offres/` et déposer son fichier
+// de route de six lignes lui donne sa page, sans qu'une ligne d'ici change.
+import { JsonLd } from '@/@shared/components/JsonLd'
+import { buildOffreStructuredData } from '@/@shared/seo'
+import { grillesTarifaires, offrePage, offres } from '@/content'
+import type { IOffre } from '@/interfaces/offre'
+import { grouperAxesParVolet } from '@/services/axes.service'
+import { resoudrePreuves } from '@/services/preuves.service'
+import { Axes } from './sections/Axes'
+import { Contact } from './sections/Contact'
+import { Decision } from './sections/Decision'
+import { Entete } from './sections/Entete'
+import { Tarifs } from './sections/Tarifs'
+
+interface IOffreViewProps {
+  offre: IOffre
+}
+
+/**
+ * Ordre des sections — c'est le raisonnement de la page :
+ *
+ * 1. ce que l'offre est (`Entete`, seul `h1` : le titre de l'offre et son accroche) ;
+ * 2. ce qu'elle couvre, axe par axe, chacun portant sa preuve quand elle existe
+ *    (`Axes`) ;
+ * 3. ce que le client peut trancher grâce à elle (`Decision`) — la ligne éditoriale
+ *    du CLAUDE.md interdit de fermer un bloc de service sur une liste d'outils ;
+ * 4. ce qu'elle coûte, si et seulement si une grille est publiée (`Tarifs`) ;
+ * 5. l'action attendue (`Contact`).
+ *
+ * La grille vient APRÈS la décision et non avant : l'argument se ferme sur ce que le
+ * client décide, et le prix se lit ensuite, là où un prospect le cherche — juste avant
+ * l'appel à contact.
+ *
+ * Les trois résolutions ont lieu ici, au rendu serveur donc au build : une référence de
+ * preuve cassée fait échouer la compilation au lieu de publier une affirmation sans
+ * preuve.
+ */
+export function OffreView({ offre }: IOffreViewProps) {
+  const groupes = grouperAxesParVolet(offre.axes)
+
+  // Toutes les offres n'ont pas de grille : Data & IA est entièrement sur devis, et
+  // Ingénierie Web n'a pas d'arbitrage rendu. L'absence est une information portée par
+  // le contenu (content/offres/index.ts), pas un cas d'erreur.
+  const grille = grillesTarifaires.find((candidate) => candidate.offre === offre.cle)
+  const [preuveTarifs] = grille ? resoudrePreuves([grille.preuve], offres) : []
+
+  return (
+    <>
+      <Entete offre={offre} />
+      <Axes contenu={offrePage} groupes={groupes} />
+      <Decision contenu={offrePage} offre={offre} />
+      {grille && preuveTarifs ? (
+        <Tarifs contenu={offrePage} grille={grille} preuve={preuveTarifs} />
+      ) : null}
+      <Contact contenu={offrePage.contact} />
+      {/* Données structurées propres à la page : le `Service` de cette offre, rattaché
+          par `@id` au `ProfessionalService` que le layout racine déclare déjà. */}
+      <JsonLd data={buildOffreStructuredData(offre)} />
+    </>
+  )
+}

--- a/front/src/views/offre/metadonnees.ts
+++ b/front/src/views/offre/metadonnees.ts
@@ -1,0 +1,37 @@
+// metadonnees.ts — jeromemarichez2026
+// Métadonnées d'une page d'offre, dérivées de l'offre elle-même.
+//
+// Vit ici plutôt que dans `app/` : les trois fichiers de route ne font QUE du routage
+// (CLAUDE.md — « pages/app ne fait que le routage »). Vit ici plutôt que dans
+// `@shared/seo/` : c'est un usage du module SEO, pas une extension du module SEO — le
+// jour où une quatrième famille de pages naîtra, elle n'aura rien à hériter de celle-ci.
+import type { Metadata } from 'next'
+import { cheminOffre } from '@/@shared/config/routes'
+import { buildPageMetadata } from '@/@shared/seo'
+import type { IOffre } from '@/interfaces/offre'
+import { LONGUEUR_MAX_DESCRIPTION } from '@/schemas/page-seo.schema'
+import { extraireDescription } from '@/utils/extrait'
+
+/**
+ * Titre, description et canonique d'une page d'offre.
+ *
+ * Les trois valeurs sont DÉRIVÉES de l'offre : son titre, son accroche, sa clé. Rien
+ * n'est écrit ici, donc rien ne peut diverger du contenu — et une quatrième offre
+ * obtient ses métadonnées sans qu'une ligne change.
+ *
+ * `title` reste suffixé par le gabarit du layout (« Ingénierie Web — Jérôme Marichez ») :
+ * `absoluteTitle` est réservé à l'accueil, seul titre qui porte déjà l'identité complète.
+ *
+ * LIMITE ASSUMÉE, à porter devant Jérôme MARICHEZ (voir la PR de l'issue #22) : `IOffre`
+ * ne porte pas de description SEO propre. Celle-ci est donc l'accroche, tronquée sur un
+ * mot lorsqu'elle dépasse la borne — deux des trois la dépassent. C'est le choix de ne
+ * rien inventer : une description écrite pour l'occasion aurait été du texte éditorial
+ * non relu contre les règles de véracité, et libre de promettre autre chose que l'offre.
+ */
+export function metadonneesOffre(offre: IOffre): Metadata {
+  return buildPageMetadata({
+    title: offre.titre,
+    description: extraireDescription(offre.accroche, LONGUEUR_MAX_DESCRIPTION),
+    path: cheminOffre(offre.cle),
+  })
+}

--- a/front/src/views/offre/sections/Axes/axes.module.css
+++ b/front/src/views/offre/sections/Axes/axes.module.css
@@ -1,0 +1,54 @@
+/* Axes d'une offre — grille de cartes, éventuellement découpée en volets. */
+
+.groupe {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+/* Sépare deux volets sans filet : la respiration suffit, et un trait de plus
+ * concurrencerait les bordures des cartes juste en dessous. */
+.groupe + .groupe {
+  margin-top: var(--space-xl);
+}
+
+.volet {
+  max-width: var(--layout-width-narrow);
+}
+
+.grille {
+  display: grid;
+
+  /* Le nombre de colonnes se déduit de la place disponible, sans point de rupture.
+   * `min()` empêche la piste de réclamer 18 rem quand le viewport est plus étroit
+   * que cela — c'est ce qui évite le défilement horizontal à 320 px. */
+  grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-md);
+  padding-left: 0;
+  list-style: none;
+}
+
+/* `grid` plutôt que `block` : la carte occupe toute la hauteur de sa rangée, ce qui
+ * aligne le bas des cartes d'une colonne à l'autre. */
+.item {
+  display: grid;
+  min-width: 0;
+}
+
+/* La preuve ferme la carte et se distingue de la description : elle est un fait, pas
+ * une promesse. `margin-top: auto` la colle en bas, les preuves s'alignent donc d'une
+ * colonne à l'autre — et une carte sans preuve ne laisse pas de trou. */
+.preuve {
+  margin-top: auto;
+  padding-top: var(--space-2xs);
+  color: var(--color-text);
+}
+
+.preuveLibelle {
+  display: block;
+  color: var(--color-accent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}

--- a/front/src/views/offre/sections/Axes/index.tsx
+++ b/front/src/views/offre/sections/Axes/index.tsx
@@ -1,0 +1,56 @@
+import { Card } from '@/@shared/components/Card'
+import { Section } from '@/@shared/components/Section'
+import type { IGroupeAxes } from '@/interfaces/groupe-axes'
+import type { IOffrePage } from '@/interfaces/offre-page'
+import styles from './axes.module.css'
+
+interface IAxesProps {
+  contenu: IOffrePage
+  groupes: readonly IGroupeAxes[]
+}
+
+/**
+ * Ce que couvre l'offre : ses axes de travail, chacun portant sa preuve quand il en a
+ * une publiable.
+ *
+ * LES VOLETS SONT RENDUS DANS L'ORDRE DU CONTENU. `grouperAxesParVolet` découpe les axes
+ * en suites contiguës sans jamais réordonner : l'offre « Data & IA » ouvre donc bien sur
+ * la fiabilité puis la qualification des données, avant ses deux volets nommés, et se
+ * referme sur MLOps, conformité et « sur devis ». Cet ordre est le message de l'offre —
+ * il distingue de qui vend l'IA d'abord et découvre ensuite que la donnée du client est
+ * inexploitable.
+ *
+ * HIÉRARCHIE DES TITRES. Un groupe nommé pose un `h3` (le volet) et ses axes deviennent
+ * des `h4` ; un groupe du socle commun n'a pas de nom à afficher et ses axes restent des
+ * `h3`. Aucun niveau n'est sauté dans l'un ou l'autre cas, et le niveau reflète
+ * exactement la profondeur réelle de l'information plutôt qu'un alignement décoratif.
+ *
+ * Les axes sont rendus en liste : un lecteur d'écran annonce leur nombre avant de les
+ * énumérer, ce qui donne d'emblée la taille du périmètre couvert.
+ */
+export function Axes({ contenu, groupes }: IAxesProps) {
+  return (
+    <Section id="axes" title={contenu.titreAxes} width="wide">
+      {groupes.map((groupe) => (
+        <div className={styles.groupe} key={groupe.cle}>
+          {groupe.volet === null ? null : <h3 className={styles.volet}>{groupe.volet}</h3>}
+          <ul className={styles.grille}>
+            {groupe.axes.map((axe) => (
+              <li className={styles.item} key={axe.cle}>
+                <Card headingLevel={groupe.volet === null ? 3 : 4} title={axe.titre}>
+                  <p>{axe.description}</p>
+                  {axe.preuve === null ? null : (
+                    <p className={styles.preuve}>
+                      <span className={styles.preuveLibelle}>{contenu.libellePreuve}</span>
+                      {axe.preuve}
+                    </p>
+                  )}
+                </Card>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </Section>
+  )
+}

--- a/front/src/views/offre/sections/Contact/contact.module.css
+++ b/front/src/views/offre/sections/Contact/contact.module.css
@@ -1,0 +1,26 @@
+/* Appel à contact — dernier bloc d'une page d'offre, seule action mise en avant. */
+
+.section {
+  padding-block: var(--space-section);
+}
+
+/* Le fond suffit à délimiter le panneau : `--color-border` sur `--color-accent-soft`
+ * ne contraste qu'à 1.19:1 (mesuré), un filet y serait donc décoratif et illisible. */
+.panneau {
+  display: flex;
+  flex-direction: column;
+
+  /* Le lien d'action garde sa largeur naturelle plutôt que de s'étirer sur toute la
+   * ligne : une cible de plusieurs centaines de pixels ne se lit plus comme un bouton. */
+  align-items: flex-start;
+  gap: var(--space-sm);
+  min-width: 0;
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-accent-soft);
+}
+
+.lead {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+}

--- a/front/src/views/offre/sections/Contact/index.tsx
+++ b/front/src/views/offre/sections/Contact/index.tsx
@@ -1,0 +1,33 @@
+import { ActionLink } from '@/@shared/components/ActionLink'
+import { Container } from '@/@shared/components/Container'
+import type { IOffrePage } from '@/interfaces/offre-page'
+import styles from './contact.module.css'
+
+interface IContactProps {
+  contenu: IOffrePage['contact']
+}
+
+/**
+ * Appel à contact fermant une page d'offre.
+ *
+ * Composé à la main plutôt qu'avec `@shared/Section` : le titre et le texte doivent se
+ * trouver À L'INTÉRIEUR du panneau mis en avant, alors que `Section` rend toujours son
+ * en-tête au-dessus de son contenu.
+ *
+ * Le panneau ne porte qu'un seul lien, et il est `primary` : sur un fond
+ * `--color-accent-soft`, un lien `secondary` deviendrait invisible au survol, puisqu'il
+ * prend précisément cette couleur comme fond (mesure consignée dans docs/design.md).
+ */
+export function Contact({ contenu }: IContactProps) {
+  return (
+    <section aria-labelledby="contact-titre" className={styles.section} id="contact">
+      <Container>
+        <div className={styles.panneau}>
+          <h2 id="contact-titre">{contenu.titre}</h2>
+          <p className={styles.lead}>{contenu.lead}</p>
+          <ActionLink href={contenu.action.href}>{contenu.action.libelle}</ActionLink>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/front/src/views/offre/sections/Decision/decision.module.css
+++ b/front/src/views/offre/sections/Decision/decision.module.css
@@ -1,0 +1,25 @@
+/* Décision permise — panneau de profondeur fermant l'argument de l'offre. */
+
+.section {
+  padding-block: var(--space-section);
+}
+
+.panneau {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-width: 0;
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+
+  /* Le dégradé est un jeton : son angle et ses deux bornes sont décidés une seule
+   * fois, et il suit le thème sans être redéclaré ici. */
+  background-image: var(--gradient-depth);
+  box-shadow: var(--shadow-lg);
+  color: var(--color-depth-text);
+}
+
+.texte {
+  max-width: var(--layout-width-narrow);
+  font-size: var(--font-size-md);
+}

--- a/front/src/views/offre/sections/Decision/index.tsx
+++ b/front/src/views/offre/sections/Decision/index.tsx
@@ -1,0 +1,34 @@
+import { Container } from '@/@shared/components/Container'
+import type { IOffre } from '@/interfaces/offre'
+import type { IOffrePage } from '@/interfaces/offre-page'
+import styles from './decision.module.css'
+
+interface IDecisionProps {
+  contenu: IOffrePage
+  offre: IOffre
+}
+
+/**
+ * Ce que le client peut trancher grâce à la prestation.
+ *
+ * Section à part entière, et non une ligne en pied de carte : la ligne éditoriale du
+ * CLAUDE.md fait de la décision permise la conclusion d'un bloc de service — « vendre
+ * une décision, pas une techno ». Elle mérite donc le même rang visuel que ce qu'elle
+ * conclut.
+ *
+ * Posée sur le dégradé de profondeur, sans aucun lien à l'intérieur : la profondeur
+ * bleutée marque ce qui explique, jamais ce qui fait agir (docs/design.md). L'action,
+ * elle, est dans le panneau de contact qui suit.
+ */
+export function Decision({ contenu, offre }: IDecisionProps) {
+  return (
+    <section aria-labelledby="decision-titre" className={styles.section} id="decision">
+      <Container>
+        <div className={styles.panneau}>
+          <h2 id="decision-titre">{contenu.titreDecision}</h2>
+          <p className={styles.texte}>{offre.decisionPermise}</p>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/front/src/views/offre/sections/Entete/entete.module.css
+++ b/front/src/views/offre/sections/Entete/entete.module.css
@@ -1,0 +1,19 @@
+/* Entête d'une page d'offre — porte le h1 et l'accroche. */
+
+.entete {
+  padding-block: var(--space-section);
+}
+
+.contenu {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.lead {
+  /* Longueur de ligne volontairement plus courte que le titre : c'est le texte que
+   * l'on lit vraiment, il doit tenir en quelques fixations de l'œil. */
+  max-width: var(--layout-width-narrow);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+}

--- a/front/src/views/offre/sections/Entete/index.tsx
+++ b/front/src/views/offre/sections/Entete/index.tsx
@@ -1,0 +1,30 @@
+import { Container } from '@/@shared/components/Container'
+import type { IOffre } from '@/interfaces/offre'
+import styles from './entete.module.css'
+
+interface IEnteteProps {
+  offre: IOffre
+}
+
+/**
+ * Ouverture d'une page d'offre : le seul `h1` du document et l'accroche.
+ *
+ * Rendue comme une région nommée par son propre titre (`aria-labelledby`) plutôt que
+ * comme un simple bloc : la liste des régions restituée par un lecteur d'écran reprend
+ * ainsi le plan visible de la page. Ce n'est pas un `@shared/Section`, qui ne sait
+ * titrer qu'en `h2` ou `h3` — le niveau `h1` appartient à la page.
+ *
+ * Aucun lien d'action ici, contrairement à l'accroche de l'accueil : la page se ferme
+ * sur son appel à contact, et le doubler en tête ajouterait un second lien au libellé
+ * identique sans rien apporter à un visiteur qui vient tout juste d'arriver.
+ */
+export function Entete({ offre }: IEnteteProps) {
+  return (
+    <section aria-labelledby="offre-titre" className={styles.entete} id="offre">
+      <Container className={styles.contenu}>
+        <h1 id="offre-titre">{offre.titre}</h1>
+        <p className={styles.lead}>{offre.accroche}</p>
+      </Container>
+    </section>
+  )
+}

--- a/front/src/views/offre/sections/Tarifs/index.tsx
+++ b/front/src/views/offre/sections/Tarifs/index.tsx
@@ -1,0 +1,52 @@
+import { Section } from '@/@shared/components/Section'
+import type { IGrilleTarifaire } from '@/interfaces/grille-tarifaire'
+import type { IOffrePage } from '@/interfaces/offre-page'
+import type { IPreuveResolue } from '@/interfaces/preuve-resolue'
+import { formaterMontant } from '@/utils/tarif'
+import styles from './tarifs.module.css'
+
+interface ITarifsProps {
+  contenu: IOffrePage
+  grille: IGrilleTarifaire
+  preuve: IPreuveResolue
+}
+
+/**
+ * La grille tarifaire d'une offre.
+ *
+ * AUCUN MONTANT N'EST ÉCRIT ICI, ni ailleurs dans le rendu. Chaque prix sort de
+ * `formaterMontant` (`utils/tarif.ts`), seul module du dépôt qui transforme un `Montant`
+ * en texte. Ce n'est pas une convention mais une garantie du typage : `formaterMontant`
+ * rend un `MontantAffichable`, type marqué qu'elle seule sait produire, et une chaîne
+ * littérale ne compile pas à cette place. La mention « TTC » sort donc collée au chiffre,
+ * dans la même chaîne : aucune mise en page ne peut la reléguer en note de bas de page,
+ * aucun rendu partiel ne peut l'oublier.
+ *
+ * Rendu en LISTE et non en tableau : deux lignes portent le même intitulé et ne se
+ * distinguent que par leur condition d'application. Un tableau aurait imposé un en-tête
+ * de colonne à inventer, et se serait mal replié sous 400 px — alors qu'une grille de
+ * prix est précisément ce qu'on lit sur un téléphone.
+ *
+ * La preuve qui appuie l'argument est RÉSOLUE, jamais recopiée : son texte reste écrit
+ * une seule fois, sur l'axe de l'offre qui le porte.
+ */
+export function Tarifs({ contenu, grille, preuve }: ITarifsProps) {
+  return (
+    <Section id="tarifs" title={contenu.titreTarifs} tone="muted">
+      <p className={styles.argument}>{grille.argument}</p>
+      <ul className={styles.lignes}>
+        {grille.lignes.map((ligne) => (
+          <li className={styles.ligne} key={ligne.cle}>
+            <p className={styles.intitule}>{ligne.intitule}</p>
+            <p className={styles.condition}>{ligne.condition}</p>
+            <p className={styles.montant}>{formaterMontant(ligne.montant)}</p>
+          </li>
+        ))}
+      </ul>
+      <div className={styles.preuve}>
+        <p className={styles.preuveLibelle}>{contenu.libellePreuveTarifs}</p>
+        <p className={styles.preuveEnonce}>{preuve.enonce}</p>
+      </div>
+    </Section>
+  )
+}

--- a/front/src/views/offre/sections/Tarifs/tarifs.module.css
+++ b/front/src/views/offre/sections/Tarifs/tarifs.module.css
@@ -1,0 +1,74 @@
+/* Grille tarifaire — lignes de prix posées sur une section au fond atténué. */
+
+.argument {
+  max-width: var(--layout-width-narrow);
+  margin-bottom: var(--space-lg);
+  color: var(--color-text-muted);
+}
+
+.lignes {
+  display: grid;
+
+  /* Le nombre de colonnes se déduit de la place disponible, sans point de rupture.
+   * `min()` empêche la piste de réclamer 16 rem quand le viewport est plus étroit —
+   * c'est ce qui évite le défilement horizontal à 320 px. */
+  grid-template-columns: repeat(auto-fit, minmax(min(16rem, 100%), 1fr));
+  gap: var(--space-md);
+  padding-left: 0;
+  list-style: none;
+}
+
+.ligne {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+  min-width: 0;
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.intitule {
+  font-weight: var(--font-weight-medium);
+}
+
+.condition {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* Le montant ferme la ligne. `margin-top: auto` l'aligne d'une colonne à l'autre,
+ * quelle que soit la longueur de l'intitulé ou de la condition au-dessus. */
+.montant {
+  margin-top: auto;
+  padding-top: var(--space-2xs);
+  color: var(--color-accent);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+}
+
+.preuve {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+  max-width: var(--layout-width-narrow);
+  margin-top: var(--space-lg);
+
+  /* 1 px : seule épaisseur de filet employée par le socle (voir Card, Preuves). */
+  border-left: 1px solid var(--color-accent);
+  padding-left: var(--space-sm);
+}
+
+.preuveLibelle {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.preuveEnonce {
+  color: var(--color-text);
+}


### PR DESCRIPTION
Closes #22

Répare les trois liens morts du site. La navigation, le pied de page et les cartes de l'accueil renvoyaient tous vers `/services/ingenierie-web`, `/services/data-ia` et `/services/sea` — un visiteur qui cliquait tombait sur une 404. C'était le défaut le plus visible du site.

Ces pages portent aussi le référencement de chaque métier, là où l'accueil porte le récit de la chaîne.

## Vérifié par exécution

```
/services/ingenierie-web     200
/services/data-ia            200
/services/sea                200

sitemap.xml  →  https://jeromemarichez.fr
                https://jeromemarichez.fr/services/data-ia
                https://jeromemarichez.fr/services/ingenierie-web
                https://jeromemarichez.fr/services/sea

grille servie →  Incluse
                 300 à 1 200 € TTC, une seule fois, selon le périmètre
                 Forfait mensuel, sur devis
```

## Arbitrage de routage

**Trois routes explicites** plutôt qu'une route dynamique `[cle]`. L'arborescence de `src/app/` reste lisible, et c'est précisément d'elle que dérive la découverte de routes du sitemap — vérifié ci-dessus, les trois pages y figurent.

## Ce que le code garantit, plutôt que la vigilance

**L'ordre des axes de Data & IA** est tenu par construction. `axes.service` groupe les axes par volet en découpant en suites contiguës : aucun tri, aucun rassemblement. La fiabilité puis la qualification des données restent donc avant l'IA — et cet ordre est le message de l'offre, pas une préférence esthétique.

**Aucun montant écrit à la main.** La grille passe par `utils/tarif.ts`, seul chemin qui garantit qu'un chiffre porte sa mention TTC : une chaîne littérale ne compile pas à cette place.

**Aucun texte éditorial en dur** : tout vient de `front/src/content/offres/`.

## Contrôles

`make lint`, `make typecheck`, `make test` (361) et `make build` passent.

Lot repris à la main après interruption de l'agent par une limite de session API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Lkzawdu7WwjAQxgKY2ar