### PR TITLE
fix(e2e): make test-e2e demarre la stack, et test des liens morts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@ coverage/
 storybook-static/
 .stryker-tmp/
 reports/
-cypress/screenshots/
-cypress/videos/
+# Chemins préfixés par « **/ » : en layout front-back, les artefacts Cypress vivent
+# dans front/cypress/ et non à la racine — un motif non ancré ne les attrape pas.
+**/cypress/screenshots/
+**/cypress/videos/
+**/cypress/downloads/
 *.tsbuildinfo
 
 # OS / IDE

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,22 @@ test-int: ## Tests d'intégration (front + back)
 	cd front && npx jest tests/integration --passWithNoTests
 	cd back && npx jest tests/integration --passWithNoTests
 
-test-e2e: ## Tests e2e navigateur (Cypress headless) — stack démarrée au préalable
+# La cible démarre elle-même le front : Cypress refuse de tourner tant que `baseUrl`
+# ne répond pas, et le workflow ci-main-e2e.yml n'a aucun autre moyen de le lancer.
+# Serveur de production (et non `next dev`) : c'est le rendu réellement livré qui doit
+# être mesuré. Le serveur est arrêté quoi qu'il arrive, y compris si Cypress échoue,
+# et le code de sortie de Cypress est celui de la cible — sans quoi un échec e2e
+# passerait inaperçu.
+test-e2e: ## Tests e2e navigateur (Cypress headless) — démarre le front, le teste, l'arrête
+	cd front && npm run build
+	@set -e; \
+	( cd front && npx next start -p 3000 >/dev/null 2>&1 ) & \
+	serveur=$$!; \
+	trap 'kill $$serveur 2>/dev/null || true' EXIT; \
+	for i in $$(seq 1 40); do \
+	  curl -sf -o /dev/null http://localhost:3000/ && break; \
+	  sleep 1; \
+	done; \
 	cd front && npx cypress run
 
 test-system: ## Tests système back (vrai serveur HTTP via listen(0))

--- a/front/cypress.config.ts
+++ b/front/cypress.config.ts
@@ -4,7 +4,9 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:3000', // TODO : port réel du front
+    // Port du serveur de production démarré par `make test-e2e`, qui attend que
+    // cette URL réponde avant de lancer Cypress.
+    baseUrl: 'http://localhost:3000',
     specPattern: 'tests/e2e/**/*.cy.ts',
     supportFile: false,
     video: false,

--- a/front/tests/e2e/navigation-et-mise-en-page.cy.ts
+++ b/front/tests/e2e/navigation-et-mise-en-page.cy.ts
@@ -1,0 +1,91 @@
+/**
+ * navigation-et-mise-en-page.cy.ts — jeromemarichez2026
+ *
+ * Intention : vérifier, dans un vrai navigateur, les trois propriétés que jsdom ne peut
+ * pas calculer et qu'aucun test unitaire ne couvre.
+ *
+ * 1. AUCUN LIEN MORT. Chaque destination annoncée par l'en-tête et le pied de page
+ *    répond réellement. Le site a vécu plusieurs livraisons avec trois liens vers des
+ *    routes inexistantes : la navigation les annonçait, elles renvoyaient 404. Ce test
+ *    est la garde qui empêche que cela se reproduise au prochain ajout d'entrée.
+ * 2. LE LIEN D'ÉVITEMENT DÉPLACE LE FOCUS. Il doit être le premier élément focusable,
+ *    revenir dans le viewport une fois focalisé, et déplacer réellement le focus sur le
+ *    contenu principal — pas seulement faire défiler la page. Le focus est un état du
+ *    navigateur : jsdom ne le simule pas fidèlement.
+ * 3. AUCUN DÉBORDEMENT HORIZONTAL, de 320 à 1920 px. C'est une propriété de mise en
+ *    page réelle, mesurable seulement une fois le CSS appliqué par un moteur de rendu.
+ *
+ * Cas limites : les deux extrémités de la plage de largeurs (320 et 1920 px) ; une
+ * destination de navigation ajoutée sans page correspondante.
+ *
+ * Niveau : e2e (Cypress), contre le serveur de production réellement livré.
+ * Jeu de données : le site lui-même, tel qu'il est construit.
+ */
+
+const LARGEURS = [320, 768, 1440, 1920] as const
+
+describe('Navigation et mise en page', () => {
+  it('ne propose aucun lien mort dans l’en-tête et le pied de page', () => {
+    cy.visit('/')
+
+    cy.get('header a[href^="/"], footer a[href^="/"]').then(($liens) => {
+      const destinations = [
+        ...new Set([...$liens].map((lien) => lien.getAttribute('href') ?? '')),
+      ].filter(Boolean)
+
+      // Une navigation vide passerait ce test sans rien vérifier.
+      expect(destinations.length, 'destinations internes trouvées').to.be.greaterThan(0)
+
+      for (const destination of destinations) {
+        cy.request({ url: destination, failOnStatusCode: false }).then((reponse) => {
+          expect(reponse.status, `GET ${destination}`).to.eq(200)
+        })
+      }
+    })
+  })
+
+  it('place le lien d’évitement en premier élément focusable et l’affiche au focus', () => {
+    cy.visit('/')
+
+    cy.get('a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])')
+      .first()
+      .should('have.attr', 'href', '#contenu')
+      .focus()
+
+    // `should` et non `then` : le lien revient par une transition CSS sur `transform`.
+    // Une mesure unique tomberait au milieu de l'animation — ici l'assertion est
+    // réessayée jusqu'à la position finale, ce qui teste bien l'état d'arrivée.
+    cy.get('a[href="#contenu"]').should(($lien) => {
+      const rect = $lien[0].getBoundingClientRect()
+      expect(rect.top, 'le lien revient dans le viewport une fois focalisé').to.be.at.least(0)
+      expect(rect.left).to.be.at.least(0)
+    })
+  })
+
+  it('déplace le focus sur le contenu principal quand on active le lien d’évitement', () => {
+    cy.visit('/')
+
+    cy.get('a[href="#contenu"]').focus().click()
+    cy.focused().should('have.id', 'contenu')
+  })
+
+  it('ne produit aucun défilement horizontal de 320 à 1920 px', () => {
+    for (const largeur of LARGEURS) {
+      cy.viewport(largeur, 900)
+      cy.visit('/')
+      cy.document().should((doc) => {
+        const racine = doc.documentElement
+        expect(racine.scrollWidth, `largeur ${largeur} px`).to.be.at.most(racine.clientWidth)
+      })
+    }
+  })
+
+  it('expose une structure de régions unique sur les pages d’offre', () => {
+    cy.visit('/services/sea')
+
+    cy.get('body > header').should('have.length', 1)
+    cy.get('body > main#contenu').should('have.length', 1)
+    cy.get('body > footer').should('have.length', 1)
+    cy.get('h1').should('have.length', 1)
+  })
+})


### PR DESCRIPTION
Le job **Tests e2e (Cypress)** ne pouvait pas passer, alors qu'il est **requis** par la protection de `main`. La mise en production était donc bloquée — et rien ne le signalait avant d'essayer.

## Deux causes cumulées

`make test-e2e` lançait `npx cypress run` **sans démarrer le serveur**, alors que `ci-main-e2e.yml` supposait l'inverse : son propre commentaire dit « doit démarrer la stack (front + back) avant Cypress headless », mais aucune commande ne le faisait. Cypress attendait une `baseUrl` qui ne répondait jamais.

Et le dossier `front/tests/e2e` était vide.

## Correctifs

- **La cible démarre le serveur de production** — pas `next dev` : c'est le rendu réellement livré qu'il faut mesurer. Elle attend que la `baseUrl` réponde, lance Cypress, puis arrête le serveur via un `trap`, y compris si Cypress échoue. Le code de sortie de Cypress reste celui de la cible, sans quoi un échec e2e passerait pour un succès.
- **`.gitignore`** : les motifs `cypress/` n'étaient pas ancrés. En layout front-back les artefacts vivent dans `front/cypress/`, donc les captures d'écran d'un échec entraient dans l'index. Même famille de défaut que les exclusions Biome corrigées à l'initialisation.

## Le test posé a trouvé un défaut réel

`navigation-et-mise-en-page.cy.ts` couvre ce que jsdom ne peut pas calculer : absence de lien mort, lien d'évitement qui **déplace le focus** et pas seulement le défilement, absence de débordement de 320 à 1920 px.

Résultat de la première exécution : **4 tests passent, 1 échoue** sur `GET /parcours → 404`.

Ce n'est pas un défaut du test. La navigation annonce `/parcours` et `/contact`, qui n'existent pas — et `/contact` est la destination de **tous** les appels à l'action du site. L'assertion n'est pas affaiblie : le lot suivant crée les deux pages.

Un second échec, lui, venait bien du test : je mesurais la position du lien d'évitement pendant sa transition CSS. Corrigé par une assertion qui réessaie jusqu'à la position finale.

## Contrôles

`make lint`, `make typecheck`, `make test` (533) passent. Cypress ne tourne que sur les PR vers `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Lkzawdu7WwjAQxgKY2ar