### PR TITLE
feat: refonte en chaîne à trois pôles, fil IA transverse et certifications sur plaque

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,83 @@
 
 ## Présentation
 
-Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.
+Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille :
+**Ingénierie Web**, **Data & IA**, **SEO/SEA**.
 
-<!-- TODO : compléter — périmètre fonctionnel, contraintes techniques, choix retenus. -->
+Le site raconte un parcours (ingénieur logiciel, 9 ans, passé par la chefferie de projet
+et l'AMOA) et vend trois offres qui s'appuient dessus. Promesse centrale, à faire
+apparaître partout : **un seul interlocuteur humain pour vos projets digitaux, aucune
+sous-traitance** — celui qui cadre est celui qui code, mesure et exploite.
+
+Le **périmètre éditorial complet** (les trois offres en détail, les preuves chiffrées,
+les certifications, l'arborescence des pages, les contraintes SEO / perf / a11y / RGPD)
+est décrit dans le [`README.md`](./README.md) : c'est la **source de vérité du contenu**.
+Ce fichier-ci porte les règles qui encadrent la façon de l'écrire et de le développer.
 
 **Stack** : TypeScript — Next.js (App Router) (front) ; Node.js/TypeScript (back le cas
 échéant) ; **Zod** pour la validation des entrées.
 
+**Contraintes produit non négociables** : rendu statique ou ISR et métadonnées par page
+(SEO), Lighthouse ≥ 95 sur les 4 catégories, accessibilité RGAA / WCAG AA testée dans
+`uat/`, mesure d'audience conforme RGPD avec consentement. Le site est la démonstration
+de ce qu'il vend : un défaut de perf ou d'accessibilité y coûte plus cher qu'ailleurs.
+
 > Projet géré par Jérôme MARICHEZ.
+
+## Règles de véracité du contenu (bloquantes)
+
+Le site engage la réputation professionnelle de Jérôme et sera lu par des prospects et
+des recruteurs. **Aucune formulation ne doit dépasser ce qui est réellement établi**, même
+quand une formule plus large serait plus vendeuse. Ces règles priment sur toute
+considération marketing.
+
+**Ne JAMAIS écrire sur ce site :**
+
+| Interdit | Formulation juste |
+|----------|-------------------|
+| ISTQB niveau **Avancé** / Automatisation de test | **ISTQB Foundation** uniquement — l'Avancé n'est pas obtenu |
+| Management, lead ou mentorat de **développeurs** | Encadrement d'**équipes marketing / SEO-SEA, de prestataires externes, d'alternants et de stagiaires**. Titre réel : « Lead Tech » chez MailingVox (équipe de 2 devs + 1 PO) |
+| « en collaboration avec l'Universitat de Barcelona » | Méthode d'extraction audio **publiée sur arXiv**, qu'il a **implémentée lui-même** puis industrialisée |
+| LangChain, LlamaIndex, tout **framework** RAG | Le **RAG comme technique** est confirmé (recherche vectorielle PostgreSQL + API OpenAI), fait **maison** |
+| AppsFlyer, Adjust, Amplitude, Tealium, Adobe Launch / Analytics | Côté mobile : **Firebase Analytics et Crashlytics uniquement**. Côté web : GTM (web et server-side), Measurement Protocol, GA, Matomo, CMP |
+| Meta Ads, LinkedIn Ads | Google Ads, Bing Ads, SEO / SEA / SMA |
+| GraphQL, NestJS, Prisma, Gherkin / Cucumber, PyTorch | Voir la stack réellement revendiquée dans le `README.md` |
+| Cluster **Kubernetes** administré en propre | Cloud Run, VM Compute Engine **auto-scalées**, cloud functions, Pub/Sub, Vertex AI — l'absence de K8s se dit telle quelle, c'est un argument de lucidité |
+| GTM attribué à la période **Verhoeven Joaillier** | GTM appartient à la période **Acetelecom / MailingVox**. Chez Verhoeven : Google Analytics, A/B testing, heatmaps |
+
+**Points de vigilance supplémentaires :**
+
+- **Prézage** et **Llama 3** peuvent être **nommés** (autorisation explicite de Jérôme,
+  2026-08-07). Restent hors ligne : le contenu du corpus, les données, les chiffres du
+  projet — le NDA couvre ceux-là.
+- Les **intitulés de poste historiques** (Verhoeven Joaillier, Truffle Capital) sont
+  repris **à l'identique des CV**, sans réécriture pour coller à une offre de service.
+- Toute **certification affichée doit pointer vers son justificatif officiel**. Une URL
+  de certification ne s'invente ni ne s'approxime : tant qu'elle n'a pas été fournie par
+  Jérôme, le lien reste marqué *à fournir* et la certification n'est **pas** publiée avec
+  un lien mort.
+- Deux points restent **à confirmer avec Jérôme** avant mise en ligne : l'année exacte de
+  la certification Google Ads (2021 ou 2022 selon les CV) et l'existence d'une
+  certification **Microsoft Ads**.
+- Les **CV de référence** vivent dans `/Users/nicolasb/Documents/CV/`
+  (`cv-ingenieur-fullstack.md`, `cv-ai-engineer.md`, `cv-tracking-specialist.md`) : en cas
+  de doute sur un chiffre, une date ou un périmètre, ce sont eux qui font foi — pas la
+  mémoire de l'assistant.
+
+## Ligne éditoriale
+
+- **Vendre une décision, pas une techno.** Chaque bloc de service se termine sur ce que
+  le client peut trancher grâce à la prestation, jamais sur une liste d'outils.
+- **Chaque affirmation porte sa preuve** : un chiffre, une durée, une contrainte tenue.
+  Les preuves disponibles sont listées dans le `README.md` (panier moyen +50 %,
+  Lighthouse 98/100, budgets de 100 000 € pilotés, migrations sans coupure, fraude en
+  baisse). Une affirmation sans preuve disponible se reformule ou se supprime.
+- **Ton** : sobre, direct, à la première personne. Pas de superlatif, pas de jargon
+  d'agence, pas d'emoji dans le contenu publié.
+- **Le développement en IA augmentée** (Claude Code / Gemini — agents, hooks, skills,
+  loop, serveurs MCP) **piloté par les tests (TDD)** est un différenciateur assumé : il
+  apparaît partout où le site parle de programmation, jamais comme un détail
+  d'outillage.
 
 ## Méthode de travail (workflow Git)
 
@@ -208,3 +277,13 @@ make lint           # Biome + limite 300 lignes
 make test           # tous les niveaux de tests
 make docker-up      # stack conteneurisée
 ```
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ catalogue de trois prestations qu'on pourrait acheter à trois fournisseurs diff
 La chaîne n'est crédible **que** parce que c'est la même personne aux trois postes :
 c'est l'argument de vente, pas un détail d'organisation.
 
+#### Le fil IA — l'axe transverse
+
+Un troisième type de section, le **fil**, traverse les trois pôles au lieu de s'insérer
+entre deux. Il lève une confusion que le site crée lui-même : l'IA y apparaît comme
+**offre** (pôle 2) *et* comme **méthode de production** (les trois pôles). Le fil parle
+de la seconde, en quatre étapes — concevoir, construire, livrer, piloter — et se place
+avant le pôle 1 pour que la méthode se lise avant les offres.
+
+Sa règle d'écriture est bloquante : **l'IA propose, les tests tranchent**. Le pilotage
+SEA reste attribué à la donnée et aux modèles (clustering, profilage), jamais à un agent
+autonome. Le fil ne cite aucune preuve qui ne soit déjà portée par un pôle.
+
 ### 1. Ingénierie Web
 
 L'offre socle : concevoir, développer et exploiter un produit web ou mobile de bout en
@@ -201,7 +213,7 @@ confirmée, sans année connue.
 
 | Route | Rôle |
 |-------|------|
-| `/` | Accroche, promesse d'interlocuteur unique, la chaîne complète (3 pôles + 2 charnières), preuves chiffrées, limites assumées, certifications, appel à contact |
+| `/` | Accroche, promesse d'interlocuteur unique, le fil IA transverse, la chaîne complète (3 pôles + 2 charnières), preuves chiffrées, limites assumées, certifications, appel à contact |
 | `/services/ingenierie-web` | Pôle 1 en détail |
 | `/services/data-ia` | Pôle 2 en détail |
 | `/services/sea-ux` | Pôle 3 en détail |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,231 @@
-# jeromemarichez-fr
+# jeromemarichez.fr
 
-Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.
+Site portfolio et vitrine de services de **Jérôme Marichez**, ingénieur logiciel à Lille :
+ingénierie web, data & IA, SEA & UX.
 
 **Stack** : TypeScript — Next.js (App Router).
 
-<!-- TODO : 2-3 phrases sur ce que fait l'application, points clés. -->
+Le site a deux fonctions et une seule promesse. Il **raconte un parcours** — ingénieur
+logiciel, 9 ans, passé par la chefferie de projet et l'AMOA — et il **vend une chaîne à trois pôles**
+qui s'appuie dessus. La promesse : *un seul interlocuteur humain pour vos projets
+digitaux, aucune sous-traitance*. Celui qui cadre est celui qui code, mesure et exploite.
+
+---
+
+## 🎯 Positionnement
+
+| Ce qui est vendu | Ce qui le rend crédible |
+|------------------|-------------------------|
+| Un interlocuteur unique, pas une chaîne de prestataires | 9 ans en petite équipe ou en autonomie complète, décisions techniques assumées en production |
+| Du conseil qui va jusqu'au run | Trois migrations majeures menées sans interruption de service |
+| De la décision simplifiée, pas des tableaux de bord de plus | Double casquette rare : développeur produit **et** pilote d'acquisition |
+| De la mesure conforme | RGPD et DORA tenus en appels d'offres grands comptes |
+
+**Angle éditorial transverse** : ne jamais vendre une techno, toujours vendre une
+décision rendue possible. Chaque bloc de service se termine sur ce que le client
+*décide* grâce à la prestation, pas sur la liste d'outils employés.
+
+---
+
+## 🧩 Les trois pôles — une chaîne, pas un catalogue
+
+Ce ne sont **pas trois offres qu'on achète séparément**. C'est une prise en charge
+continue, où chaque pôle passe explicitement la main au suivant :
+
+| | Pôle | Ce qu'il fait | Ce qu'il remet au suivant |
+|---|------|---------------|---------------------------|
+| 1 | **Ingénierie web** | construire le site, le SaaS, l'application mobile — et les exploiter | un produit **en production**, donc mesuré : le run fait naître le besoin de data |
+| 2 | **Data & IA** | mettre la donnée au propre, puis y brancher les modèles et les LLM | une donnée **clarifiée**, donc arbitrable |
+| 3 | **SEA & UX** | trancher les parcours et les budgets sur cette donnée, puis implémenter | la modification **retourne au pôle 1** — même personne, aucun transfert de dossier |
+
+Les deux jointures — appelées **charnières** dans le site — sont traitées comme des
+sections à part entière, avec leur propre titre. Sans elles, l'offre redevient un
+catalogue de trois prestations qu'on pourrait acheter à trois fournisseurs différents.
+La chaîne n'est crédible **que** parce que c'est la même personne aux trois postes :
+c'est l'argument de vente, pas un détail d'organisation.
+
+### 1. Ingénierie Web
+
+L'offre socle : concevoir, développer et exploiter un produit web ou mobile de bout en
+bout. Elle mobilise toutes les compétences du parcours.
+
+- **UI / UX** — maquettage et design system, catalogue de composants (Storybook),
+  accessibilité **RGAA / WCAG / W3C**, refonte de parcours pilotée par la mesure
+  (A/B testing, heatmaps, taux de rebond). *Preuve : panier moyen +50 % sur un
+  e-commerce de joaillerie de luxe.*
+- **Front-end** — React, Next.js avec stratégie de rendu différenciée par type de page
+  (CSR / SSR / SSG / ISR) pour arbitrer performance perçue, coût serveur et
+  référencement ; Angular, Ionic (iOS / Android), Redux / Zustand / React Query,
+  Tailwind, Material UI. *Preuve : Lighthouse 98/100.*
+- **Back-end** — Node.js / Express, API REST, webhooks, cloud functions, traitements
+  asynchrones distribués (Google Cloud Pub/Sub), PostgreSQL (relationnel, séries
+  temporelles, vectoriel), MySQL, Firebase, validation Zod.
+- **Architecture & exploitation** — arbitrage monolithe / microservices, Docker, CI/CD
+  GitHub Actions, Google Cloud (Cloud Run, VM Compute Engine auto-scalées, cloud
+  functions, Pub/Sub), Vercel, serveurs on-premise et IaaS. SLI / SLO / SLA, PCA et PRA
+  testés, déploiements sans interruption de service.
+- **Qualité** — développement **piloté par les tests (TDD)**, Jest, Cypress, Playwright,
+  tests de mutation (Stryker), Postman, tests de performance et de charge,
+  non-régression à chaque livraison. Certification **ISTQB Foundation**.
+- **Migrations sans coupure** — PHP 5 → 7 puis réécriture Node.js, jQuery → React,
+  Ionic 6 → 8 et Angular 15 → 19, chacune menée sans interruption ni gel de la roadmap.
+- **Chefferie de projet & AMOA** — recueil du besoin, spécifications, **BPMN 2.0**,
+  cartographie SI, matrice de risques, recette et tests d'acceptation (UAT),
+  coordination d'une équipe marketing de 5 à 10 personnes et de 3 prestataires.
+- **Développement en IA augmentée** — Claude Code et Gemini au quotidien (agents,
+  hooks, skills, loop, serveurs MCP internes), piloté par les tests. Vélocité
+  augmentée à effectif constant.
+
+### 2. Data & IA
+
+Mettre l'IA **en production**, dans des produits vendus, avec les contraintes qui vont
+avec : coût d'inférence, latence, RGPD, disponibilité. Pas dans des notebooks.
+
+- **LLM en production** — Claude (Vertex AI, API Anthropic), OpenAI, Gemini, Llama.
+  Context engineering, comparaison continue des modèles et arbitrage
+  **coût / latence / qualité / confidentialité** par cas d'usage.
+- **Adaptation de modèles** — fine-tuning de **Llama 3** sur corpus métier pour
+  l'application mobile *Prézage*, complété par un procédé maison d'augmentation du
+  contexte proche du RAG. Objectif métier tenu : charge de travail des prestataires
+  réduite.
+- **RAG documentaire** — réponse automatisée aux tickets de support de niveau 1 sur
+  l'ensemble des produits : recherche vectorielle PostgreSQL + API OpenAI, réponses
+  ancrées sur la documentation interne et non sur la mémoire du modèle.
+- **Agents & interopérabilité** — conception, développement **et documentation** de
+  serveurs **MCP** et de plugins **n8n / Make / Zapier** : le produit devient appelable
+  par un agent IA ou un scénario no-code chez le client.
+- **Machine learning** — modèle supervisé anticipant les échecs de dépôt vocal, en
+  production (TensorFlow, inférence en cloud functions) : extraction des
+  caractéristiques du signal audio selon une méthode publiée sur **arXiv** par
+  l'Universitat de Barcelona, implémentée, adaptée aux données réelles puis
+  industrialisée. Routes vocales coûteuses évitées.
+- **Data mining & règles métier** — analyse exploratoire sous Orange Data Mining,
+  pondération et sélection des variables, élimination des corrélations fortes et du
+  bruit, puis règles implémentées dans le produit. *Preuve : fraude en baisse,
+  conversion des inscriptions en hausse, latence réduite.*
+- **Data engineering** — pipelines d'ingestion, nettoyage, dédoublonnage, agrégation et
+  réconciliation multi-sources. La qualité de la donnée est traitée comme un
+  **prérequis**, pas comme un correctif : contrôles d'intégrité et de véracité dès
+  l'ingestion, détection d'anomalies.
+- **MLOps & cloud** — déploiement, versioning et monitoring de modèles, CI/CD Docker et
+  GitHub Actions, Vertex AI, Pub/Sub, Cloud Run, VM auto-scalées.
+- **Conformité** — RGPD et DORA, exigés en appels d'offres grands comptes
+  (distribution, assurance, banque).
+
+### 3. SEA & UX
+
+L'offre acquisition **et arbitrage**, tenue par un ingénieur des données. C'est ce qui
+la différencie d'une agence : la mesure n'est pas déclarative, elle est construite dans
+le code.
+
+> **Point de vigilance éditorial numéro un.** *UX* ne veut **pas** dire design
+> graphique. Jérôme ne vend **aucune** création visuelle, aucune direction artistique,
+> aucune maquette livrée en fichier. Ce qu'il vend, ce sont des **arbitrages** pris sur
+> la donnée : quel parcours, quelle étape supprimée, quel formulaire raccourci, quel
+> test A/B tranché, quelle page rendue en SSR plutôt qu'en CSR — puis implémentés par
+> lui-même. Toute formulation qui laisserait planer un doute là-dessus est à réécrire.
+
+- **Mesure et taggage** — Google Tag Manager conteneur **web et server-side**,
+  dataLayer, Measurement Protocol, plan de taggage et nomenclature d'événements
+  standardisée, documentée et opposable. Google Analytics, Matomo, Search Console,
+  et côté mobile Firebase Analytics / Crashlytics.
+- **Conformité by design** — RGPD, CMP et gestion du consentement (déclenchement
+  conditionnel des tags par catégorie), cadrage des traitements avec le juridique.
+  La conformité n'est pas une case à cocher après coup : elle conditionne l'architecture
+  de collecte.
+- **LTV, pas one-shot** — système d'analyse multi-sources (SEO, SEA, IA) conforme RGPD :
+  agrégation des sources d'acquisition, réconciliation et dédoublonnage des identités,
+  mesure de la **rentabilité client à long terme**. Les budgets sont arbitrés sur la
+  rentabilité réelle, pas sur les métriques natives des régies.
+- **Solutions sur mesure multi-source** — pas de connecteur générique : la donnée est
+  agrégée depuis les régies (Google Ads, Bing Ads), le produit et le CRM, puis
+  réconciliée selon le modèle métier du client.
+- **Tableaux de bord personnalisés** — un dashboard par client et par produit, pas un
+  gabarit. Data visualisation et **clustering / profilage clients** (KNN) pour rendre
+  la décision lisible : ce que le dirigeant doit trancher apparaît, le reste
+  disparaît.
+- **SEA & pilotage** — Google Ads, Bing Ads, SEO / SEA / SMA, A/B testing, optimisation
+  du taux de conversion. *Budgets pilotés : 100 000 € ADS/SEO chez Truffle Capital,
+  ~25 000 € d'encadrement de prestataires SEA chez Verhoeven Joaillier.*
+- **Arbitrages UX** — refonte de parcours pilotée par la mesure : A/B testing des pages
+  et des designs, heatmaps, taux de rebond, part de trafic mobile. Une étape disparaît
+  parce que les chiffres le disent. *Preuve : panier moyen +50 % chez Verhoeven
+  Joaillier.* Et comme c'est la même personne qui code, l'arbitrage décidé est
+  **implémenté**, pas transmis à un tiers — c'est ce qui boucle la chaîne sur le pôle 1.
+- **SEO technique** — stratégie de rendu Next.js par type de page, Core Web Vitals,
+  Lighthouse, accessibilité — le référencement traité comme une propriété du produit.
+
+---
+
+## 🚫 Les limites assumées
+
+Le site porte une section **« Ce que je ne fais pas »** ([`src/@vitrine/contenu/limites.ts`](./src/@vitrine/contenu/limites.ts)).
+Ce n'est pas un aveu, c'est l'argument qui rend le reste croyable : un prestataire qui
+sait tout faire ne sait rien faire.
+
+Chaque ligne y traduit une règle de véracité du [`CLAUDE.md`](./CLAUDE.md) — pas de
+cluster Kubernetes administré en propre, pas de framework RAG tiers, pas de création
+graphique, une seule chaîne d'outillage de mesure mobile, ISTQB Foundation et rien
+au-delà.
+
+**Règle de rédaction de cette section** : elle énonce ce qui est fait, elle ne **nomme
+jamais** un outil ou un niveau de certification proscrit par la table de véracité, même
+sous forme de négation. « Deux régies publicitaires, pas douze » plutôt que la liste de
+celles qui ne sont pas couvertes. Le test d'intégration `veracite-contenu.spec.ts`
+échoue si un terme proscrit réapparaît où que ce soit dans le contenu publié.
+
+---
+
+## 🎓 Certifications à mettre en avant
+
+Chaque certification doit être **cliquable vers son justificatif officiel**. Aucune URL
+n'ayant été fournie à ce jour, les sept certifications sont publiées **sans lien**, avec
+la mention « justificatifs communiqués sur demande » : un lien mort coûterait plus cher
+que l'absence de lien. Les millésimes ont été arbitrés par Jérôme le **2026-08-20** —
+Google Ads en 2021 (le CV Tracking Specialist indiquait 2022) et Microsoft Ads
+confirmée, sans année connue.
+
+| Certification | Année | Lien officiel |
+|---------------|-------|---------------|
+| Claude with Google Cloud's Vertex AI | 2026 | *à fournir* |
+| ISTQB **Foundation** (niveau Avancé **non** obtenu) | 2026 | *à fournir* |
+| Google Analytics Individual Qualification (GAIQ) | 2021 | *à fournir* |
+| Google Ads | 2021 | *à fournir* |
+| Microsoft Ads | — | *à fournir* |
+| WeLoveDev — Top 5 % React | 2023 | *à fournir* |
+| EF SET — Anglais B2 (CECRL) | — | *à fournir* |
+
+---
+
+## 🗺️ Arborescence prévue
+
+| Route | Rôle |
+|-------|------|
+| `/` | Accroche, promesse d'interlocuteur unique, la chaîne complète (3 pôles + 2 charnières), preuves chiffrées, limites assumées, certifications, appel à contact |
+| `/services/ingenierie-web` | Pôle 1 en détail |
+| `/services/data-ia` | Pôle 2 en détail |
+| `/services/sea-ux` | Pôle 3 en détail |
+| `/parcours` | *(pas encore construite)* Parcours d'ingénieur et de chef de projet, formation |
+| `/contact` | *(pas encore construite)* Formulaire (validation Zod) + coordonnées directes. En attendant, l'accueil et le pied de page portent un `mailto:` direct |
+
+Chaque page de service porte ses propres métadonnées SEO, ses données structurées
+(`schema.org/Service` et `ProfessionalService`) et un appel à contact contextualisé.
+
+## ✅ Contraintes produit
+
+- **SEO** : rendu statique ou ISR par défaut, métadonnées et données structurées par
+  page, sitemap et robots générés.
+- **Performance** : Lighthouse ≥ 95 sur les 4 catégories, Core Web Vitals au vert —
+  le site est lui-même la démonstration de ce qui est vendu.
+- **Accessibilité** : RGAA / WCAG AA, testée et non supposée (`uat/`).
+- **RGPD** : mesure d'audience conforme, consentement géré, aucune donnée personnelle
+  collectée hors formulaire de contact explicite.
+
+Le contenu éditorial doit respecter les **règles de véracité** listées dans
+[`CLAUDE.md`](./CLAUDE.md) — ce qui n'est pas revendicable n'est pas écrit, même quand
+la formule serait vendeuse.
+
+---
 
 ## 🚀 Pour lancer l'application
 
@@ -30,18 +251,21 @@ make install        # dépendances
 make dev            # démarrage en mode développement
 ```
 
-<!-- TODO : URLs locales (front, API), variables d'environnement requises (.env.example). -->
+L'application est servie sur **http://localhost:3000**. Les variables d'environnement
+requises sont décrites dans `.env.example` (elles sont validées par un schéma Zod au
+démarrage).
 
 ## 🧪 Tests & qualité
 
 ```bash
-make lint           # Biome + limite 300 lignes/fichier
-make test           # unitaires + intégration
-make test-unit      # unitaires
-make test-int       # intégration
-make test-e2e       # e2e (navigateur)
-make test-system    # système (vrai serveur HTTP)
-make test-mutation  # mutation (Stryker)
+make lint             # Biome + limite 300 lignes/fichier
+make test             # unitaires + intégration
+make test-unit        # unitaires
+make test-int         # intégration
+make test-e2e         # e2e (navigateur)
+make test-system      # système (vrai serveur HTTP)
+make test-acceptance  # acceptation / non-fonctionnels (uat/)
+make test-mutation    # mutation (Stryker)
 ```
 
 La stratégie complète (niveaux, conventions d'emplacement et de nommage) est

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,11 +1,32 @@
 # Architecture
 
-<!-- TODO : compléter à mesure que le projet prend forme. -->
-
 ## Vue d'ensemble
 
-Décrire ici : les grands blocs (front React, back API, base de données), leurs
-responsabilités et les flux entre eux (schéma bienvenu).
+Site **vitrine** : l'essentiel est du contenu éditorial rendu statiquement. Il n'y a ni
+base de données ni authentification — la seule surface dynamique est le formulaire de
+contact.
+
+```
+Visiteur ──► Pages statiques (SSG)          ── contenu des offres, parcours, certifications
+         └─► POST /api/contact (route API)  ── validation Zod ──► envoi du message
+```
+
+**Conséquence structurante** : tout ce qui peut être prérendu l'est. Une page qui exige
+du rendu serveur doit le justifier — c'est la contrainte SEO et performance du
+`README.md` qui commande, et le site est lui-même la démonstration de ce qu'il vend.
+
+### Découpage par domaine
+
+| Domaine | Contenu |
+|---------|---------|
+| `src/@vitrine/` | Sections éditoriales : offres, parcours, preuves, certifications |
+| `src/@contact/` | Formulaire, schéma Zod, service d'envoi |
+| `src/@shared/` | Design system, layout, composants transverses, SEO/métadonnées |
+
+Le **contenu éditorial est de la donnée, pas du JSX** : offres, expériences et
+certifications vivent dans des structures typées (`src/interfaces/`, une entité par
+fichier, préfixe `I`) que les composants consomment. Ajouter une certification ou une
+offre ne doit pas demander de toucher au rendu.
 
 ## Front (Next.js (App Router) + TypeScript)
 
@@ -50,4 +71,9 @@ responsabilités et les flux entre eux (schéma bienvenu).
 
 | Choix | Alternatives considérées | Justification |
 |-------|--------------------------|---------------|
-| _TODO_ | | |
+| **Next.js (App Router)** | Vite + React, Astro | Rendu statique et métadonnées par page nativement, stratégie de rendu arbitrable route par route — exactement l'argument SEO vendu dans l'offre. C'est aussi la stack mise en avant sur le site : la cohérence compte. |
+| **Rendu statique (SSG) par défaut** | SSR systématique | Contenu éditorial quasi figé. Coût serveur nul, TTFB minimal, Core Web Vitals au vert sans effort d'optimisation ultérieur. |
+| **Pas de base de données** | CMS headless (Strapi), Notion API | Le contenu change quelques fois par an et n'a qu'un seul auteur. Le versionner dans le dépôt le rend relisible en revue de PR et supprime une dépendance d'exploitation. À réévaluer si la publication devient fréquente. |
+| **Contenu typé en TypeScript** | Fichiers Markdown / MDX | Les entités (offre, expérience, certification) ont une forme stricte que le typage fait respecter — un lien de certification manquant devient une erreur de compilation, pas une page publiée avec un lien mort. |
+| **Zod sur `/api/contact`** | Validation manuelle | Seule entrée externe du site, donc seule surface d'attaque : elle est validée à la frontière, type dérivé par `z.infer`. |
+| **Hébergement** | _à trancher_ | Vercel (affinité Next.js, previews par PR) ou le VPS Hetzner existant. Décision à prendre avant la première mise en production. |

--- a/docs/design.md
+++ b/docs/design.md
@@ -115,6 +115,7 @@ personnalisé.
 | Geste | Où | Détail |
 |-------|-----|--------|
 | **Tracer** | les deux charnières | filet cuivre 2px, `scaleY(0)` → `scaleY(1)`, 700ms. Seul mouvement porteur de sens : la chaîne se trace |
+| **Traverser** | le fil IA | filets cuivre **horizontaux**, `scaleX(0)` → `scaleX(1)`, même durée. Perpendiculaires à ceux des charnières : la chaîne descend, le fil la coupe — la géométrie dit « ceci n'est pas une quatrième offre » |
 | **Pivoter** | la scène WebGL | rotation interpolée sur l'avancement du défilement du premier écran |
 | **Micro-états** | liens et boutons | épaisseur de soulignement, `translateY(-1px)`, 120 à 140ms — aucun déplacement de mise en page |
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,54 +1,156 @@
 # Design & UI
 
-<!-- TODO : compléter avec la charte du projet (bibliothèque UI, tokens réels). -->
+Direction retenue : **« L'Établi »**. Le site est un plan de travail vu à travers des
+panneaux de verre — on voit littéralement au travers parce qu'il n'y a rien à cacher,
+ni chaîne de prestataires ni couche commerciale. Les trois pôles ne sont pas trois
+offres côte à côte : ce sont trois plaques alignées dans le même axe, tenues par un
+liseré de cuivre.
+
+Le verre ne réfracte **jamais du texte**, seulement le fond d'atelier (dégradé + trame
+technique). La transparence reste visible, la lisibilité reste intacte : c'est
+exactement l'arbitrage que le site vend, appliqué à lui-même.
 
 ## Principes
 
-- **Cohérence** : composants réutilisables, tokens de design centralisés
-  (couleurs, espacements, typographie).
-- **Responsive** : mobile-first, breakpoints documentés.
-- **Thème** : clair/sombre si pertinent.
+- **Cohérence** : composants réutilisables, jetons de design centralisés dans
+  [`src/app/globals.css`](../src/app/globals.css). Aucune couleur, aucun espacement,
+  aucune taille en dur dans un composant.
+- **Responsive** : mobile-first. La scène WebGL et le verre réfractant sont des
+  **enrichissements desktop**, jamais des prérequis de lecture.
+- **Thème** : clair et sombre, via `prefers-color-scheme`. Les deux palettes sont
+  complètes et vérifiées en contraste — aucune couleur n'est définie dans un seul thème.
 
 ## Bibliothèque UI
 
-Choisir **une** bibliothèque et s'y tenir (ne pas mélanger plusieurs systèmes) :
+Aucune bibliothèque de composants. Le site est une vitrine de six écrans : importer un
+système entier coûterait plus en poids et en contraintes qu'il ne ferait gagner.
 
 | Choix | Notes |
 |-------|-------|
-| _TODO (ex. shadcn/ui, PrimeReact, MUI…)_ | |
+| Composants maison | `src/@shared/components/` (transverse) et `src/@vitrine/components/` (éditorial) |
+| **liquidGL** (NaughtyDuk, MIT) | Verre réfractant WebGL — voir la section dédiée ci-dessous |
+| **three** + **@react-three/fiber** | Scène 3D des trois dalles, chargée en différé |
 
 ## Stratégie de style
 
-Une **seule** stratégie par projet, cohérente avec [`frontend-practices.md`](./frontend-practices.md) :
+**CSS Modules** : un `*.module.css` co-localisé avec chaque composant, classes en
+français, valeurs issues des jetons.
 
-| Stratégie | Quand | Convention |
-|-----------|-------|------------|
-| **CSS Modules** | style scopé, sans lib CSS-in-JS | `Composant/index.module.css` co-localisé, classes en **BEM** |
-| **styled / emotion** | design system type MUI | thème centralisé, pas de style en dur |
-| **Utilitaire (Tailwind…)** | prototypage rapide, design tokens intégrés | classes utilitaires, `@apply` pour les motifs récurrents |
-
-Règles communes : style **co-localisé** avec le composant, **mobile-first**, valeurs
-issues des **tokens** ci-dessous (jamais de couleur/espacement en dur).
+**Une seule exception**, documentée et bornée : la classe `.glass-surface`
+([`src/app/glass-surface.css`](../src/app/glass-surface.css)) est **globale**. liquidGL
+retrouve ses lentilles par un sélecteur CSS littéral au montage — un nom haché par CSS
+Modules ne serait jamais trouvé. Aucune autre classe globale n'est autorisée.
 
 ## Breakpoints
 
-| Nom | Largeur min | Usage |
-|-----|-------------|-------|
-| `sm` | 640px | mobile paysage |
-| `md` | 768px | tablette |
-| `lg` | 1024px | desktop |
-| `xl` | 1280px | large desktop |
+| Nom | Largeur | Usage |
+|-----|---------|-------|
+| `720px` | mobile / tablette | l'en-tête passe en colonne |
+| `900px` | tablette | le décalage en diagonale du schéma de chaîne est supprimé |
+| `1024px` | desktop | **seuil d'activation** de la scène WebGL et du verre liquidGL |
 
-<!-- Ajuster aux breakpoints réels de la bibliothèque UI retenue. -->
+Le seuil de 1024px n'est pas esthétique : Safari devient instable dès qu'une lentille
+liquidGL dépasse la moitié du viewport — ce qui est le cas de toute carte pleine largeur
+sur mobile — et le coût GPU d'une capture plein document n'a aucune contrepartie sur un
+petit écran.
 
-## Tokens
+## Jetons
 
-| Token | Valeur (exemple) | Usage |
-|-------|------------------|-------|
-| `color-primary` | `#2563eb` | actions principales, liens |
-| `color-danger` | `#dc2626` | erreurs, suppression |
-| `space-unit` | `8px` | base des espacements (multiples : 8/16/24…) |
-| `radius-base` | `6px` | arrondis de cartes/boutons |
-| `font-body` | `system-ui, sans-serif` | texte courant |
+Valeurs réelles dans [`globals.css`](../src/app/globals.css). Les ratios de contraste
+ci-dessous sont ceux des couples texte/fond effectivement utilisés.
 
-<!-- Remplacer par les tokens réels du projet. -->
+### Couleurs — thème clair
+
+| Jeton | Valeur | Usage | Contraste sur `--fond` |
+|-------|--------|-------|------------------------|
+| `--fond` | `#F2EFE8` | fond de page, papier chaud | — |
+| `--fond-creux` | `#E7E2D7` | bandes de section en retrait | — |
+| `--encre` | `#14171A` | texte courant et titres | 15.67:1 |
+| `--encre-douce` | `#4A5157` | texte secondaire, chapôs | 7.02:1 |
+| `--cuivre` | `#8F4520` | liens, accents de texte, focus | 6.02:1 |
+| `--cuivre-vif` | `#B4623A` | **non-texte uniquement** : filets, arêtes | 3.85:1 |
+| `--signal` | `#1F5F52` | disponibilité, ligne « ce que vous tranchez » | 6.49:1 |
+
+### Couleurs — thème sombre
+
+| Jeton | Valeur | Contraste sur `--fond` |
+|-------|--------|------------------------|
+| `--fond` | `#0E1114` | — |
+| `--encre` | `#ECE7DE` (jamais `#FFF`) | 15.38:1 |
+| `--encre-douce` | `#9BA3AA` | 7.41:1 |
+| `--cuivre` | `#E08B4C` | 7.18:1 |
+| `--cuivre-vif` | `#F0A468` | 9.21:1 |
+| `--signal` | `#5FD1AE` | 10.12:1 |
+
+> `--cuivre-vif` en thème clair est à **3.85:1** : il passe le seuil AA des éléments
+> non textuels (3:1) mais **pas** celui du texte (4.5:1). Il ne doit jamais porter de
+> texte en thème clair.
+
+### Typographie
+
+Trois familles, chargées par `next/font/google` — donc auto-hébergées au build : aucune
+requête vers `fonts.googleapis.com`, rien à déclarer côté RGPD.
+
+| Rôle | Famille | Notes |
+|------|---------|-------|
+| Titres | **Fraunces** (variable) | `'SOFT' 0, 'WONK' 0` — la fantaisie est retirée, il reste une antique ferme |
+| Corps | **Inter** (variable) | `'ss01' 1, 'cv05' 1` |
+| Annotations et chiffres | **IBM Plex Mono** | registre étiquette d'établi, `tabular-nums` sur les preuves |
+
+Échelle fluide en `clamp()`, base 16px : `--t--1` (13px) à `--t-4` (38→64px), plus
+`--t-chiffre` pour le mur de preuves. Mesures : 64ch sur le corps, 34ch sur les `h2`,
+20ch sur le `h1`, 46ch dans un panneau de verre.
+
+### Espaces et formes
+
+Rythme vertical sur base 8 : `--e-1` (8px) à `--e-7` (104px). `--rayon-verre` 18px,
+`--rayon-petit` 8px, `--largeur-page` 76rem.
+
+## Mouvement
+
+Le mouvement sert la lecture ou il n'existe pas. **Pas** de défilement détourné (ni
+Lenis ni Locomotive), pas de compteur qui s'incrémente, pas de parallaxe, pas de curseur
+personnalisé.
+
+| Geste | Où | Détail |
+|-------|-----|--------|
+| **Tracer** | les deux charnières | filet cuivre 2px, `scaleY(0)` → `scaleY(1)`, 700ms. Seul mouvement porteur de sens : la chaîne se trace |
+| **Pivoter** | la scène WebGL | rotation interpolée sur l'avancement du défilement du premier écran |
+| **Micro-états** | liens et boutons | épaisseur de soulignement, `translateY(-1px)`, 120 à 140ms — aucun déplacement de mise en page |
+
+Sous `prefers-reduced-motion: reduce` : les animations CSS sont coupées, la scène est
+rendue **figée** (une image, `uTime` gelé), et liquidGL **n'est pas amorcé du tout** —
+sa boucle de rendu permanente est une animation, même quand aucune lentille ne bouge.
+
+## Le verre liquidGL
+
+Réglages centralisés dans [`src/@shared/glass/settings.ts`](../src/@shared/glass/settings.ts).
+Trois contraintes de la bibliothèque sont tenues, et leur parade est explicite :
+
+| Contrainte réelle | Parade |
+|-------------------|--------|
+| Toutes les lentilles doivent partager le **même z-index** | `z-index: 2` posé une seule fois dans `glass-surface.css` ; aucun `z-index` local |
+| Les éléments `fixed` et `sticky` sont **ignorés** | L'en-tête collant utilise un `backdrop-filter` CSS, pas liquidGL |
+| Safari instable au-delà de **50 % du viewport** | Verre désactivé sous 1024px, et plafonné à 3 surfaces par page (`glass-policy.ts`) |
+| Les `<canvas>` sont **exclus de la capture** | La scène 3D n'est jamais placée derrière une surface de verre ; elle porte `data-liquid-ignore` |
+| Capture plein document, coût en carré de `resolution` | `resolution: 1.5` au lieu de 2.0 par défaut |
+| Aucune API de destruction | Démontage maison dans [`glass/teardown.ts`](../src/@shared/glass/teardown.ts) |
+
+Le repli `backdrop-filter` n'est pas un pis-aller : c'est le rendu **par défaut** sur
+mobile, sans WebGL et en mouvement réduit.
+
+## La scène WebGL
+
+Trois dalles de verre biseautées, décalées en profondeur, alignées dans le même axe :
+la thèse du site rendue en volume. Aucun texte, aucun logo, aucune particule.
+
+- **Géométrie** : `ExtrudeGeometry` avec biseau réel — c'est lui qui attrape la lumière.
+  ~600 triangles par dalle, géométrie construite une fois et partagée par les trois.
+- **Matériau** : un `ShaderMaterial` partagé, Fresnel non éclairé. **Pas** de
+  `transmission` : elle impose une passe de rendu et une cible de rendu par objet, sans
+  rapport avec le résultat cherché. Zéro lumière, zéro ombre, zéro texture.
+- **Chargement** : `next/dynamic` sans SSR, monté seulement à l'approche du viewport,
+  repli SVG inline tenant la place — donc zéro CLS et un LCP qui reste le `h1`.
+- **Dégradations** : viewport < 1024px, absence de WebGL, `saveData`, ou
+  `prefers-reduced-motion` → repli SVG ou image figée. Le conteneur est `aria-hidden` :
+  la scène ne porte aucune information que le texte ne donne déjà.

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,17 +1,32 @@
 // Configuration Jest — jeromemarichez-fr
 // Unitaire : tests/unitaire/**  —  Intégration : tests/integration/**
-// TODO : adapter transform/preset au scaffolding réel (ts-jest, next/jest ou babel).
+//
+// L'environnement par défaut est `jsdom` : la quasi-totalité du code testable est du
+// rendu React. Un test qui a besoin de Node (script, service pur) le déclare fichier
+// par fichier avec `@jest-environment node` en tête.
 
 /** @type {import('jest').Config} */
 export default {
-  testEnvironment: 'node', // 'jsdom' côté front (composants React)
+  testEnvironment: 'jsdom',
   roots: ['<rootDir>/tests'],
   testMatch: [
     '**/tests/unitaire/**/*.(test|spec).ts?(x)',
     '**/tests/integration/**/*.(test|spec).ts?(x)',
     '**/tests/systeme/**/*.test.ts',
   ],
-  transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }] },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: { jsx: 'react-jsx', esModuleInterop: true, module: 'commonjs' } },
+    ],
+  },
+  moduleNameMapper: {
+    // Les modules CSS n'ont pas de sens hors navigateur : chaque classe demandée rend
+    // son propre nom, ce qui suffit à vérifier qu'un composant applique la bonne.
+    '\\.module\\.css$': 'identity-obj-proxy',
+    '\\.css$': '<rootDir>/tests/fixtures/style-vide.js',
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
   coverageThreshold: {
     global: { branches: 80, functions: 80, lines: 80, statements: 80 },

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import './.next/types/routes.d.ts'
+import './.next/types/root-params.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11009 @@
+{
+  "name": "jeromemarichez-fr",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jeromemarichez-fr",
+      "version": "0.1.0",
+      "dependencies": {
+        "@react-three/fiber": "^9.7.0",
+        "liquid-gl": "^2.0.1",
+        "next": "^16.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "three": "^0.185.1",
+        "zod": "^4.0.0"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.0.0",
+        "@stryker-mutator/core": "^9.0.0",
+        "@stryker-mutator/jest-runner": "^9.0.0",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^24.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@types/three": "^0.185.4",
+        "cypress": "^15.0.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^30.0.0",
+        "jest-environment-jsdom": "^30.0.0",
+        "ts-jest": "^29.4.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
+      "integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.7",
+        "@biomejs/cli-darwin-x64": "2.5.7",
+        "@biomejs/cli-linux-arm64": "2.5.7",
+        "@biomejs/cli-linux-arm64-musl": "2.5.7",
+        "@biomejs/cli-linux-x64": "2.5.7",
+        "@biomejs/cli-linux-x64-musl": "2.5.7",
+        "@biomejs/cli-win32-arm64": "2.5.7",
+        "@biomejs/cli-win32-x64": "2.5.7"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
+      "integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
+      "integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
+      "integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
+      "integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
+      "integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
+      "integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
+      "integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
+      "integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cypress/request": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+      "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~4.0.4",
+        "http-signature": "~1.4.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "performance-now": "^2.1.0",
+        "qs": "^6.15.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "^5.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/@cypress/xvfb": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+      "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "lodash.once": "^4.1.1"
+      }
+    },
+    "node_modules/@cypress/xvfb/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+      "integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
+      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
+      "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.1.tgz",
+      "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/instrumenter": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "ajv": "~8.18.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.7.3",
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.1.tgz",
+      "integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~7.29.0",
+        "@babel/generator": "~7.29.0",
+        "@babel/parser": "~7.29.0",
+        "@babel/plugin-proposal-decorators": "~7.29.0",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
+        "@babel/preset-typescript": "~7.28.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "angular-html-parser": "~10.4.0",
+        "semver": "~7.7.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~1.3.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-9.6.1.tgz",
+      "integrity": "sha512-nIrIndfWwdweYkIcxJmyBTpl84nrXs9AE6A8vzEwwzUGvDb9kVvwBPfpEajtdAkjwPceH0pPuVrPkotvqcgYqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "semver": "~7.7.0",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "9.6.1"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
+      "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+      "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.4",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+      "integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/angular-html-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.4.0.tgz",
+      "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/blob-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "1.4.0"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cypress": {
+      "version": "15.20.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.20.0.tgz",
+      "integrity": "sha512-yrt6z9YERlggq5FReDx+PkbjrNoEQPeM03MQC1GvLlFGItk8ervC0A/7fjzWoWVRRXjsem+Pj3cunknARl/37g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cypress/request": "^4.0.0",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/sinonjs__fake-timers": "8.1.1",
+        "@types/sizzle": "^2.3.2",
+        "@types/tmp": "^0.2.3",
+        "arch": "^3.0.0",
+        "blob-util": "^2.0.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.7.1",
+        "cachedir": "^2.4.0",
+        "chalk": "^4.1.0",
+        "ci-info": "^4.1.0",
+        "cli-table3": "0.6.1",
+        "commander": "^6.2.1",
+        "common-tags": "^1.8.0",
+        "dayjs": "^1.10.4",
+        "debug": "^4.3.4",
+        "eventemitter2": "6.4.7",
+        "execa": "4.1.0",
+        "executable": "^4.1.1",
+        "fs-extra": "^9.1.0",
+        "hasha": "5.2.2",
+        "is-installed-globally": "~0.4.0",
+        "listr2": "^9.0.5",
+        "lodash": "^4.17.23",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.8",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
+        "proxy-from-env": "1.0.0",
+        "request-progress": "^3.0.0",
+        "supports-color": "^8.1.1",
+        "systeminformation": "^5.31.1",
+        "tmp": "~0.2.4",
+        "tree-kill": "1.2.2",
+        "untildify": "^4.0.0",
+        "yauzl": "^3.3.1"
+      },
+      "bin": {
+        "cypress": "bin/cypress"
+      },
+      "engines": {
+        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cypress/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cypress/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/cypress/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cypress/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cypress/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cypress/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/executable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.18.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-changed-files/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+      "integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/environment-jsdom-abstract": "30.4.1",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-validate/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/liquid-gl": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/liquid-gl/-/liquid-gl-2.0.1.tgz",
+      "integrity": "sha512-4HTE7uwAeTlT3VZe6gUSHrGpfIb8SivqQAG9TAel9HJp776rqHbEpgviFoaGsgf1KAsrIkQ/uyOuVxqixOWMZg==",
+      "license": "MIT"
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz",
+      "integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
+      "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.7.3"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
+      "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.3.0",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.5.23",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ospath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+      "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/request-progress": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "throttleit": "^1.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
+      "integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.5",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/typed-rest-client/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/weapon-regex": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
+      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+      "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,21 +10,26 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "@react-three/fiber": "^9.7.0",
+    "liquid-gl": "^2.0.1",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "three": "^0.185.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@stryker-mutator/core": "^9.0.0",
     "@stryker-mutator/jest-runner": "^9.0.0",
-    "cypress": "^15.0.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/three": "^0.185.4",
+    "cypress": "^15.0.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
     "ts-jest": "^29.4.0",

--- a/public/certifications/LISEZMOI.md
+++ b/public/certifications/LISEZMOI.md
@@ -1,0 +1,18 @@
+# Logos des organismes certificateurs
+
+Déposer ici les fichiers **SVG** (ou PNG à défaut) des logos, puis renseigner le champ
+`logo` de la certification correspondante dans `src/@vitrine/contenu/certifications.ts`.
+
+| Certification | Fichier attendu | Autorisation d'usage |
+|---|---|---|
+| ISTQB Foundation | `istqb.svg` | Badge « ISTQB Certified Tester » uniquement — le logo ISTQB seul n'est pas libre d'usage |
+| Claude with Google Cloud's Vertex AI | `google-cloud.svg` | Google Brand Permissions — usage encadré |
+| WeLoveDev — Top 5 % React | `welovedev.svg` | À vérifier auprès de WeLoveDev |
+| Google Analytics IQ | `google.svg` | Google Brand Permissions — usage encadré |
+| Google Ads | `google-ads.svg` | Google Brand Permissions — usage encadré |
+| Microsoft Ads | `microsoft.svg` | Microsoft Trademark Guidelines — usage encadré |
+| EF SET — Anglais B2 | `ef.svg` | À vérifier auprès de EF |
+
+**Tant qu'un fichier est absent, la certification s'affiche en toutes lettres.** C'est le
+comportement voulu : la même règle que pour les justificatifs — rien de cassé, rien
+d'approximatif. Aucun logo ne doit être publié sans l'autorisation correspondante.

--- a/src/@shared/components/ChainCanvas/SlabFallback.tsx
+++ b/src/@shared/components/ChainCanvas/SlabFallback.tsx
@@ -1,0 +1,46 @@
+// SlabFallback.tsx — jeromemarichez-fr
+// Le repli de la scène : la même composition, en SVG statique.
+//
+// Ce n'est pas un pis-aller réservé aux vieux navigateurs. C'est ce que voient, par
+// construction : les visiteurs sous mouvement réduit, ceux qui n'ont pas de WebGL,
+// ceux dont l'écran fait moins de 1024px, et tout le monde tant que la scène n'a pas
+// fini de se charger. Il doit donc tenir seul.
+
+import styles from './slab-fallback.module.css'
+
+/** Trois dalles décalées dans le même axe, liseré cuivre, ~1,4 ko. */
+export function SlabFallback() {
+  return (
+    <svg
+      className={styles.repli}
+      fill="none"
+      focusable="false"
+      role="presentation"
+      viewBox="0 0 340 420"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Trois dalles de verre alignées dans le même axe</title>
+      <defs>
+        <linearGradient id="dalle-lueur" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0" stopColor="currentColor" stopOpacity="0.16" />
+          <stop offset="0.55" stopColor="currentColor" stopOpacity="0.04" />
+          <stop offset="1" stopColor="currentColor" stopOpacity="0.14" />
+        </linearGradient>
+      </defs>
+
+      <g className={styles.groupe}>
+        <rect className={styles.arriere} height="290" rx="14" width="190" x="132" y="94" />
+        <rect className={styles.milieu} height="300" rx="15" width="200" x="76" y="66" />
+        <rect
+          className={styles.avant}
+          fill="url(#dalle-lueur)"
+          height="312"
+          rx="16"
+          width="210"
+          x="18"
+          y="38"
+        />
+      </g>
+    </svg>
+  )
+}

--- a/src/@shared/components/ChainCanvas/chain-canvas.module.css
+++ b/src/@shared/components/ChainCanvas/chain-canvas.module.css
@@ -1,0 +1,26 @@
+/* chain-canvas.module.css — réservation d'espace pour la scène WebGL.
+ * L'aspect-ratio est posé en CSS pour que la place soit tenue AVANT le chargement de
+ * la scène : sans lui, l'arrivée différée du canvas décalerait la mise en page et
+ * coûterait un CLS que ce site ne peut pas se permettre. */
+
+.conteneur {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  max-height: 34rem;
+}
+
+.conteneur canvas {
+  border-radius: var(--rayon-verre);
+}
+
+/* Le substitut n'est jamais montré : le conteneur est déjà `aria-hidden`. Il ne sert
+   qu'à documenter dans le DOM ce que la scène représente, pour la relecture. */
+.substitut {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/src/@shared/components/ChainCanvas/chain-canvas.module.css
+++ b/src/@shared/components/ChainCanvas/chain-canvas.module.css
@@ -3,8 +3,15 @@
  * la scène : sans lui, l'arrivée différée du canvas décalerait la mise en page et
  * coûterait un CLS que ce site ne peut pas se permettre. */
 
+/* `z-index: 3` : au-dessus du canvas de réfraction de liquidGL (posé sur `body` en
+   `position: fixed; z-index: 0`) et de ses canvas miroirs (z-index de la lentille
+   moins 1, donc 1). Sans lui, la scène 3D passe SOUS le calque de liquidGL et
+   disparaît dès que le verre est amorcé — alors qu'elle s'affiche parfaitement en
+   dessous de 1024px, où liquidGL ne tourne pas. Le piège est difficile à voir : la
+   scène ne casse que sur les écrans larges. */
 .conteneur {
   position: relative;
+  z-index: 3;
   width: 100%;
   aspect-ratio: 4 / 5;
   max-height: 34rem;

--- a/src/@shared/components/ChainCanvas/index.tsx
+++ b/src/@shared/components/ChainCanvas/index.tsx
@@ -7,7 +7,7 @@ import dynamic from 'next/dynamic'
 import { useEffect, useRef, useState } from 'react'
 import { hasWebGl } from '../../glass/support'
 import { useInViewport } from '../../hooks/use-in-viewport'
-import { useReducedMotion } from '../../hooks/use-reduced-motion'
+import { useMotionPaused } from '../../hooks/use-motion-paused'
 import styles from './chain-canvas.module.css'
 import { SlabFallback } from './SlabFallback'
 
@@ -41,7 +41,7 @@ interface ChainCanvasProps {
 export function ChainCanvas({ description }: ChainCanvasProps) {
   const conteneur = useRef<HTMLDivElement>(null)
   const visible = useInViewport(conteneur)
-  const reducedMotion = useReducedMotion()
+  const fige = useMotionPaused()
   const [capable, setCapable] = useState(false)
 
   useEffect(() => {
@@ -53,7 +53,7 @@ export function ChainCanvas({ description }: ChainCanvasProps) {
   return (
     <div aria-hidden="true" className={styles.conteneur} data-liquid-ignore ref={conteneur}>
       <span className={styles.substitut}>{description}</span>
-      {rendVolume ? <ChainScene fige={reducedMotion} /> : <SlabFallback />}
+      {rendVolume ? <ChainScene fige={fige} /> : <SlabFallback />}
     </div>
   )
 }

--- a/src/@shared/components/ChainCanvas/index.tsx
+++ b/src/@shared/components/ChainCanvas/index.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+// ChainCanvas/index.tsx — jeromemarichez-fr
+// Enveloppe de chargement de la scène WebGL, et son repli.
+
+import dynamic from 'next/dynamic'
+import { useEffect, useRef, useState } from 'react'
+import { hasWebGl } from '../../glass/support'
+import { useInViewport } from '../../hooks/use-in-viewport'
+import { useReducedMotion } from '../../hooks/use-reduced-motion'
+import styles from './chain-canvas.module.css'
+import { SlabFallback } from './SlabFallback'
+
+/**
+ * `three` et `@react-three/fiber` pèsent plusieurs centaines de kilo-octets : ils sont
+ * chargés en différé, sans rendu serveur, et seulement quand la scène approche du
+ * viewport. Le repli SVG tient la place entre-temps, donc l'échange ne coûte aucun CLS.
+ */
+const ChainScene = dynamic(() => import('../../three/ChainScene').then((m) => m.ChainScene), {
+  ssr: false,
+  loading: () => <SlabFallback />,
+})
+
+/** En dessous, la scène n'est jamais montée : le budget mobile ne paie pas le WebGL. */
+const LARGEUR_MINIMALE = 1024
+
+interface ChainCanvasProps {
+  /** Ce que la scène représente. Documenté dans le DOM, jamais annoncé — c'est un décor. */
+  description: string
+}
+
+/**
+ * Décor, jamais information.
+ *
+ * La scène ne porte aucun contenu que le texte de la page ne dise déjà : elle est
+ * masquée aux technologies d'assistance, et son absence — mouvement réduit, pas de
+ * WebGL, écran étroit, mode économie de données, JavaScript coupé — ne retire rien à
+ * la compréhension. C'est la condition pour qu'une scène 3D soit acceptable sur un
+ * site qui vend de l'accessibilité tenue.
+ */
+export function ChainCanvas({ description }: ChainCanvasProps) {
+  const conteneur = useRef<HTMLDivElement>(null)
+  const visible = useInViewport(conteneur)
+  const reducedMotion = useReducedMotion()
+  const [capable, setCapable] = useState(false)
+
+  useEffect(() => {
+    setCapable(window.innerWidth >= LARGEUR_MINIMALE && !isSaveData() && hasWebGl())
+  }, [])
+
+  const rendVolume = capable && visible
+
+  return (
+    <div aria-hidden="true" className={styles.conteneur} data-liquid-ignore ref={conteneur}>
+      <span className={styles.substitut}>{description}</span>
+      {rendVolume ? <ChainScene fige={reducedMotion} /> : <SlabFallback />}
+    </div>
+  )
+}
+
+/** Mode économie de données : on ne télécharge pas 180 ko pour un décor. */
+function isSaveData(): boolean {
+  const connexion = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection
+  return connexion?.saveData === true
+}

--- a/src/@shared/components/ChainCanvas/slab-fallback.module.css
+++ b/src/@shared/components/ChainCanvas/slab-fallback.module.css
@@ -1,0 +1,27 @@
+/* slab-fallback.module.css — repli SVG des trois dalles.
+ * Les couleurs viennent des jetons : le repli suit le thème clair et sombre comme le
+ * reste, il n'a pas de palette à lui. */
+
+.repli {
+  width: 100%;
+  height: 100%;
+  color: var(--encre);
+}
+
+.groupe rect {
+  stroke-width: 1;
+}
+
+.arriere {
+  fill: color-mix(in srgb, var(--encre) 3%, transparent);
+  stroke: color-mix(in srgb, var(--encre) 14%, transparent);
+}
+
+.milieu {
+  fill: color-mix(in srgb, var(--encre) 4%, transparent);
+  stroke: color-mix(in srgb, var(--encre) 18%, transparent);
+}
+
+.avant {
+  stroke: var(--verre-arete);
+}

--- a/src/@shared/components/GlassSurface/glass-class.ts
+++ b/src/@shared/components/GlassSurface/glass-class.ts
@@ -1,0 +1,14 @@
+// glass-class.ts — jeromemarichez-fr
+// Nom de la classe de verre, isolé pour rester synchronisé avec le sélecteur liquidGL.
+
+import { GLASS_TARGET } from '../../glass/settings'
+
+/**
+ * Classe globale — et non un module CSS.
+ *
+ * liquidGL cible les lentilles par un sélecteur CSS littéral au moment du montage :
+ * un nom de classe haché par CSS Modules ne serait jamais retrouvé. C'est la seule
+ * exception à la règle « style co-localisé et scopé » de `docs/frontend-practices.md`,
+ * et elle est bornée à cette classe-là, définie dans `styles/glass-surface.css`.
+ */
+export const GLASS_CLASS = GLASS_TARGET.slice(1)

--- a/src/@shared/components/GlassSurface/glass-surface.module.css
+++ b/src/@shared/components/GlassSurface/glass-surface.module.css
@@ -1,0 +1,25 @@
+/* glass-surface.module.css — le cadre et le contenu d'une surface de verre.
+ * Le panneau de verre lui-même est stylé globalement (src/app/glass-surface.css) :
+ * liquidGL le retrouve par un sélecteur littéral, un nom haché serait introuvable. */
+
+/* Pas de `z-index` ici, et surtout pas d'`isolation: isolate` : le cadre ne doit
+   créer AUCUN contexte d'empilement, sinon le z-index du panneau et celui du contenu
+   ne se compareraient plus à ceux des canvas que liquidGL pose sur `body`. */
+.cadre {
+  position: relative;
+}
+
+/* z-index 3 : au-dessus du panneau de verre (2), des canvas miroirs de liquidGL
+   (z-index de la lentille moins 1, donc 1) et du canvas de réfraction (0). C'est ce
+   qui garantit que le texte reste net et cliquable quoi que fasse la bibliothèque. */
+.contenu {
+  position: relative;
+  z-index: 3;
+  padding: var(--e-5);
+}
+
+@media (max-width: 720px) {
+  .contenu {
+    padding: var(--e-4) var(--e-3);
+  }
+}

--- a/src/@shared/components/GlassSurface/index.tsx
+++ b/src/@shared/components/GlassSurface/index.tsx
@@ -1,0 +1,33 @@
+// GlassSurface/index.tsx — jeromemarichez-fr
+// Une surface de verre réfractant.
+
+import type { ReactNode } from 'react'
+import { GLASS_CLASS } from './glass-class'
+
+interface GlassSurfaceProps {
+  children: ReactNode
+  /** Classes de mise en page ajoutées par l'appelant (module CSS du parent). */
+  className?: string
+  /** Rendu en `<article>` plutôt qu'en `<div>` quand le contenu est autoportant. */
+  as?: 'div' | 'article' | 'aside'
+}
+
+/**
+ * Marque un bloc comme surface de verre.
+ *
+ * Le composant ne fait qu'apposer la classe globale que liquidGL cible : c'est
+ * `LiquidGlassRuntime` qui amorce le moteur, une seule fois par page. Tant qu'il n'a
+ * pas tourné — et sur mobile, sans WebGL ou en mouvement réduit, où il ne tourne pas du
+ * tout — le repli `backdrop-filter` de `glass-surface.css` porte seul le rendu. Le bloc
+ * est donc toujours lisible, jamais dépendant du WebGL.
+ *
+ * Contrainte liquidGL à ne pas contourner : toutes les surfaces partagent le même
+ * z-index, posé une seule fois dans `glass-surface.css`. N'y ajoutez pas de `z-index`
+ * local, et ne posez pas de surface en `position: fixed` — la bibliothèque les ignore.
+ */
+export function GlassSurface({ children, className, as = 'div' }: GlassSurfaceProps) {
+  const Tag = as
+  const classes = className ? `${GLASS_CLASS} ${className}` : GLASS_CLASS
+
+  return <Tag className={classes}>{children}</Tag>
+}

--- a/src/@shared/components/GlassSurface/index.tsx
+++ b/src/@shared/components/GlassSurface/index.tsx
@@ -3,6 +3,7 @@
 
 import type { ReactNode } from 'react'
 import { GLASS_CLASS } from './glass-class'
+import styles from './glass-surface.module.css'
 
 interface GlassSurfaceProps {
   children: ReactNode
@@ -13,21 +14,30 @@ interface GlassSurfaceProps {
 }
 
 /**
- * Marque un bloc comme surface de verre.
+ * La lentille est un panneau **vide**, et le contenu est son voisin — jamais son enfant.
  *
- * Le composant ne fait qu'apposer la classe globale que liquidGL cible : c'est
- * `LiquidGlassRuntime` qui amorce le moteur, une seule fois par page. Tant qu'il n'a
- * pas tourné — et sur mobile, sans WebGL ou en mouvement réduit, où il ne tourne pas du
- * tout — le repli `backdrop-filter` de `glass-surface.css` porte seul le rendu. Le bloc
- * est donc toujours lisible, jamais dépendant du WebGL.
+ * Ce découpage n'est pas une élégance : liquidGL mute l'élément qu'il transforme en
+ * lentille. Il lui pose `opacity: 0` (liquidGL.js l. 3397), puis `pointer-events: none`
+ * (l. 3419) — et ce second réglage n'est **jamais restauré**, aucune ligne du fichier ne
+ * le remet à sa valeur d'origine. Il efface aussi `background`, `background-image` et
+ * `backdrop-filter` en styles en ligne. Faire du conteneur de contenu une lentille
+ * revient donc à confier la visibilité du texte à l'animation d'apparition de la
+ * bibliothèque, et à tuer silencieusement tout lien ou bouton qu'on y ajoutera un jour.
  *
- * Contrainte liquidGL à ne pas contourner : toutes les surfaces partagent le même
- * z-index, posé une seule fois dans `glass-surface.css`. N'y ajoutez pas de `z-index`
- * local, et ne posez pas de surface en `position: fixed` — la bibliothèque les ignore.
+ * Avec ce découpage, liquidGL ne possède qu'une div décorative et vide. Le contenu
+ * garde son opacité, ses événements de pointeur et son style.
+ *
+ * Contraintes liquidGL tenues dans `glass-surface.css` : toutes les lentilles partagent
+ * le même z-index, et aucune n'est en `position: fixed` — la bibliothèque les ignore.
  */
 export function GlassSurface({ children, className, as = 'div' }: GlassSurfaceProps) {
   const Tag = as
-  const classes = className ? `${GLASS_CLASS} ${className}` : GLASS_CLASS
+  const classes = className ? `${styles.cadre} ${className}` : styles.cadre
 
-  return <Tag className={classes}>{children}</Tag>
+  return (
+    <Tag className={classes}>
+      <div aria-hidden="true" className={GLASS_CLASS} />
+      <div className={styles.contenu}>{children}</div>
+    </Tag>
+  )
 }

--- a/src/@shared/components/LiquidGlassRuntime/index.tsx
+++ b/src/@shared/components/LiquidGlassRuntime/index.tsx
@@ -4,19 +4,21 @@
 // Amorce liquidGL une fois par page, puis le démonte.
 
 import { useLiquidGlass } from '../../hooks/use-liquid-glass'
-import { useReducedMotion } from '../../hooks/use-reduced-motion'
+import { useMotionPaused } from '../../hooks/use-motion-paused'
 
 /**
  * Composant sans rendu : il n'existe que pour porter le cycle de vie du moteur de
  * verre. Le placer une seule fois par page, après les surfaces qu'il doit éclairer —
  * liquidGL lit le DOM au montage, un placement en tête ne trouverait aucune lentille.
  *
- * Sous `prefers-reduced-motion`, le moteur n'est pas amorcé du tout : la boucle de
- * rendu permanente de liquidGL est une animation, même quand aucune lentille ne bouge.
+ * Sous `prefers-reduced-motion` — ou dès que le visiteur a figé l'animation depuis la
+ * page — le moteur n'est pas amorcé du tout : la boucle de rendu permanente de liquidGL
+ * est une animation, même quand aucune lentille ne bouge. S'il tournait déjà, il est
+ * démonté proprement par le nettoyage du hook.
  */
 export function LiquidGlassRuntime() {
-  const reducedMotion = useReducedMotion()
-  useLiquidGlass(!reducedMotion)
+  const fige = useMotionPaused()
+  useLiquidGlass(!fige)
 
   return null
 }

--- a/src/@shared/components/LiquidGlassRuntime/index.tsx
+++ b/src/@shared/components/LiquidGlassRuntime/index.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+// LiquidGlassRuntime/index.tsx — jeromemarichez-fr
+// Amorce liquidGL une fois par page, puis le démonte.
+
+import { useLiquidGlass } from '../../hooks/use-liquid-glass'
+import { useReducedMotion } from '../../hooks/use-reduced-motion'
+
+/**
+ * Composant sans rendu : il n'existe que pour porter le cycle de vie du moteur de
+ * verre. Le placer une seule fois par page, après les surfaces qu'il doit éclairer —
+ * liquidGL lit le DOM au montage, un placement en tête ne trouverait aucune lentille.
+ *
+ * Sous `prefers-reduced-motion`, le moteur n'est pas amorcé du tout : la boucle de
+ * rendu permanente de liquidGL est une animation, même quand aucune lentille ne bouge.
+ */
+export function LiquidGlassRuntime() {
+  const reducedMotion = useReducedMotion()
+  useLiquidGlass(!reducedMotion)
+
+  return null
+}

--- a/src/@shared/components/MotionToggle/index.tsx
+++ b/src/@shared/components/MotionToggle/index.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+// MotionToggle/index.tsx — jeromemarichez-fr
+// Le bouton qui fige l'animation.
+
+import { useSyncExternalStore } from 'react'
+import { useReducedMotion } from '../../hooks/use-reduced-motion'
+import { motionStore } from '../../motion/motion-store'
+import styles from './motion-toggle.module.css'
+
+/**
+ * Mécanisme de mise en pause au sens WCAG 2.2.2.
+ *
+ * Il n'est **pas** masqué quand `prefers-reduced-motion` est déjà actif : dans ce cas
+ * il indique simplement que le mouvement est déjà coupé, et reste utilisable — un
+ * utilisateur peut vouloir le réactiver pour cette page seulement.
+ *
+ * `aria-pressed` porte l'état : c'est un interrupteur, pas une action ponctuelle, et un
+ * lecteur d'écran doit pouvoir annoncer sa position sans avoir à interpréter le libellé.
+ */
+export function MotionToggle() {
+  const fige = useSyncExternalStore(
+    motionStore.subscribe,
+    motionStore.getSnapshot,
+    motionStore.getServerSnapshot,
+  )
+  const reduced = useReducedMotion()
+  const actif = fige || reduced
+
+  return (
+    <button
+      aria-pressed={actif}
+      className={styles.bouton}
+      onClick={() => motionStore.toggle()}
+      type="button"
+    >
+      <span aria-hidden="true" className={styles.temoin} data-fige={actif} />
+      {actif ? 'Animation figée' : "Figer l'animation"}
+      {reduced && !fige ? <span className={styles.precision}> — réglage système</span> : null}
+    </button>
+  )
+}

--- a/src/@shared/components/MotionToggle/motion-toggle.module.css
+++ b/src/@shared/components/MotionToggle/motion-toggle.module.css
@@ -1,0 +1,41 @@
+/* motion-toggle.module.css — le contrôle de mise en pause.
+ * Discret mais jamais caché : un mécanisme d'accessibilité qu'il faut chercher n'en
+ * est pas un. */
+
+.bouton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55em;
+  padding: var(--e-1) var(--e-2);
+  border: 1px solid color-mix(in srgb, var(--encre) 18%, transparent);
+  border-radius: var(--rayon-petit);
+  background: transparent;
+  color: var(--encre-douce);
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    color 140ms ease-out,
+    border-color 140ms ease-out;
+}
+
+.bouton:hover {
+  color: var(--encre);
+  border-color: var(--cuivre);
+}
+
+.temoin {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--signal);
+}
+
+.temoin[data-fige="true"] {
+  background: var(--encre-douce);
+}
+
+.precision {
+  color: var(--encre-douce);
+}

--- a/src/@shared/components/SiteFooter/index.tsx
+++ b/src/@shared/components/SiteFooter/index.tsx
@@ -1,0 +1,64 @@
+// SiteFooter/index.tsx — jeromemarichez-fr
+// Pied de page : reprendre la chaîne, et donner un moyen direct de joindre.
+
+import Link from 'next/link'
+import { POLES_NAV } from '@/@vitrine/contenu/poles-nav'
+import { SITE_IDENTITY } from '../../seo/site'
+import styles from './site-footer.module.css'
+
+/**
+ * Le pied de page redit la promesse plutôt que de la résumer : c'est le dernier endroit
+ * où un visiteur qui a tout lu décide d'écrire ou de partir.
+ *
+ * L'adresse de contact est un `mailto:` direct, sans formulaire intermédiaire — c'est
+ * cohérent avec ce que le site vend, un interlocuteur joignable sans filtre.
+ */
+export function SiteFooter() {
+  return (
+    <footer className={styles.pied}>
+      <div className={styles.contenu}>
+        <div className={styles.appel}>
+          <p className={styles.promesse}>
+            Un seul interlocuteur, du cadrage au run. Décrivez votre situation, je vous dis ce que
+            j'en ferais — et si ce n'est pas pour moi, je vous le dis aussi.
+          </p>
+          <a className={styles.contact} href={`mailto:${SITE_IDENTITY.email}`}>
+            {SITE_IDENTITY.email}
+          </a>
+        </div>
+
+        <nav aria-label="Pied de page" className={styles.navigation}>
+          <p className={styles.titreNav}>Les trois pôles</p>
+          <ul className={styles.liens}>
+            {POLES_NAV.map((pole) => (
+              <li key={pole.id}>
+                <Link href={pole.route}>{pole.nom}</Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <nav aria-label="Profils" className={styles.navigation}>
+          <p className={styles.titreNav}>Ailleurs</p>
+          <ul className={styles.liens}>
+            <li>
+              <a href={SITE_IDENTITY.github} rel="me noopener noreferrer" target="_blank">
+                GitHub
+              </a>
+            </li>
+            <li>
+              <a href={SITE_IDENTITY.linkedin} rel="me noopener noreferrer" target="_blank">
+                LinkedIn
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+
+      <p className={styles.mentions}>
+        {SITE_IDENTITY.nom} — {SITE_IDENTITY.titre} à {SITE_IDENTITY.ville}. Site conçu, développé
+        et exploité par moi-même, comme le reste.
+      </p>
+    </footer>
+  )
+}

--- a/src/@shared/components/SiteFooter/site-footer.module.css
+++ b/src/@shared/components/SiteFooter/site-footer.module.css
@@ -1,0 +1,79 @@
+/* site-footer.module.css — pied de page. */
+
+.pied {
+  position: relative;
+  z-index: 1;
+  margin-top: var(--e-7);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+  background: color-mix(in srgb, var(--fond-creux) 70%, transparent);
+}
+
+.contenu {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--e-5);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-6) var(--e-4) var(--e-4);
+}
+
+.appel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+}
+
+.promesse {
+  max-width: 48ch;
+  font-family: var(--police-titre-pile);
+  font-variation-settings:
+    "SOFT" 0,
+    "WONK" 0,
+    "opsz" 24;
+  font-size: var(--t-2);
+  line-height: 1.3;
+}
+
+.contact {
+  font-family: var(--police-mono-pile);
+  font-size: 1.0625rem;
+  width: fit-content;
+}
+
+.navigation {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+}
+
+.titreNav {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--encre-douce);
+}
+
+.liens {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.9375rem;
+}
+
+.mentions {
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-3) var(--e-4) var(--e-5);
+  font-size: var(--t--1);
+  color: var(--encre-douce);
+}
+
+@media (max-width: 720px) {
+  .contenu {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/@shared/components/SiteHeader/index.tsx
+++ b/src/@shared/components/SiteHeader/index.tsx
@@ -1,0 +1,49 @@
+// SiteHeader/index.tsx — jeromemarichez-fr
+// En-tête : identité, et la chaîne des trois pôles rendue navigable.
+
+import Link from 'next/link'
+import { POLES_NAV } from '@/@vitrine/contenu/poles-nav'
+import { ROUTES } from '../../routes'
+import { SITE_IDENTITY } from '../../seo/site'
+import styles from './site-header.module.css'
+
+/**
+ * En-tête collant.
+ *
+ * Il n'utilise **pas** liquidGL : la bibliothèque ignore délibérément les éléments en
+ * `position: fixed` ou `sticky`, un panneau de verre y resterait figé sur la capture
+ * initiale et dériverait au défilement. Son fond est donc un `backdrop-filter` CSS
+ * classique — moins spectaculaire, mais juste à toutes les positions de défilement.
+ *
+ * La numérotation des pôles n'est pas décorative : elle dit que l'offre est une chaîne
+ * ordonnée, pas un menu où l'on pioche.
+ */
+export function SiteHeader() {
+  return (
+    <header className={styles.entete}>
+      <div className={styles.contenu}>
+        <Link className={styles.identite} href={ROUTES.accueil}>
+          <span className={styles.nom}>{SITE_IDENTITY.nom}</span>
+          <span className={styles.role}>
+            {SITE_IDENTITY.titre} · {SITE_IDENTITY.ville}
+          </span>
+        </Link>
+
+        <nav aria-label="Les trois pôles" className={styles.navigation}>
+          <ol className={styles.liste}>
+            {POLES_NAV.map((pole) => (
+              <li key={pole.id}>
+                <Link className={styles.lien} href={pole.route}>
+                  <span aria-hidden="true" className={styles.rang}>
+                    {pole.rang}
+                  </span>
+                  {pole.nom}
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -6,10 +6,19 @@
   position: sticky;
   top: 0;
   z-index: 50;
-  background: color-mix(in srgb, var(--fond) 82%, transparent);
-  backdrop-filter: blur(12px) saturate(1.1);
-  -webkit-backdrop-filter: blur(12px) saturate(1.1);
+  /* Opaque par défaut, translucide seulement là où le flou existe réellement.
+     Sans cette précaution, le texte des sections qui défilent dessous reste lisible à
+     travers l'en-tête : la transparence ne doit jamais coûter la lisibilité du nom. */
+  background: var(--fond);
   border-bottom: 1px solid color-mix(in srgb, var(--encre) 10%, transparent);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .entete {
+    background: color-mix(in srgb, var(--fond) 78%, transparent);
+    backdrop-filter: blur(14px) saturate(1.1);
+    -webkit-backdrop-filter: blur(14px) saturate(1.1);
+  }
 }
 
 .contenu {

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -15,7 +15,7 @@
 
 @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
   .entete {
-    background: color-mix(in srgb, var(--fond) 78%, transparent);
+    background: color-mix(in srgb, var(--fond) 88%, transparent);
     backdrop-filter: blur(14px) saturate(1.1);
     -webkit-backdrop-filter: blur(14px) saturate(1.1);
   }

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -1,0 +1,98 @@
+/* site-header.module.css — en-tête collant.
+ * Pas de liquidGL ici : la bibliothèque ignore les éléments `sticky` et `fixed`. Le
+ * fond est un backdrop-filter CSS, juste à toutes les positions de défilement. */
+
+.entete {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: color-mix(in srgb, var(--fond) 82%, transparent);
+  backdrop-filter: blur(12px) saturate(1.1);
+  -webkit-backdrop-filter: blur(12px) saturate(1.1);
+  border-bottom: 1px solid color-mix(in srgb, var(--encre) 10%, transparent);
+}
+
+.contenu {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--e-4);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-2) var(--e-4);
+}
+
+.identite {
+  display: flex;
+  flex-direction: column;
+  color: var(--encre);
+  text-decoration: none;
+}
+
+.nom {
+  font-family: var(--police-titre-pile);
+  font-variation-settings:
+    "SOFT" 0,
+    "WONK" 0,
+    "opsz" 18;
+  font-weight: 600;
+  font-size: 1.0625rem;
+  line-height: 1.2;
+}
+
+.role {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.06em;
+  color: var(--encre-douce);
+}
+
+.navigation {
+  min-width: 0;
+}
+
+.liste {
+  display: flex;
+  gap: var(--e-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lien {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4em;
+  padding: var(--e-1) var(--e-2);
+  border-radius: var(--rayon-petit);
+  color: var(--encre);
+  text-decoration: none;
+  font-size: 0.9375rem;
+  transition: background-color 140ms ease-out;
+}
+
+.lien:hover {
+  background: color-mix(in srgb, var(--cuivre) 12%, transparent);
+}
+
+.rang {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  color: var(--cuivre);
+}
+
+/* Sous 720px, la numérotation des pôles suffit à dire la chaîne : les intitulés
+   passent en second plan plutôt que de forcer un menu déroulant, qui coûterait du
+   JavaScript et un piège au clavier pour trois liens. */
+@media (max-width: 720px) {
+  .contenu {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--e-2);
+  }
+
+  .lien {
+    font-size: 0.875rem;
+    padding-inline: var(--e-1);
+  }
+}

--- a/src/@shared/components/SkipLink/index.tsx
+++ b/src/@shared/components/SkipLink/index.tsx
@@ -1,0 +1,19 @@
+// SkipLink/index.tsx — jeromemarichez-fr
+// Lien d'évitement vers le contenu principal.
+
+import styles from './skip-link.module.css'
+
+/**
+ * Premier élément focusable du document (RGAA 12.7, WCAG 2.4.1).
+ *
+ * Il est déplacé hors écran plutôt que masqué par `display: none` : un lien réellement
+ * masqué n'est pas atteignable au clavier, ce qui annule le service rendu. Il réapparaît
+ * au focus, sans dépendre du JavaScript.
+ */
+export function SkipLink() {
+  return (
+    <a className={styles.lien} href="#contenu">
+      Aller au contenu
+    </a>
+  )
+}

--- a/src/@shared/components/SkipLink/skip-link.module.css
+++ b/src/@shared/components/SkipLink/skip-link.module.css
@@ -1,0 +1,21 @@
+/* skip-link.module.css — le lien reste atteignable au clavier, jamais display:none. */
+
+.lien {
+  position: absolute;
+  left: var(--e-3);
+  top: var(--e-3);
+  z-index: 100;
+  transform: translateY(-200%);
+  padding: var(--e-2) var(--e-3);
+  border-radius: var(--rayon-petit);
+  background: var(--fond);
+  color: var(--encre);
+  border: 1px solid var(--cuivre);
+  text-decoration: none;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+}
+
+.lien:focus-visible {
+  transform: translateY(0);
+}

--- a/src/@shared/components/StructuredData/index.tsx
+++ b/src/@shared/components/StructuredData/index.tsx
@@ -1,0 +1,31 @@
+// StructuredData/index.tsx — jeromemarichez-fr
+// Injecte un ou plusieurs graphes JSON-LD dans la page.
+
+interface StructuredDataProps {
+  /** Graphes schema.org construits par `@shared/seo/structured-data`. */
+  schemas: Record<string, unknown>[]
+}
+
+/**
+ * Rendu côté serveur : le JSON-LD part dans le HTML statique, donc il est lu au premier
+ * passage du robot, sans dépendre du JavaScript.
+ *
+ * `JSON.stringify` sur des objets construits en interne, jamais sur une entrée
+ * utilisateur : c'est ce qui rend `dangerouslySetInnerHTML` acceptable ici. Le
+ * remplacement de `<` ferme la seule porte restante, celle d'une chaîne éditoriale qui
+ * contiendrait une balise et casserait le `<script>`.
+ */
+export function StructuredData({ schemas }: StructuredDataProps) {
+  return (
+    <>
+      {schemas.map((schema) => (
+        <script
+          key={String(schema['@id'] ?? schema['@type'])}
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: seul moyen d'émettre du JSON-LD ; la donnée est interne et échappée.
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(schema).replace(/</g, '\\u003c') }}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/@shared/glass/settings.ts
+++ b/src/@shared/glass/settings.ts
@@ -1,0 +1,44 @@
+// settings.ts — jeromemarichez-fr
+// Réglages du verre réfractant, au même endroit pour tout le site.
+
+/**
+ * Sélecteur unique des surfaces de verre.
+ *
+ * liquidGL impose que **toutes les lentilles partagent le même z-index** : le sélecteur
+ * est donc unique et la valeur de z-index est posée une seule fois, dans
+ * `glass-surface.css`. Une surface qui s'écarterait de cette classe casserait
+ * l'empilement de toutes les autres.
+ */
+export const GLASS_TARGET = '.glass-surface'
+
+/**
+ * Largeur de viewport en deçà de laquelle le verre WebGL n'est pas activé.
+ *
+ * Deux raisons, pas une : Safari devient instable dès qu'une lentille dépasse la moitié
+ * de la largeur ou de la hauteur du viewport — ce qui est le cas de toute carte pleine
+ * largeur sur mobile — et le coût GPU d'une capture plein document n'a aucune
+ * contrepartie sur un petit écran. En dessous, le repli `backdrop-filter` s'applique.
+ */
+export const MIN_GLASS_VIEWPORT = 1024
+
+/**
+ * Réglages de rendu.
+ *
+ * `resolution` est volontairement en dessous du défaut (2.0) : la capture couvre tout
+ * le document, et sa taille en mémoire GPU croît avec le carré de ce facteur. Les
+ * documents longs finissent par dépasser la limite de texture du GPU — c'est la panne
+ * la plus courante de cette bibliothèque.
+ */
+export const LIQUID_GL_OPTIONS = {
+  resolution: 1.5,
+  refraction: 0.02,
+  aberration: 0.04,
+  bevelDepth: 0.07,
+  bevelWidth: 0.18,
+  frost: 3,
+  shadow: true,
+  specular: true,
+  reveal: 'fade',
+  tilt: false,
+  magnify: 1,
+} as const

--- a/src/@shared/glass/settings.ts
+++ b/src/@shared/glass/settings.ts
@@ -24,10 +24,14 @@ export const MIN_GLASS_VIEWPORT = 1024
 /**
  * Réglages de rendu.
  *
- * `resolution` est volontairement en dessous du défaut (2.0) : la capture couvre tout
- * le document, et sa taille en mémoire GPU croît avec le carré de ce facteur. Les
- * documents longs finissent par dépasser la limite de texture du GPU — c'est la panne
- * la plus courante de cette bibliothèque.
+ * `resolution` est très en dessous du défaut (2.0), et c'est délibéré. La capture
+ * couvre toute la hauteur de l'élément visé : la page d'accueil dépasse 9 000 px, ce
+ * qui donnerait 13 500 px de texture à 1.5 — au-delà de ce que garantissent beaucoup
+ * de GPU, et c'est la panne la plus courante de cette bibliothèque.
+ *
+ * On peut se le permettre parce qu'on ne capture PAS la page : on capture un dégradé
+ * et une trame de 32 px. Vue à travers un verre dépoli, sa netteté n'a aucune
+ * importance — alors que la mémoire, elle, en a.
  */
 export const LIQUID_GL_OPTIONS = {
   /**
@@ -41,7 +45,7 @@ export const LIQUID_GL_OPTIONS = {
    * ce site vend, appliqué à lui-même.
    */
   snapshot: '.fond-atelier',
-  resolution: 1.5,
+  resolution: 0.75,
   refraction: 0.02,
   aberration: 0.04,
   bevelDepth: 0.07,

--- a/src/@shared/glass/settings.ts
+++ b/src/@shared/glass/settings.ts
@@ -30,6 +30,17 @@ export const MIN_GLASS_VIEWPORT = 1024
  * la plus courante de cette bibliothèque.
  */
 export const LIQUID_GL_OPTIONS = {
+  /**
+   * Ce que la lentille réfracte. **Le fond d'atelier, jamais `body`.**
+   *
+   * C'est le réglage qui décide si le site est lisible. Avec le défaut (`'body'`),
+   * liquidGL capture la page entière — texte compris — et chaque panneau affiche une
+   * copie déformée de ce qui se trouve dessous : le contenu du panneau se superpose à
+   * son propre reflet et devient illisible. En ne capturant que le calque de fond, la
+   * transparence reste visible et le texte reste net. C'est exactement l'arbitrage que
+   * ce site vend, appliqué à lui-même.
+   */
+  snapshot: '.fond-atelier',
   resolution: 1.5,
   refraction: 0.02,
   aberration: 0.04,

--- a/src/@shared/glass/support.ts
+++ b/src/@shared/glass/support.ts
@@ -2,6 +2,17 @@
 // Conditions d'activation du verre réfractant.
 
 /**
+ * Résultat de la sonde WebGL, mémorisé pour la durée de la page.
+ *
+ * La sonde crée un canvas et lui demande un contexte. Un navigateur plafonne le nombre
+ * de contextes WebGL vivants (autour de la quinzaine) et **abandonne les plus anciens**
+ * quand le plafond est atteint. Sonder à chaque montage — verre réfractant d'un côté,
+ * scène de la chaîne de l'autre — consommait donc des contextes qui n'étaient jamais
+ * rendus, et finissait par faire perdre le sien à la scène.
+ */
+let sondeWebGl: boolean | undefined
+
+/**
  * Dit si le verre WebGL peut être activé sur ce poste et à cette taille d'écran.
  *
  * Le test WebGL est fait ici plutôt que laissé à liquidGL : sa propre détection
@@ -20,14 +31,24 @@ export function supportsLiquidGlass(minViewport: number): boolean {
 /**
  * Dit si un contexte WebGL est obtenable.
  *
- * Exporté parce que la scène de la chaîne pose exactement la même question : deux
- * sondes séparées créeraient deux canvas jetables et deux contextes à chaque montage.
+ * Exporté parce que la scène de la chaîne pose exactement la même question. Le contexte
+ * de sonde est **explicitement libéré** via `WEBGL_lose_context` : sans cela, chaque
+ * appel laisse un contexte vivant derrière lui.
  */
 export function hasWebGl(): boolean {
+  if (sondeWebGl !== undefined) return sondeWebGl
+  if (typeof document === 'undefined') return false
+
   try {
     const canvas = document.createElement('canvas')
-    return Boolean(canvas.getContext('webgl2') ?? canvas.getContext('webgl'))
+    const contexte = canvas.getContext('webgl2') ?? canvas.getContext('webgl')
+    sondeWebGl = Boolean(contexte)
+
+    const liberer = contexte?.getExtension('WEBGL_lose_context')
+    liberer?.loseContext()
   } catch {
-    return false
+    sondeWebGl = false
   }
+
+  return sondeWebGl
 }

--- a/src/@shared/glass/support.ts
+++ b/src/@shared/glass/support.ts
@@ -1,0 +1,33 @@
+// support.ts — jeromemarichez-fr
+// Conditions d'activation du verre réfractant.
+
+/**
+ * Dit si le verre WebGL peut être activé sur ce poste et à cette taille d'écran.
+ *
+ * Le test WebGL est fait ici plutôt que laissé à liquidGL : sa propre détection
+ * applique un repli en styles **en ligne** (`background` et `backdrop-filter` en dur,
+ * teintés pour un fond sombre) qui écrase la feuille de styles du site et casse le
+ * thème clair. Mieux vaut ne pas l'amorcer du tout et garder le repli maison.
+ *
+ * @param minViewport largeur minimale, en pixels CSS.
+ */
+export function supportsLiquidGlass(minViewport: number): boolean {
+  if (typeof window === 'undefined') return false
+  if (window.innerWidth < minViewport) return false
+  return hasWebGl()
+}
+
+/**
+ * Dit si un contexte WebGL est obtenable.
+ *
+ * Exporté parce que la scène de la chaîne pose exactement la même question : deux
+ * sondes séparées créeraient deux canvas jetables et deux contextes à chaque montage.
+ */
+export function hasWebGl(): boolean {
+  try {
+    const canvas = document.createElement('canvas')
+    return Boolean(canvas.getContext('webgl2') ?? canvas.getContext('webgl'))
+  } catch {
+    return false
+  }
+}

--- a/src/@shared/glass/teardown.ts
+++ b/src/@shared/glass/teardown.ts
@@ -1,0 +1,46 @@
+// teardown.ts — jeromemarichez-fr
+// Démontage de liquidGL.
+//
+// La bibliothèque n'expose aucune API de destruction : elle installe un moteur unique
+// sur `window.__liquidGLRenderer__`, une boucle `requestAnimationFrame` permanente, un
+// canvas plein écran et une div d'ombre par lentille, tous accrochés à `document.body`.
+// Sans ce démontage, une navigation client laisserait la boucle tourner sur des
+// lentilles disparues — une fuite qui se paie en INP sur toutes les pages suivantes.
+
+/** Forme interne réellement observée dans `liquid-gl@2.0.1`. */
+interface InternalRenderer {
+  _rafId?: number | null
+  canvas?: HTMLCanvasElement
+  lenses?: Array<{ _shadowEl?: HTMLElement | null }>
+}
+
+interface LiquidGlWindow extends Window {
+  __liquidGLRenderer__?: InternalRenderer
+  __liquidGLNoWebGL__?: boolean
+}
+
+const DYNAMIC_STYLES_ID = 'liquid-gl-dynamic-styles'
+
+/** Arrête la boucle de rendu et retire du DOM tout ce que liquidGL y a ajouté. */
+export function teardownLiquidGlass(): void {
+  if (typeof window === 'undefined') return
+
+  const scope = window as LiquidGlWindow
+  const renderer = scope.__liquidGLRenderer__
+  if (!renderer) return
+
+  if (typeof renderer._rafId === 'number') {
+    cancelAnimationFrame(renderer._rafId)
+    renderer._rafId = null
+  }
+
+  for (const lens of renderer.lenses ?? []) {
+    lens._shadowEl?.remove()
+    lens._shadowEl = null
+  }
+
+  renderer.canvas?.remove()
+  document.getElementById(DYNAMIC_STYLES_ID)?.remove()
+
+  scope.__liquidGLRenderer__ = undefined
+}

--- a/src/@shared/hooks/use-in-viewport.ts
+++ b/src/@shared/hooks/use-in-viewport.ts
@@ -1,0 +1,42 @@
+'use client'
+
+// use-in-viewport.ts — jeromemarichez-fr
+// Dit si un élément est entré dans le viewport, une bonne fois pour toutes.
+
+import { type RefObject, useEffect, useState } from 'react'
+
+/**
+ * Passe à `true` au premier croisement et n'en repart pas.
+ *
+ * Sert à ne payer le coût d'une dépendance lourde — ici la scène WebGL — que si le
+ * visiteur descend réellement jusqu'à elle. Un observateur qui repasserait à `false`
+ * en sortie ferait démonter puis remonter le contexte WebGL au fil du défilement,
+ * ce qui coûte bien plus cher que de le laisser vivre.
+ *
+ * @param margin marge de déclenchement, pour amorcer le chargement juste avant que
+ *   l'élément ne devienne visible.
+ */
+export function useInViewport(ref: RefObject<Element | null>, margin = '200px'): boolean {
+  const [seen, setSeen] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node || seen) return
+
+    if (typeof IntersectionObserver === 'undefined') {
+      setSeen(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setSeen(true)
+      },
+      { rootMargin: margin },
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [ref, seen, margin])
+
+  return seen
+}

--- a/src/@shared/hooks/use-liquid-glass.ts
+++ b/src/@shared/hooks/use-liquid-glass.ts
@@ -1,0 +1,48 @@
+'use client'
+
+// use-liquid-glass.ts — jeromemarichez-fr
+// Amorce et démonte liquidGL (NaughtyDuk, MIT) sur les surfaces de verre du site.
+//
+// liquidGL est un singleton global (`window.liquidGL`, `window.__liquidGLRenderer__`)
+// chargé en différé : il n'entre jamais dans le bundle initial et ne peut donc pas
+// peser sur le LCP. Ce hook encapsule les trois garde-fous que la bibliothèque impose
+// et que le site doit tenir pour rester à Lighthouse ≥ 95 partout.
+
+import { useEffect } from 'react'
+import { GLASS_TARGET, LIQUID_GL_OPTIONS, MIN_GLASS_VIEWPORT } from '../glass/settings'
+import { supportsLiquidGlass } from '../glass/support'
+import { teardownLiquidGlass } from '../glass/teardown'
+
+/**
+ * Active le verre réfractant sur les éléments `GLASS_TARGET` de la page montée.
+ *
+ * Ne fait rien — et laisse le repli CSS `backdrop-filter` en place — dans trois cas :
+ * mouvement réduit demandé, viewport trop étroit (Safari devient instable dès qu'une
+ * lentille dépasse la moitié du viewport, ce qui est systématique sur mobile), ou
+ * absence de WebGL.
+ *
+ * @param enabled passe à `false` pour laisser le repli CSS, par exemple sous
+ *   `prefers-reduced-motion`.
+ */
+export function useLiquidGlass(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return
+    if (!supportsLiquidGlass(MIN_GLASS_VIEWPORT)) return
+
+    let cancelled = false
+
+    const boot = async () => {
+      const { default: liquidGL } = await import('liquid-gl')
+      if (cancelled) return
+      if (!document.querySelector(GLASS_TARGET)) return
+      liquidGL({ target: GLASS_TARGET, ...LIQUID_GL_OPTIONS })
+    }
+
+    void boot()
+
+    return () => {
+      cancelled = true
+      teardownLiquidGlass()
+    }
+  }, [enabled])
+}

--- a/src/@shared/hooks/use-motion-paused.ts
+++ b/src/@shared/hooks/use-motion-paused.ts
@@ -1,0 +1,27 @@
+'use client'
+
+// use-motion-paused.ts — jeromemarichez-fr
+// Le mouvement doit-il être coupé ? Deux raisons possibles, une seule réponse.
+
+import { useSyncExternalStore } from 'react'
+import { motionStore } from '../motion/motion-store'
+import { useReducedMotion } from './use-reduced-motion'
+
+/**
+ * Rend `true` si l'utilisateur a demandé moins d'animation **au niveau du système**, ou
+ * s'il a figé l'animation **depuis la page**.
+ *
+ * Les deux sont nécessaires et ne se remplacent pas : la préférence système couvre les
+ * personnes qui l'ont réglée une fois pour toutes, le contrôle de la page couvre tous
+ * les autres — c'est lui qui satisfait WCAG 2.2.2.
+ */
+export function useMotionPaused(): boolean {
+  const reduced = useReducedMotion()
+  const fige = useSyncExternalStore(
+    motionStore.subscribe,
+    motionStore.getSnapshot,
+    motionStore.getServerSnapshot,
+  )
+
+  return reduced || fige
+}

--- a/src/@shared/hooks/use-reduced-motion.ts
+++ b/src/@shared/hooks/use-reduced-motion.ts
@@ -1,0 +1,35 @@
+'use client'
+
+// use-reduced-motion.ts — jeromemarichez-fr
+// Lit `prefers-reduced-motion` et suit ses changements.
+//
+// Le site vend de l'accessibilité tenue (RGAA / WCAG AA) : les deux surfaces animées
+// — la scène WebGL et le verre réfractant — se coupent réellement quand l'utilisateur
+// a demandé moins de mouvement, elles ne se contentent pas de ralentir.
+
+import { useEffect, useState } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+/**
+ * Rend `true` quand l'utilisateur demande moins d'animation.
+ *
+ * Vaut `false` au premier rendu, y compris côté serveur : le rendu statique ne connaît
+ * pas la préférence du visiteur. Les composants animés doivent donc démarrer dans un
+ * état inerte et ne s'animer qu'après montage, pour ne jamais afficher une animation
+ * l'espace d'une frame à quelqu'un qui l'a désactivée.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    const media = window.matchMedia(QUERY)
+    setReduced(media.matches)
+
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches)
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
+  }, [])
+
+  return reduced
+}

--- a/src/@shared/motion/motion-store.ts
+++ b/src/@shared/motion/motion-store.ts
@@ -1,0 +1,61 @@
+'use client'
+
+// motion-store.ts — jeromemarichez-fr
+// Le choix « animation figée », partagé par toute la page et retenu d'une visite à l'autre.
+//
+// WCAG 2.2.2 exige un mécanisme de **mise en pause** pour toute animation automatique
+// qui dure plus de cinq secondes. `prefers-reduced-motion` n'en est pas un : c'est une
+// préférence système que beaucoup d'utilisateurs ne savent pas régler, et elle ne se
+// change pas depuis la page. Il faut un contrôle explicite, et il doit tenir.
+
+const CLE = 'jm-animation-figee'
+
+type Abonne = () => void
+
+const abonnes = new Set<Abonne>()
+let fige: boolean | undefined
+
+function lire(): boolean {
+  if (fige !== undefined) return fige
+  if (typeof window === 'undefined') return false
+
+  try {
+    fige = window.localStorage.getItem(CLE) === '1'
+  } catch {
+    // Stockage refusé (navigation privée verrouillée, politique d'entreprise) : le
+    // contrôle reste utilisable, il ne survit simplement pas au rechargement.
+    fige = false
+  }
+
+  return fige
+}
+
+export const motionStore = {
+  subscribe(abonne: Abonne): () => void {
+    abonnes.add(abonne)
+    return () => {
+      abonnes.delete(abonne)
+    }
+  },
+
+  getSnapshot(): boolean {
+    return lire()
+  },
+
+  /** Rendu côté serveur : jamais figé, sinon l'état initial différerait à l'hydratation. */
+  getServerSnapshot(): boolean {
+    return false
+  },
+
+  toggle(): void {
+    fige = !lire()
+
+    try {
+      window.localStorage.setItem(CLE, fige ? '1' : '0')
+    } catch {
+      // Sans stockage, le choix vaut pour la session en cours. C'est déjà l'essentiel.
+    }
+
+    for (const abonne of abonnes) abonne()
+  },
+}

--- a/src/@shared/routes.ts
+++ b/src/@shared/routes.ts
@@ -1,0 +1,29 @@
+// routes.ts — jeromemarichez-fr
+// Les routes du site, énumérées une seule fois.
+//
+// Navigation, sitemap, fils d'Ariane et données structurées lisent toutes cette
+// liste : une page ajoutée ici apparaît partout, une page oubliée nulle part.
+
+import type { PoleId } from '@/interfaces/types'
+
+export const ROUTES = {
+  accueil: '/',
+  'ingenierie-web': '/services/ingenierie-web',
+  'data-ia': '/services/data-ia',
+  'sea-ux': '/services/sea-ux',
+} as const satisfies Record<'accueil' | PoleId, string>
+
+/** Ordre de la chaîne : construire, exploiter et mesurer, arbitrer. */
+export const POLE_ORDER = [
+  'ingenierie-web',
+  'data-ia',
+  'sea-ux',
+] as const satisfies readonly PoleId[]
+
+/** Toutes les routes indexables, dans l'ordre de priorité. */
+export const INDEXABLE_ROUTES = [
+  ROUTES.accueil,
+  ROUTES['ingenierie-web'],
+  ROUTES['data-ia'],
+  ROUTES['sea-ux'],
+] as const

--- a/src/@shared/seo/site.ts
+++ b/src/@shared/seo/site.ts
@@ -1,0 +1,29 @@
+// site.ts — jeromemarichez-fr
+// Constantes d'identité du site, source unique pour les métadonnées et le JSON-LD.
+
+/** Origine canonique. Sert aux URL absolues des métadonnées, du sitemap et du JSON-LD. */
+export const SITE_URL = 'https://jeromemarichez.fr'
+
+/** Identité publiée. Reprise à l'identique des CV de référence. */
+export const SITE_IDENTITY = {
+  nom: 'Jérôme Marichez',
+  titre: 'Ingénieur logiciel',
+  ville: 'Lille',
+  region: 'Hauts-de-France',
+  pays: 'FR',
+  email: 'jeromemarichez@ik.me',
+  github: 'https://github.com/Jerome-Marichez',
+  linkedin: 'https://www.linkedin.com/in/jerome-marichez-31948712b',
+} as const
+
+/**
+ * Promesse centrale du site. Elle apparaît dans les métadonnées de la page d'accueil
+ * comme dans le contenu : c'est le même engagement, il ne se reformule pas d'un
+ * support à l'autre.
+ */
+export const SITE_PROMESSE =
+  'Un seul interlocuteur pour vos projets digitaux, aucune sous-traitance. ' +
+  'Celui qui cadre est celui qui code, qui mesure et qui exploite.'
+
+/** Rayon d'intervention réellement couvert. */
+export const SITE_ZONE = ['Lille', 'Hauts-de-France', 'France'] as const

--- a/src/@shared/seo/structured-data.ts
+++ b/src/@shared/seo/structured-data.ts
@@ -1,0 +1,76 @@
+// structured-data.ts — jeromemarichez-fr
+// Données structurées schema.org.
+//
+// Même règle de véracité que le contenu visible : le JSON-LD n'affirme rien que le
+// site n'affirme pas déjà. Il est lu par des moteurs, pas par des prospects, ce qui
+// le rend d'autant plus tentant à gonfler — et d'autant plus grave à gonfler.
+
+import { SITE_IDENTITY, SITE_URL, SITE_ZONE } from './site'
+
+/** Le professionnel indépendant derrière le site. */
+export function buildPersonSchema(): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    '@id': `${SITE_URL}/#personne`,
+    name: SITE_IDENTITY.nom,
+    jobTitle: SITE_IDENTITY.titre,
+    url: SITE_URL,
+    email: `mailto:${SITE_IDENTITY.email}`,
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: SITE_IDENTITY.ville,
+      addressRegion: SITE_IDENTITY.region,
+      addressCountry: SITE_IDENTITY.pays,
+    },
+    sameAs: [SITE_IDENTITY.github, SITE_IDENTITY.linkedin],
+  }
+}
+
+/** L'activité de conseil, rattachée à la même personne. */
+export function buildProfessionalServiceSchema(description: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ProfessionalService',
+    '@id': `${SITE_URL}/#activite`,
+    name: SITE_IDENTITY.nom,
+    description,
+    url: SITE_URL,
+    founder: { '@id': `${SITE_URL}/#personne` },
+    areaServed: SITE_ZONE.map((nom) => ({ '@type': 'Place', name: nom })),
+  }
+}
+
+/** Un pôle, décrit comme un service rendu par cette activité. */
+export function buildServiceSchema(params: {
+  nom: string
+  description: string
+  route: string
+}): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    '@id': `${SITE_URL}${params.route}#service`,
+    name: params.nom,
+    description: params.description,
+    url: `${SITE_URL}${params.route}`,
+    serviceType: params.nom,
+    provider: { '@id': `${SITE_URL}/#activite` },
+    areaServed: SITE_ZONE.map((nom) => ({ '@type': 'Place', name: nom })),
+  }
+}
+
+/** Fil d'Ariane d'une page de pôle. */
+export function buildBreadcrumbSchema(params: {
+  nom: string
+  route: string
+}): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Accueil', item: SITE_URL },
+      { '@type': 'ListItem', position: 2, name: params.nom, item: `${SITE_URL}${params.route}` },
+    ],
+  }
+}

--- a/src/@shared/three/ChainScene.tsx
+++ b/src/@shared/three/ChainScene.tsx
@@ -6,43 +6,56 @@
 // Chargée uniquement par `ChainCanvas`, jamais importée ailleurs — c'est ce qui garde
 // `three` et `@react-three/fiber` hors du chemin critique.
 
-import { Canvas, useFrame, useThree } from '@react-three/fiber'
+import { Canvas, useFrame } from '@react-three/fiber'
 import { useEffect, useMemo, useRef } from 'react'
 import { Color, type Group, type ShaderMaterial } from 'three'
-import { buildSlabGeometry, SLAB_PLACEMENTS } from './slab-geometry'
-import {
-  SLAB_CORE_COLOR,
-  SLAB_EDGE_COLORS,
-  SLAB_FRAGMENT_SHADER,
-  SLAB_VERTEX_SHADER,
-} from './slab-shader'
+import { useReducedMotion } from '../hooks/use-reduced-motion'
+import { buildSlabEdges, buildSlabGeometry, SLAB_PLACEMENTS } from './slab-geometry'
+import { SLAB_ALPHA, SLAB_EDGE_TINT, SLAB_FRAGMENT_SHADER, SLAB_VERTEX_SHADER } from './slab-shader'
 import { useScrollProgress } from './use-scroll-progress'
+import { type SceneColors, useThemeColors } from './use-theme-colors'
 
 const ROTATION_BASE = -0.18
 const ROTATION_AMPLITUDE = 0.34
+
+function useSlabUniforms(couleurs: SceneColors, sombre: boolean) {
+  return useMemo(() => {
+    const alpha = sombre ? SLAB_ALPHA.sombre : SLAB_ALPHA.clair
+
+    return SLAB_PLACEMENTS.map((placement) => {
+      const arete = new Color(couleurs.arete)
+      // Les dalles 2 et 3 s'éteignent vers la couleur du corps : le cuivre reste au
+      // premier plan, et la profondeur se lit sans avoir à inventer trois teintes.
+      arete.lerp(new Color(couleurs.corps), 1 - SLAB_EDGE_TINT[placement.index])
+
+      return {
+        uEdgeColor: { value: arete },
+        uCoreColor: { value: new Color(couleurs.corps) },
+        uTime: { value: 0 },
+        uIndex: { value: placement.index },
+        uCoreAlpha: { value: alpha.corps },
+        uEdgeAlpha: { value: alpha.arete },
+      }
+    })
+  }, [couleurs, sombre])
+}
 
 function Slabs({ fige }: { fige: boolean }) {
   const groupe = useRef<Group>(null)
   const materiaux = useRef<ShaderMaterial[]>([])
   const geometrie = useMemo(buildSlabGeometry, [])
+  const aretes = useMemo(() => buildSlabEdges(geometrie), [geometrie])
+  const couleurs = useThemeColors()
+  const sombre = useIsDarkTheme()
+  const uniforms = useSlabUniforms(couleurs, sombre)
   const progression = useScrollProgress()
-  const { invalidate } = useThree()
 
   useEffect(() => {
-    const geo = geometrie
-    return () => geo.dispose()
-  }, [geometrie])
-
-  const uniforms = useMemo(
-    () =>
-      SLAB_PLACEMENTS.map((placement) => ({
-        uEdgeColor: { value: new Color(SLAB_EDGE_COLORS[placement.index]) },
-        uCoreColor: { value: new Color(SLAB_CORE_COLOR) },
-        uTime: { value: 0 },
-        uIndex: { value: placement.index },
-      })),
-    [],
-  )
+    return () => {
+      geometrie.dispose()
+      aretes.dispose()
+    }
+  }, [geometrie, aretes])
 
   useFrame((state, delta) => {
     if (!groupe.current) return
@@ -56,28 +69,51 @@ function Slabs({ fige }: { fige: boolean }) {
       const temps = materiau?.uniforms.uTime
       if (temps) temps.value += delta
     }
-    invalidate()
   })
 
   return (
     <group ref={groupe}>
       {SLAB_PLACEMENTS.map((placement) => (
-        <mesh geometry={geometrie} key={placement.index} position={placement.position}>
-          <shaderMaterial
-            depthWrite={false}
-            fragmentShader={SLAB_FRAGMENT_SHADER}
-            ref={(node) => {
-              if (node) materiaux.current[placement.index] = node
-            }}
-            side={2}
-            transparent
-            uniforms={uniforms[placement.index]}
-            vertexShader={SLAB_VERTEX_SHADER}
-          />
-        </mesh>
+        <group key={placement.index} position={placement.position}>
+          <mesh geometry={geometrie}>
+            <shaderMaterial
+              depthWrite={false}
+              fragmentShader={SLAB_FRAGMENT_SHADER}
+              ref={(node) => {
+                if (node) materiaux.current[placement.index] = node
+              }}
+              // FrontSide et non DoubleSide : le corps, le dos et les facettes du
+              // biseau se superposent déjà dans chaque dalle, et les trois dalles se
+              // superposent entre elles. Doubler les faces empilait une dizaine de
+              // couches translucides, ce qui rendait le verre opaque.
+              side={0}
+              transparent
+              uniforms={uniforms[placement.index]}
+              vertexShader={SLAB_VERTEX_SHADER}
+            />
+          </mesh>
+
+          {/* Le liseré : sans lui, une dalle vue de face n'a aucun contour et la scène
+              se lit comme un aplat. C'est aussi la « feuille de cuivre » de la
+              direction — ce qui tient les trois plaques ensemble. */}
+          <lineSegments geometry={aretes}>
+            <lineBasicMaterial
+              color={uniforms[placement.index]?.uEdgeColor.value}
+              opacity={sombre ? 0.5 : 0.42}
+              transparent
+            />
+          </lineSegments>
+        </group>
       ))}
     </group>
   )
+}
+
+function useIsDarkTheme(): boolean {
+  return useMemo(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  }, [])
 }
 
 interface ChainSceneProps {
@@ -86,14 +122,21 @@ interface ChainSceneProps {
 }
 
 export function ChainScene({ fige = false }: ChainSceneProps) {
+  const reducedMotion = useReducedMotion()
+  const immobile = fige || reducedMotion
+
   return (
     <Canvas
-      camera={{ position: [0, 0, 4.6], fov: 38 }}
+      // Visée décalée sur la dalle du milieu : les trois plaques sont décalées vers
+      // la droite et vers le bas, une caméra à l'origine sortait la troisième du cadre.
+      camera={{ position: [0.42, -0.14, 4.8], fov: 38 }}
       dpr={[1, 1.5]}
-      frameloop="demand"
+      // `demand` fige la scène sur une seule image : c'est exactement ce qu'il faut
+      // quand l'utilisateur a demandé moins de mouvement, et rien d'autre à couper.
+      frameloop={immobile ? 'demand' : 'always'}
       gl={{ alpha: true, antialias: true, powerPreference: 'low-power' }}
     >
-      <Slabs fige={fige} />
+      <Slabs fige={immobile} />
     </Canvas>
   )
 }

--- a/src/@shared/three/ChainScene.tsx
+++ b/src/@shared/three/ChainScene.tsx
@@ -9,7 +9,6 @@
 import { Canvas, useFrame } from '@react-three/fiber'
 import { useEffect, useMemo, useRef } from 'react'
 import { Color, type Group, type ShaderMaterial } from 'three'
-import { useReducedMotion } from '../hooks/use-reduced-motion'
 import { buildSlabEdges, buildSlabGeometry, SLAB_PLACEMENTS } from './slab-geometry'
 import { SLAB_ALPHA, SLAB_EDGE_TINT, SLAB_FRAGMENT_SHADER, SLAB_VERTEX_SHADER } from './slab-shader'
 import { useScrollProgress } from './use-scroll-progress'
@@ -122,9 +121,6 @@ interface ChainSceneProps {
 }
 
 export function ChainScene({ fige = false }: ChainSceneProps) {
-  const reducedMotion = useReducedMotion()
-  const immobile = fige || reducedMotion
-
   return (
     <Canvas
       // Visée décalée sur la dalle du milieu : les trois plaques sont décalées vers
@@ -133,10 +129,10 @@ export function ChainScene({ fige = false }: ChainSceneProps) {
       dpr={[1, 1.5]}
       // `demand` fige la scène sur une seule image : c'est exactement ce qu'il faut
       // quand l'utilisateur a demandé moins de mouvement, et rien d'autre à couper.
-      frameloop={immobile ? 'demand' : 'always'}
+      frameloop={fige ? 'demand' : 'always'}
       gl={{ alpha: true, antialias: true, powerPreference: 'low-power' }}
     >
-      <Slabs fige={immobile} />
+      <Slabs fige={fige} />
     </Canvas>
   )
 }

--- a/src/@shared/three/ChainScene.tsx
+++ b/src/@shared/three/ChainScene.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+// ChainScene.tsx — jeromemarichez-fr
+// Trois dalles de verre alignées dans le même axe : la thèse du site en volume.
+//
+// Chargée uniquement par `ChainCanvas`, jamais importée ailleurs — c'est ce qui garde
+// `three` et `@react-three/fiber` hors du chemin critique.
+
+import { Canvas, useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import { Color, type Group, type ShaderMaterial } from 'three'
+import { buildSlabGeometry, SLAB_PLACEMENTS } from './slab-geometry'
+import {
+  SLAB_CORE_COLOR,
+  SLAB_EDGE_COLORS,
+  SLAB_FRAGMENT_SHADER,
+  SLAB_VERTEX_SHADER,
+} from './slab-shader'
+import { useScrollProgress } from './use-scroll-progress'
+
+const ROTATION_BASE = -0.18
+const ROTATION_AMPLITUDE = 0.34
+
+function Slabs({ fige }: { fige: boolean }) {
+  const groupe = useRef<Group>(null)
+  const materiaux = useRef<ShaderMaterial[]>([])
+  const geometrie = useMemo(buildSlabGeometry, [])
+  const progression = useScrollProgress()
+  const { invalidate } = useThree()
+
+  useEffect(() => {
+    const geo = geometrie
+    return () => geo.dispose()
+  }, [geometrie])
+
+  const uniforms = useMemo(
+    () =>
+      SLAB_PLACEMENTS.map((placement) => ({
+        uEdgeColor: { value: new Color(SLAB_EDGE_COLORS[placement.index]) },
+        uCoreColor: { value: new Color(SLAB_CORE_COLOR) },
+        uTime: { value: 0 },
+        uIndex: { value: placement.index },
+      })),
+    [],
+  )
+
+  useFrame((state, delta) => {
+    if (!groupe.current) return
+
+    const cible = ROTATION_BASE + progression.current * ROTATION_AMPLITUDE
+    groupe.current.rotation.y += (cible - groupe.current.rotation.y) * 0.08
+    groupe.current.rotation.x = 0.05 + Math.sin(state.clock.elapsedTime * 0.565) * 0.035
+
+    if (fige) return
+    for (const materiau of materiaux.current) {
+      const temps = materiau?.uniforms.uTime
+      if (temps) temps.value += delta
+    }
+    invalidate()
+  })
+
+  return (
+    <group ref={groupe}>
+      {SLAB_PLACEMENTS.map((placement) => (
+        <mesh geometry={geometrie} key={placement.index} position={placement.position}>
+          <shaderMaterial
+            depthWrite={false}
+            fragmentShader={SLAB_FRAGMENT_SHADER}
+            ref={(node) => {
+              if (node) materiaux.current[placement.index] = node
+            }}
+            side={2}
+            transparent
+            uniforms={uniforms[placement.index]}
+            vertexShader={SLAB_VERTEX_SHADER}
+          />
+        </mesh>
+      ))}
+    </group>
+  )
+}
+
+interface ChainSceneProps {
+  /** Rend une image fixe : le temps n'avance plus, seule la pose reste. */
+  fige?: boolean
+}
+
+export function ChainScene({ fige = false }: ChainSceneProps) {
+  return (
+    <Canvas
+      camera={{ position: [0, 0, 4.6], fov: 38 }}
+      dpr={[1, 1.5]}
+      frameloop="demand"
+      gl={{ alpha: true, antialias: true, powerPreference: 'low-power' }}
+    >
+      <Slabs fige={fige} />
+    </Canvas>
+  )
+}

--- a/src/@shared/three/slab-geometry.ts
+++ b/src/@shared/three/slab-geometry.ts
@@ -1,0 +1,50 @@
+// slab-geometry.ts — jeromemarichez-fr
+// La dalle : un rectangle arrondi extrudé avec un vrai biseau.
+
+import { ExtrudeGeometry, Shape } from 'three'
+
+const LARGEUR = 1.7
+const HAUTEUR = 2.35
+const RAYON = 0.09
+
+/**
+ * Construit la géométrie d'une dalle, biseau compris.
+ *
+ * Le biseau n'est pas cosmétique : c'est la seule surface dont la normale s'écarte
+ * franchement de l'axe de vue, donc la seule que le Fresnel du shader allume. Sans
+ * lui, les trois dalles seraient trois voiles plats.
+ *
+ * Environ 600 triangles. La géométrie est construite **une fois** et partagée par les
+ * trois maillages — trois appels de dessin, un seul programme, aucune texture.
+ */
+export function buildSlabGeometry(): ExtrudeGeometry {
+  const contour = new Shape()
+  const x = -LARGEUR / 2
+  const y = -HAUTEUR / 2
+
+  contour.moveTo(x + RAYON, y)
+  contour.lineTo(x + LARGEUR - RAYON, y)
+  contour.quadraticCurveTo(x + LARGEUR, y, x + LARGEUR, y + RAYON)
+  contour.lineTo(x + LARGEUR, y + HAUTEUR - RAYON)
+  contour.quadraticCurveTo(x + LARGEUR, y + HAUTEUR, x + LARGEUR - RAYON, y + HAUTEUR)
+  contour.lineTo(x + RAYON, y + HAUTEUR)
+  contour.quadraticCurveTo(x, y + HAUTEUR, x, y + HAUTEUR - RAYON)
+  contour.lineTo(x, y + RAYON)
+  contour.quadraticCurveTo(x, y, x + RAYON, y)
+
+  return new ExtrudeGeometry(contour, {
+    depth: 0.05,
+    bevelEnabled: true,
+    bevelThickness: 0.018,
+    bevelSize: 0.022,
+    bevelSegments: 2,
+    curveSegments: 8,
+  })
+}
+
+/** Décalage des trois dalles : même axe, profondeurs différentes. */
+export const SLAB_PLACEMENTS = [
+  { position: [0, 0, 0], index: 0 },
+  { position: [0.42, -0.14, -0.9], index: 1 },
+  { position: [0.84, -0.28, -1.8], index: 2 },
+] as const

--- a/src/@shared/three/slab-geometry.ts
+++ b/src/@shared/three/slab-geometry.ts
@@ -1,7 +1,7 @@
 // slab-geometry.ts — jeromemarichez-fr
 // La dalle : un rectangle arrondi extrudé avec un vrai biseau.
 
-import { ExtrudeGeometry, Shape } from 'three'
+import { EdgesGeometry, ExtrudeGeometry, Shape } from 'three'
 
 const LARGEUR = 1.7
 const HAUTEUR = 2.35
@@ -48,3 +48,17 @@ export const SLAB_PLACEMENTS = [
   { position: [0.42, -0.14, -0.9], index: 1 },
   { position: [0.84, -0.28, -1.8], index: 2 },
 ] as const
+
+/**
+ * Le liseré d'une dalle : ses arêtes vives, sous forme de segments.
+ *
+ * Sans lui, une dalle vue de face n'a plus aucun contour — le Fresnel n'allume que
+ * les faces rasantes — et les trois plaques se confondent avec le fond. Le rendu
+ * filaire est quasi gratuit : quelques centaines de segments, aucun éclairage.
+ *
+ * `thresholdAngle` à 30° ne garde que les vraies arêtes et laisse tomber les
+ * facettes internes du biseau, qui feraient un grillage au lieu d'un liseré.
+ */
+export function buildSlabEdges(geometrie: ExtrudeGeometry): EdgesGeometry {
+  return new EdgesGeometry(geometrie, 30)
+}

--- a/src/@shared/three/slab-shader.ts
+++ b/src/@shared/three/slab-shader.ts
@@ -1,0 +1,66 @@
+// slab-shader.ts — jeromemarichez-fr
+// Le matériau des dalles de verre. Un seul programme, partagé par les trois.
+//
+// Volontairement PAS de `MeshPhysicalMaterial` avec `transmission` : la transmission
+// impose une passe de rendu et une cible de rendu par objet transparent. Pour trois
+// dalles qui n'ont besoin que d'une arête allumée, le coût serait sans rapport avec
+// le résultat. Un Fresnel dans un shader non éclairé donne la même lecture pour
+// zéro lumière, zéro ombre et zéro texture.
+
+export const SLAB_VERTEX_SHADER = /* glsl */ `
+  varying vec3 vNormalView;
+  varying vec3 vPositionView;
+  varying vec2 vUv;
+
+  void main() {
+    vUv = uv;
+    vNormalView = normalize(normalMatrix * normal);
+    vec4 positionView = modelViewMatrix * vec4(position, 1.0);
+    vPositionView = positionView.xyz;
+    gl_Position = projectionMatrix * positionView;
+  }
+`
+
+export const SLAB_FRAGMENT_SHADER = /* glsl */ `
+  precision mediump float;
+
+  uniform vec3 uEdgeColor;
+  uniform vec3 uCoreColor;
+  uniform float uTime;
+  uniform float uIndex;
+
+  varying vec3 vNormalView;
+  varying vec3 vPositionView;
+  varying vec2 vUv;
+
+  void main() {
+    vec3 normal = normalize(vNormalView);
+    vec3 view = normalize(-vPositionView);
+
+    // Fresnel : le centre reste presque vide, l'arête s'allume. C'est le biseau de la
+    // géométrie qui rend l'effet lisible — sans lui, la dalle serait un simple voile.
+    float fresnel = pow(1.0 - clamp(dot(normal, view), 0.0, 1.0), 3.0);
+
+    // Bande spéculaire unique, qui glisse lentement le long de la dalle. Décalée par
+    // dalle pour que les trois ne clignotent pas ensemble.
+    float bandeCentre = fract(uTime * 0.06 + uIndex * 0.31);
+    float bande = smoothstep(0.06, 0.0, abs(vUv.y - bandeCentre));
+
+    vec3 couleur = mix(uCoreColor, uEdgeColor, fresnel);
+    couleur += bande * 0.35;
+
+    float alpha = mix(0.045, 0.55, fresnel) + bande * 0.10;
+    gl_FragColor = vec4(couleur, clamp(alpha, 0.0, 0.75));
+  }
+`
+
+/**
+ * Teinte d'arête par dalle : cuivrée, neutre, froide.
+ *
+ * Les trois pôles sont codés sans être nommés — la scène n'affiche aucun texte et
+ * n'est jamais la source d'une information que la page ne donne pas déjà.
+ */
+export const SLAB_EDGE_COLORS = ['#b4623a', '#9ba3aa', '#7f97a8'] as const
+
+/** Cœur de dalle, presque éteint : c'est l'absence de matière qui fait le verre. */
+export const SLAB_CORE_COLOR = '#c9c2b6'

--- a/src/@shared/three/slab-shader.ts
+++ b/src/@shared/three/slab-shader.ts
@@ -28,6 +28,8 @@ export const SLAB_FRAGMENT_SHADER = /* glsl */ `
   uniform vec3 uCoreColor;
   uniform float uTime;
   uniform float uIndex;
+  uniform float uCoreAlpha;
+  uniform float uEdgeAlpha;
 
   varying vec3 vNormalView;
   varying vec3 vPositionView;
@@ -37,9 +39,10 @@ export const SLAB_FRAGMENT_SHADER = /* glsl */ `
     vec3 normal = normalize(vNormalView);
     vec3 view = normalize(-vPositionView);
 
-    // Fresnel : le centre reste presque vide, l'arête s'allume. C'est le biseau de la
-    // géométrie qui rend l'effet lisible — sans lui, la dalle serait un simple voile.
-    float fresnel = pow(1.0 - clamp(dot(normal, view), 0.0, 1.0), 3.0);
+    // Fresnel : le centre reste presque vide, l'arête s'allume. Exposant 2.0 plutôt
+    // que 3.0 — à 3.0, une dalle vue de face n'allume plus que son biseau et devient
+    // invisible sur un fond clair, ce qui vide la scène de son sujet.
+    float fresnel = pow(1.0 - clamp(dot(normal, view), 0.0, 1.0), 2.0);
 
     // Bande spéculaire unique, qui glisse lentement le long de la dalle. Décalée par
     // dalle pour que les trois ne clignotent pas ensemble.
@@ -47,20 +50,24 @@ export const SLAB_FRAGMENT_SHADER = /* glsl */ `
     float bande = smoothstep(0.06, 0.0, abs(vUv.y - bandeCentre));
 
     vec3 couleur = mix(uCoreColor, uEdgeColor, fresnel);
-    couleur += bande * 0.35;
 
-    float alpha = mix(0.045, 0.55, fresnel) + bande * 0.10;
-    gl_FragColor = vec4(couleur, clamp(alpha, 0.0, 0.75));
+    float alpha = mix(uCoreAlpha, uEdgeAlpha, fresnel) + bande * 0.08;
+    gl_FragColor = vec4(couleur, clamp(alpha, 0.0, 0.85));
   }
 `
 
 /**
- * Teinte d'arête par dalle : cuivrée, neutre, froide.
+ * Opacité du corps et de l'arête.
  *
- * Les trois pôles sont codés sans être nommés — la scène n'affiche aucun texte et
- * n'est jamais la source d'une information que la page ne donne pas déjà.
+ * Deux jeux de valeurs, parce que le verre ne se lit pas pareil selon le fond : posé
+ * sur le papier clair, un voile à 4 % disparaît purement et simplement — c'est le
+ * défaut qu'on corrige ici. Sur le graphite du thème sombre, la même valeur suffit
+ * largement et monter plus haut donnerait une plaque laiteuse.
  */
-export const SLAB_EDGE_COLORS = ['#b4623a', '#9ba3aa', '#7f97a8'] as const
+export const SLAB_ALPHA = {
+  clair: { corps: 0.035, arete: 0.3 },
+  sombre: { corps: 0.03, arete: 0.34 },
+} as const
 
-/** Cœur de dalle, presque éteint : c'est l'absence de matière qui fait le verre. */
-export const SLAB_CORE_COLOR = '#c9c2b6'
+/** Teinte d'arête par dalle : la première prend le cuivre, les deux autres s'éteignent. */
+export const SLAB_EDGE_TINT = [1, 0.55, 0.3] as const

--- a/src/@shared/three/use-scroll-progress.ts
+++ b/src/@shared/three/use-scroll-progress.ts
@@ -1,0 +1,40 @@
+'use client'
+
+// use-scroll-progress.ts — jeromemarichez-fr
+// Avancement du défilement dans le premier écran, lu sans re-rendre React.
+
+import { type MutableRefObject, useEffect, useRef } from 'react'
+
+/**
+ * Rend une référence dont `.current` va de 0 (haut de page) à 1 (un écran plus bas).
+ *
+ * La valeur vit dans une `ref` et non dans un état : un `useState` déclencherait un
+ * rendu React à chaque frame de défilement, ce qui coûterait bien plus cher que la
+ * scène elle-même. Le listener est `passive` et ne fait qu'une lecture, la mise à
+ * jour réelle se faisant dans la boucle de rendu.
+ */
+export function useScrollProgress(): MutableRefObject<number> {
+  const progression = useRef(0)
+
+  useEffect(() => {
+    let planifie = false
+
+    const lire = () => {
+      planifie = false
+      const hauteur = window.innerHeight || 1
+      progression.current = Math.min(1, Math.max(0, window.scrollY / hauteur))
+    }
+
+    const onScroll = () => {
+      if (planifie) return
+      planifie = true
+      requestAnimationFrame(lire)
+    }
+
+    lire()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return progression
+}

--- a/src/@shared/three/use-theme-colors.ts
+++ b/src/@shared/three/use-theme-colors.ts
@@ -1,0 +1,38 @@
+'use client'
+
+// use-theme-colors.ts — jeromemarichez-fr
+// Les couleurs de la scène viennent des jetons CSS, pas de constantes en dur.
+
+import { useEffect, useState } from 'react'
+
+export interface SceneColors {
+  /** Liseré des dalles. Jeton `--cuivre-vif`. */
+  arete: string
+  /** Teinte du corps des dalles. Jeton `--encre`. */
+  corps: string
+}
+
+const DEFAUT: SceneColors = { arete: '#b4623a', corps: '#14171a' }
+
+/**
+ * Lit `--cuivre-vif` et `--encre` sur la racine du document.
+ *
+ * Sans cela, la scène porterait sa propre palette et se désaccorderait du thème sombre
+ * — un objet 3D teinté pour du papier chaud posé sur un fond graphite se voit
+ * immédiatement. Les jetons restent la source unique de vérité, y compris en WebGL.
+ */
+export function useThemeColors(): SceneColors {
+  const [couleurs, setCouleurs] = useState<SceneColors>(DEFAUT)
+
+  useEffect(() => {
+    const styles = getComputedStyle(document.documentElement)
+    const lire = (jeton: string, repli: string) => styles.getPropertyValue(jeton).trim() || repli
+
+    setCouleurs({
+      arete: lire('--cuivre-vif', DEFAUT.arete),
+      corps: lire('--encre', DEFAUT.corps),
+    })
+  }, [])
+
+  return couleurs
+}

--- a/src/@shared/typography/fonts.ts
+++ b/src/@shared/typography/fonts.ts
@@ -1,0 +1,38 @@
+// fonts.ts — jeromemarichez-fr
+// Les familles de caractères, chargées par `next/font` et exposées en variables CSS.
+//
+// `next/font/google` télécharge les fichiers au build et les sert depuis le domaine du
+// site : aucune requête vers fonts.gstatic.com à l'exécution, donc aucun tiers dans le
+// chemin critique et rien à déclarer côté RGPD. `display: 'swap'` évite le texte
+// invisible pendant le chargement, qui compterait comme un défaut de LCP.
+
+import { Fraunces, IBM_Plex_Mono, Inter } from 'next/font/google'
+
+/** Titres et accroches. Serif à contraste variable, pour le registre d'atelier. */
+export const fontDisplay = Fraunces({
+  subsets: ['latin'],
+  display: 'swap',
+  // Pas de `weight` : `axes` n'est acceptable que sur une fonte chargée en variable.
+  // `SOFT` et `WONK` à zéro retirent la fantaisie de Fraunces et laissent une antique
+  // ferme — le registre visé, celui d'un homme qui parle, pas d'un logotype d'agence.
+  axes: ['SOFT', 'WONK', 'opsz'],
+  variable: '--police-titre',
+})
+
+/** Texte courant. */
+export const fontBody = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--police-texte',
+})
+
+/** Étiquettes techniques, chiffres, rangs de pôle. */
+export const fontMono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  weight: ['400', '500'],
+  variable: '--police-mono',
+})
+
+/** Classes à poser sur `<html>` pour exposer les trois variables. */
+export const FONT_VARIABLES = `${fontDisplay.variable} ${fontBody.variable} ${fontMono.variable}`

--- a/src/@types/liquid-gl.d.ts
+++ b/src/@types/liquid-gl.d.ts
@@ -1,0 +1,59 @@
+// liquid-gl.d.ts — jeromemarichez-fr
+// Déclarations pour `liquid-gl` (NaughtyDuk, MIT) — le paquet est publié sans types.
+// Surface volontairement réduite à ce que le site utilise réellement.
+
+declare module 'liquid-gl' {
+  /** Options de rendu d'une lentille. Voir `@shared/glass/settings`. */
+  export interface LiquidGlOptions {
+    /** Sélecteur des éléments transformés en verre. */
+    target?: string
+    /** Élément capturé pour la réfraction. `'body'` par défaut. */
+    snapshot?: string
+    /** Qualité de la capture, 0.1 à 3. Coût GPU en carré de ce facteur. */
+    resolution?: number
+    /** Force du décalage réfractif, 0 à 1. */
+    refraction?: number
+    /** Aberration chromatique, 0 à 1. */
+    aberration?: number
+    /** Profondeur du biseau, 0 à 1. */
+    bevelDepth?: number
+    /** Largeur de la zone biseautée, 0 à 1. */
+    bevelWidth?: number
+    /** Rayon de flou, en pixels. */
+    frost?: number
+    /** Ombre portée. */
+    shadow?: boolean
+    /** Reflet spéculaire. */
+    specular?: boolean
+    /** Apparition de la lentille. */
+    reveal?: 'none' | 'fade'
+    /** Inclinaison au survol. */
+    tilt?: boolean
+    /** Amplitude de l'inclinaison, 0 à 25 degrés. */
+    tiltFactor?: number
+    /** Durée d'amortissement de l'inclinaison, en millisecondes. */
+    tiltEase?: number
+    /** Grossissement, 0.001 à 3. */
+    magnify?: number
+    on?: { init?: () => void }
+  }
+
+  /** Une lentille attachée à un élément du DOM. */
+  export interface LiquidGlLens {
+    el: HTMLElement
+    options: LiquidGlOptions
+    setShadow(enabled: boolean): void
+    setTilt(enabled: boolean): void
+  }
+
+  export interface LiquidGl {
+    (options?: LiquidGlOptions): LiquidGlLens | LiquidGlLens[] | undefined
+    /** Déclare des éléments animés que la capture doit rafraîchir. */
+    registerDynamic(elements: string | Element | Element[]): void
+    /** Branche le rendu sur un défilement lissé (Lenis, Locomotive). */
+    syncWith(config?: Record<string, unknown>): unknown
+  }
+
+  const liquidGL: LiquidGl
+  export default liquidGL
+}

--- a/src/@vitrine/components/BoundaryList/boundary-list.module.css
+++ b/src/@vitrine/components/BoundaryList/boundary-list.module.css
@@ -1,0 +1,34 @@
+/* boundary-list.module.css — ce que je ne fais pas.
+ * Le terme est barré d'un filet, pas d'une croix : le registre reste celui du relevé
+ * technique, pas celui de l'excuse. */
+
+.liste {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 24rem), 1fr));
+  gap: var(--e-4);
+  margin: 0;
+}
+
+.paire {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  padding-left: var(--e-3);
+  border-left: 2px solid color-mix(in srgb, var(--encre) 20%, transparent);
+}
+
+.hors {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--encre);
+}
+
+.alaPlace {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--encre-douce);
+}

--- a/src/@vitrine/components/BoundaryList/index.tsx
+++ b/src/@vitrine/components/BoundaryList/index.tsx
@@ -1,0 +1,27 @@
+// BoundaryList/index.tsx — jeromemarichez-fr
+// Le bloc qui rend tout le reste croyable.
+
+import type { IBoundary } from '@/interfaces/IBoundary'
+import styles from './boundary-list.module.css'
+
+interface BoundaryListProps {
+  limites: IBoundary[]
+}
+
+/**
+ * Une liste de définitions plutôt qu'un tableau : chaque limite est un terme, et ce
+ * qui est fait à la place en est la définition. Un lecteur d'écran restitue la paire
+ * telle quelle, ce qu'un tableau à deux colonnes rendrait bien plus laborieusement.
+ */
+export function BoundaryList({ limites }: BoundaryListProps) {
+  return (
+    <dl className={styles.liste}>
+      {limites.map((limite) => (
+        <div className={styles.paire} key={limite.hors}>
+          <dt className={styles.hors}>{limite.hors}</dt>
+          <dd className={styles.alaPlace}>{limite.alaPlace}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/src/@vitrine/components/CertificationList/certification-list.module.css
+++ b/src/@vitrine/components/CertificationList/certification-list.module.css
@@ -1,0 +1,52 @@
+/* certification-list.module.css — les certifications.
+ * Aucun justificatif n'étant publié à ce jour, la liste s'affiche entièrement sans
+ * lien. Le style ne simule donc pas de lien : rien n'est souligné ni coloré en
+ * cuivre tant qu'il n'y a pas de cible réelle. */
+
+.liste {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  padding-top: var(--e-2);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+}
+
+.intitule {
+  font-family: var(--police-titre-pile);
+  font-variation-settings:
+    "SOFT" 0,
+    "WONK" 0,
+    "opsz" 18;
+  font-weight: 600;
+  font-size: 1.0625rem;
+  line-height: 1.25;
+}
+
+.organisme {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6em;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.04em;
+  color: var(--encre-douce);
+}
+
+.annee {
+  color: var(--cuivre);
+}
+
+.apport {
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--encre-douce);
+}

--- a/src/@vitrine/components/CertificationList/certification-list.module.css
+++ b/src/@vitrine/components/CertificationList/certification-list.module.css
@@ -20,6 +20,43 @@
   border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
 }
 
+/* La plaque : hauteur fixe pour tous les organismes, sinon sept logos de ratios
+   différents transforment la grille en escalier. Le fond reste clair dans les deux
+   thèmes — les logos de marque sont dessinés pour un fond clair et les inverser
+   contreviendrait aux chartes d'usage de leurs propriétaires. */
+.plaque {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: 3rem;
+  margin-bottom: var(--e-2);
+  padding: 0 var(--e-3);
+  border-radius: var(--rayon-petit);
+  background: #fbfaf7;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--encre) 10%, transparent);
+}
+
+.logo {
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 1.75rem;
+  object-fit: contain;
+}
+
+/* Repli lisible tant qu'aucun fichier n'est déposé : le nom de l'organisme tient la
+   place exacte du futur logo, donc la mise en page ne bougera pas en l'ajoutant. */
+.sigle {
+  overflow: hidden;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: #4a5157;
+}
+
 .intitule {
   font-family: var(--police-titre-pile);
   font-variation-settings:

--- a/src/@vitrine/components/CertificationList/index.tsx
+++ b/src/@vitrine/components/CertificationList/index.tsx
@@ -1,6 +1,7 @@
 // CertificationList/index.tsx — jeromemarichez-fr
 // Les certifications, avec ce que chacune change concrètement.
 
+import Image from 'next/image'
 import type { ICertification } from '@/interfaces/ICertification'
 import styles from './certification-list.module.css'
 
@@ -9,19 +10,38 @@ interface CertificationListProps {
 }
 
 /**
- * Rend une liste de certifications.
+ * Rend une liste de certifications, chacune en tête de sa plaque de logo.
  *
- * Une certification n'est affichée avec un lien que si son justificatif officiel est
- * connu (`ICertification.justificatif`). Aucun n'ayant été fourni à ce jour, la liste
- * s'affiche entièrement sans lien : c'est volontaire, et c'est la règle du projet —
- * mieux vaut une certification non cliquable qu'un lien mort sur un site qui vend de
- * la rigueur.
+ * Deux règles se rejoignent ici, et toutes deux tiennent au même principe — ne jamais
+ * publier ce qui n'a pas été fourni :
+ *   — le lien n'apparaît que si le justificatif officiel est connu ;
+ *   — le logo n'apparaît que si le fichier a été déposé dans `public/certifications/`
+ *     **et** autorisé par le propriétaire de la marque (voir le LISEZMOI du dossier).
+ * Sans fichier, la plaque affiche le nom de l'organisme en lettres capitales : la grille
+ * garde son rythme, et rien n'est cassé.
+ *
+ * Le logo est `alt=""` : l'organisme est déjà écrit juste en dessous, et le doubler
+ * ferait entendre deux fois la même chose à un lecteur d'écran.
  */
 export function CertificationList({ certifications }: CertificationListProps) {
   return (
     <ul className={styles.liste}>
       {certifications.map((certification) => (
         <li className={styles.item} key={certification.intitule}>
+          <span className={styles.plaque}>
+            {certification.logo ? (
+              <Image
+                alt=""
+                className={styles.logo}
+                height={certification.logo.hauteur}
+                src={certification.logo.fichier}
+                width={certification.logo.largeur}
+              />
+            ) : (
+              <span className={styles.sigle}>{certification.organisme}</span>
+            )}
+          </span>
+
           <p className={styles.intitule}>
             {certification.justificatif ? (
               <a href={certification.justificatif} rel="noopener noreferrer" target="_blank">

--- a/src/@vitrine/components/CertificationList/index.tsx
+++ b/src/@vitrine/components/CertificationList/index.tsx
@@ -1,0 +1,45 @@
+// CertificationList/index.tsx — jeromemarichez-fr
+// Les certifications, avec ce que chacune change concrètement.
+
+import type { ICertification } from '@/interfaces/ICertification'
+import styles from './certification-list.module.css'
+
+interface CertificationListProps {
+  certifications: ICertification[]
+}
+
+/**
+ * Rend une liste de certifications.
+ *
+ * Une certification n'est affichée avec un lien que si son justificatif officiel est
+ * connu (`ICertification.justificatif`). Aucun n'ayant été fourni à ce jour, la liste
+ * s'affiche entièrement sans lien : c'est volontaire, et c'est la règle du projet —
+ * mieux vaut une certification non cliquable qu'un lien mort sur un site qui vend de
+ * la rigueur.
+ */
+export function CertificationList({ certifications }: CertificationListProps) {
+  return (
+    <ul className={styles.liste}>
+      {certifications.map((certification) => (
+        <li className={styles.item} key={certification.intitule}>
+          <p className={styles.intitule}>
+            {certification.justificatif ? (
+              <a href={certification.justificatif} rel="noopener noreferrer" target="_blank">
+                {certification.intitule}
+              </a>
+            ) : (
+              certification.intitule
+            )}
+          </p>
+          <p className={styles.organisme}>
+            {certification.organisme}
+            {certification.annee ? (
+              <span className={styles.annee}>{certification.annee}</span>
+            ) : null}
+          </p>
+          <p className={styles.apport}>{certification.apport}</p>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
+++ b/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
@@ -1,0 +1,89 @@
+/* chain-diagram.module.css — la chaîne en un écran.
+ * Les plaques sont décalées en diagonale : la lecture descend, comme la chaîne. Le
+ * décalage est supprimé sous 900px, où il ferait déborder la grille. */
+
+.chaine {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: maillon;
+}
+
+.maillon {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+}
+
+.maillon:nth-child(2) {
+  padding-left: clamp(0rem, 4vw, 3.5rem);
+}
+
+.maillon:nth-child(3) {
+  padding-left: clamp(0rem, 8vw, 7rem);
+}
+
+.plaque {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  max-width: 34rem;
+  padding: var(--e-4);
+  border: 1px solid var(--verre-arete);
+  border-radius: var(--rayon-verre);
+  background: color-mix(in srgb, var(--fond) 55%, transparent);
+  box-shadow: inset 0 1px 0 var(--verre-lueur);
+}
+
+.rang {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--cuivre);
+}
+
+.nom {
+  font-size: var(--t-2);
+  margin: 0;
+}
+
+.lien {
+  color: var(--encre);
+  text-decoration-color: var(--cuivre-vif);
+}
+
+.promesse {
+  color: var(--encre-douce);
+}
+
+/* La remise est ce que le pôle transmet au suivant. Sans elle, les trois plaques
+   redeviennent trois offres posées côte à côte. */
+.remise {
+  display: flex;
+  align-items: baseline;
+  gap: var(--e-2);
+  max-width: 40rem;
+  padding-left: clamp(0rem, 4vw, 3.5rem);
+  font-size: 0.9375rem;
+  color: var(--encre-douce);
+}
+
+.fleche {
+  flex: none;
+  width: 2px;
+  height: 1.6em;
+  background: var(--cuivre-vif);
+}
+
+@media (max-width: 900px) {
+  .maillon:nth-child(2),
+  .maillon:nth-child(3),
+  .remise {
+    padding-left: 0;
+  }
+}

--- a/src/@vitrine/components/ChainDiagram/index.tsx
+++ b/src/@vitrine/components/ChainDiagram/index.tsx
@@ -1,0 +1,43 @@
+// ChainDiagram/index.tsx — jeromemarichez-fr
+// La chaîne en un écran : trois plaques, deux passages de relais.
+
+import Link from 'next/link'
+import { POLES_NAV } from '../../contenu/poles-nav'
+import styles from './chain-diagram.module.css'
+
+/**
+ * Le schéma est en HTML et CSS purs — pas de canvas, pas de SVG porteur de texte.
+ *
+ * C'est délibéré : ce bloc sert à la fois de thèse, de sommaire et d'ancre de
+ * navigation. Il doit donc être lu par un moteur de recherche, atteint au clavier et
+ * annoncé par un lecteur d'écran. Une image ne rendrait aucun de ces trois services.
+ *
+ * `<ol>` et non `<ul>` : l'ordre porte le sens. On ne pioche pas un pôle dans un menu,
+ * on avance dans une chaîne.
+ */
+export function ChainDiagram() {
+  return (
+    <ol className={styles.chaine}>
+      {POLES_NAV.map((pole) => (
+        <li className={styles.maillon} key={pole.id}>
+          <article className={styles.plaque}>
+            <p className={styles.rang}>Pôle {pole.rang}</p>
+            <h3 className={styles.nom}>
+              <Link className={styles.lien} href={pole.route}>
+                {pole.nom}
+              </Link>
+            </h3>
+            <p className={styles.promesse}>{pole.promesse}</p>
+          </article>
+
+          {pole.remise ? (
+            <p className={styles.remise}>
+              <span aria-hidden="true" className={styles.fleche} />
+              {pole.remise}
+            </p>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/src/@vitrine/components/EditorialSection/editorial-section.module.css
+++ b/src/@vitrine/components/EditorialSection/editorial-section.module.css
@@ -40,14 +40,9 @@
 }
 
 /* Variante vitrée : la section est posée sur le fond d'atelier, et le verre laisse
-   voir la trame se plier au niveau du biseau. La mesure du texte est resserrée à
-   46ch — un panneau de verre plus large que ça devient une vitre, pas une carte, et
-   Safari devient instable au-delà de la moitié du viewport. */
-.verre {
-  padding: var(--e-5);
-  max-width: 100%;
-}
-
+   voir la trame se plier au niveau du biseau. Le rembourrage vit dans le composant
+   `GlassSurface` — ici, seule la largeur de mesure change, le texte d'un panneau
+   pouvant occuper toute sa largeur. */
 .verre .chapo,
 .verre .blocs {
   max-width: none;

--- a/src/@vitrine/components/EditorialSection/editorial-section.module.css
+++ b/src/@vitrine/components/EditorialSection/editorial-section.module.css
@@ -1,0 +1,54 @@
+/* editorial-section.module.css — une section de contenu. */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+  scroll-margin-top: 6rem;
+}
+
+.entete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+}
+
+.kicker {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--cuivre);
+}
+
+.titre {
+  margin: 0;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+.blocs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 21rem), 1fr));
+  gap: var(--e-4);
+}
+
+/* Variante vitrée : la section est posée sur le fond d'atelier, et le verre laisse
+   voir la trame se plier au niveau du biseau. La mesure du texte est resserrée à
+   46ch — un panneau de verre plus large que ça devient une vitre, pas une carte, et
+   Safari devient instable au-delà de la moitié du viewport. */
+.verre {
+  padding: var(--e-5);
+  max-width: 100%;
+}
+
+.verre .chapo,
+.verre .blocs {
+  max-width: none;
+}

--- a/src/@vitrine/components/EditorialSection/index.tsx
+++ b/src/@vitrine/components/EditorialSection/index.tsx
@@ -6,6 +6,7 @@ import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 import { ExpertiseBlock } from '../ExpertiseBlock'
 import { HingeNote } from '../HingeNote'
 import { HingeSection } from '../HingeSection'
+import { ThreadSection } from '../ThreadSection'
 import styles from './editorial-section.module.css'
 
 interface EditorialSectionProps {
@@ -26,6 +27,9 @@ export function EditorialSection({ section, glass = false }: EditorialSectionPro
   // Une charnière n'est pas une section de contenu avec un fond différent : elle a sa
   // propre grammaire — pas de blocs d'expertise, pas de verre, un filet qui se trace.
   if (section.kind === 'charniere') return <HingeSection section={section} />
+  // Un fil traverse les trois pôles au lieu de s'intercaler entre deux : il a lui aussi
+  // sa grammaire propre — étapes numérotées, filet horizontal, jamais de verre.
+  if (section.kind === 'fil') return <ThreadSection section={section} />
 
   const titreId = `${section.id}-titre`
 

--- a/src/@vitrine/components/EditorialSection/index.tsx
+++ b/src/@vitrine/components/EditorialSection/index.tsx
@@ -1,0 +1,58 @@
+// EditorialSection/index.tsx — jeromemarichez-fr
+// Une section de contenu, rendue selon sa nature.
+
+import { GlassSurface } from '@/@shared/components/GlassSurface'
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+import { ExpertiseBlock } from '../ExpertiseBlock'
+import { HingeNote } from '../HingeNote'
+import { HingeSection } from '../HingeSection'
+import styles from './editorial-section.module.css'
+
+interface EditorialSectionProps {
+  section: IEditorialSection
+  /** Rendu sur verre réfractant. Réservé aux sections posées sur un fond travaillé. */
+  glass?: boolean
+}
+
+/**
+ * Rend une section éditoriale, chapô puis blocs d'expertise, et referme sur sa
+ * charnière quand elle en porte une.
+ *
+ * Le contenu vient d'une structure typée : ajouter un point d'expertise se fait dans
+ * `@vitrine/contenu`, jamais ici. C'est la contrainte d'architecture du projet — le
+ * rendu ne connaît pas le fond.
+ */
+export function EditorialSection({ section, glass = false }: EditorialSectionProps) {
+  // Une charnière n'est pas une section de contenu avec un fond différent : elle a sa
+  // propre grammaire — pas de blocs d'expertise, pas de verre, un filet qui se trace.
+  if (section.kind === 'charniere') return <HingeSection section={section} />
+
+  const titreId = `${section.id}-titre`
+
+  const corps = (
+    <>
+      <header className={styles.entete}>
+        <p className={styles.kicker}>{section.kicker}</p>
+        <h2 className={styles.titre} id={titreId}>
+          {section.titre}
+        </h2>
+        <p className={styles.chapo}>{section.chapo}</p>
+      </header>
+
+      {section.blocs.length > 0 ? (
+        <div className={styles.blocs}>
+          {section.blocs.map((bloc) => (
+            <ExpertiseBlock key={bloc.titre} bloc={bloc} />
+          ))}
+        </div>
+      ) : null}
+    </>
+  )
+
+  return (
+    <section aria-labelledby={titreId} className={styles.section} id={section.id}>
+      {glass ? <GlassSurface className={styles.verre}>{corps}</GlassSurface> : corps}
+      {section.transition ? <HingeNote texte={section.transition} /> : null}
+    </section>
+  )
+}

--- a/src/@vitrine/components/ExpertiseBlock/expertise-block.module.css
+++ b/src/@vitrine/components/ExpertiseBlock/expertise-block.module.css
@@ -1,0 +1,46 @@
+/* expertise-block.module.css — un point d'expertise.
+ * La preuve et la décision sont les deux seules lignes qu'un dirigeant pressé lira :
+ * elles sont repérables au filet cuivre, sans être criées. */
+
+.bloc {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+  padding-top: var(--e-3);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+}
+
+.titre {
+  font-size: var(--t-2);
+  margin: 0;
+}
+
+.texte {
+  max-width: 46ch;
+  color: var(--encre-douce);
+}
+
+.preuve,
+.decision {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 46ch;
+  padding-left: var(--e-2);
+  border-left: 2px solid var(--cuivre-vif);
+  font-size: 0.9375rem;
+}
+
+.decision {
+  border-left-color: var(--signal);
+  color: var(--encre);
+}
+
+.etiquette {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--encre-douce);
+}

--- a/src/@vitrine/components/ExpertiseBlock/index.tsx
+++ b/src/@vitrine/components/ExpertiseBlock/index.tsx
@@ -1,0 +1,43 @@
+// ExpertiseBlock/index.tsx — jeromemarichez-fr
+// Un point d'expertise : ce qu'il couvre, ce qu'il prouve, ce qu'il permet de trancher.
+
+import type { IEditorialBlock } from '@/interfaces/IEditorialBlock'
+import styles from './expertise-block.module.css'
+
+interface ExpertiseBlockProps {
+  bloc: IEditorialBlock
+  /** Niveau de titre, pour que la hiérarchie du document reste juste selon le contexte. */
+  headingLevel?: 'h3' | 'h4'
+}
+
+/**
+ * Rend un bloc d'expertise.
+ *
+ * La preuve et la décision sont typographiées différemment du corps : ce sont les deux
+ * seules lignes qu'un dirigeant pressé lira, et la ligne éditoriale du projet veut
+ * qu'elles soient repérables sans être criées.
+ */
+export function ExpertiseBlock({ bloc, headingLevel = 'h3' }: ExpertiseBlockProps) {
+  const Heading = headingLevel
+
+  return (
+    <article className={styles.bloc}>
+      <Heading className={styles.titre}>{bloc.titre}</Heading>
+      <p className={styles.texte}>{bloc.texte}</p>
+
+      {bloc.preuve ? (
+        <p className={styles.preuve}>
+          <span className={styles.etiquette}>Preuve</span>
+          {bloc.preuve}
+        </p>
+      ) : null}
+
+      {bloc.decision ? (
+        <p className={styles.decision}>
+          <span className={styles.etiquette}>Ce que vous tranchez</span>
+          {bloc.decision}
+        </p>
+      ) : null}
+    </article>
+  )
+}

--- a/src/@vitrine/components/HingeNote/hinge-note.module.css
+++ b/src/@vitrine/components/HingeNote/hinge-note.module.css
@@ -1,0 +1,49 @@
+/* hinge-note.module.css — la charnière.
+ * Le filet vertical cuivre est le seul mouvement du site qui porte du sens : la
+ * chaîne se trace. Il est purement décoratif au sens accessibilité — les lecteurs
+ * d'écran n'entendent que la phrase. */
+
+.charniere {
+  position: relative;
+  max-width: 54ch;
+  margin-top: var(--e-3);
+  padding-left: var(--e-4);
+  font-family: var(--police-titre-pile);
+  font-variation-settings:
+    "SOFT" 0,
+    "WONK" 0,
+    "opsz" 24;
+  font-size: var(--t-1);
+  line-height: 1.4;
+  color: var(--encre);
+}
+
+.charniere::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 2px;
+  background: var(--cuivre-vif);
+  transform-origin: top;
+  animation: tracer var(--duree-tracer) var(--courbe-tracer) both;
+}
+
+.texte {
+  display: block;
+}
+
+@keyframes tracer {
+  from {
+    transform: scaleY(0);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .charniere::before {
+    animation: none;
+  }
+}

--- a/src/@vitrine/components/HingeNote/index.tsx
+++ b/src/@vitrine/components/HingeNote/index.tsx
@@ -1,0 +1,27 @@
+// HingeNote/index.tsx — jeromemarichez-fr
+// La phrase qui passe la main d'un pôle au suivant.
+
+import styles from './hinge-note.module.css'
+
+interface HingeNoteProps {
+  texte: string
+}
+
+/**
+ * Rend une charnière.
+ *
+ * C'est le composant le plus important du site pour ce qu'il vend : sans ces phrases,
+ * les trois pôles redeviennent trois offres juxtaposées, et l'argument « c'est la même
+ * personne du cadrage au run » tombe. Elles sont donc rendues comme des respirations
+ * pleine largeur, pas comme des notes de bas de section.
+ *
+ * Le trait qui les précède est purement décoratif : il est produit en CSS et reste
+ * invisible aux lecteurs d'écran, qui n'entendent que la phrase.
+ */
+export function HingeNote({ texte }: HingeNoteProps) {
+  return (
+    <p className={styles.charniere}>
+      <span className={styles.texte}>{texte}</span>
+    </p>
+  )
+}

--- a/src/@vitrine/components/HingeSection/hinge-section.module.css
+++ b/src/@vitrine/components/HingeSection/hinge-section.module.css
@@ -1,0 +1,88 @@
+/* hinge-section.module.css — la charnière.
+ * Bande en retrait, filet cuivre vertical qui se trace à l'entrée : c'est le seul
+ * mouvement du site qui porte du sens — la chaîne se trace sous les yeux. */
+
+.charniere {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+  max-width: 60ch;
+  margin-left: clamp(0rem, 6vw, 5rem);
+  padding: var(--e-5) 0 var(--e-5) var(--e-4);
+  scroll-margin-top: 6rem;
+}
+
+.charniere::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 2px;
+  background: var(--cuivre-vif);
+  transform-origin: top;
+  animation: tracer var(--duree-tracer) var(--courbe-tracer) both;
+}
+
+.kicker {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--cuivre);
+}
+
+.titre {
+  margin: 0;
+}
+
+.texte {
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+.reperes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+  margin: var(--e-1) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.repere {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.6em;
+  font-size: 0.9375rem;
+}
+
+.repereTitre {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--encre);
+}
+
+.repereTexte {
+  color: var(--encre-douce);
+}
+
+@keyframes tracer {
+  from {
+    transform: scaleY(0);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .charniere::before {
+    animation: none;
+  }
+}

--- a/src/@vitrine/components/HingeSection/index.tsx
+++ b/src/@vitrine/components/HingeSection/index.tsx
@@ -1,0 +1,45 @@
+// HingeSection/index.tsx — jeromemarichez-fr
+// Une charnière : le moment où un pôle passe la main au suivant.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+import styles from './hinge-section.module.css'
+
+interface HingeSectionProps {
+  section: IEditorialSection
+}
+
+/**
+ * Les charnières sont des sections à part entière, avec leur propre `h2` — pas des
+ * transitions décoratives entre deux blocs.
+ *
+ * C'est ce qui distingue ce site d'un catalogue : sans elles, « ingénierie web »,
+ * « data & IA » et « SEA & UX » redeviennent trois prestations qu'on pourrait acheter
+ * à trois fournisseurs différents. Avec elles, l'enchaînement devient l'argument — et
+ * l'argument n'est tenable que parce que c'est la même personne aux trois postes.
+ *
+ * Les repères sont rendus en liste : ce sont des faits d'exploitation, pas du décor.
+ */
+export function HingeSection({ section }: HingeSectionProps) {
+  const titreId = `${section.id}-titre`
+
+  return (
+    <section aria-labelledby={titreId} className={styles.charniere} id={section.id}>
+      <p className={styles.kicker}>{section.kicker}</p>
+      <h2 className={styles.titre} id={titreId}>
+        {section.titre}
+      </h2>
+      <p className={styles.texte}>{section.chapo}</p>
+
+      {section.blocs.length > 0 ? (
+        <ul className={styles.reperes}>
+          {section.blocs.map((bloc) => (
+            <li className={styles.repere} key={bloc.titre}>
+              <span className={styles.repereTitre}>{bloc.titre}</span>
+              <span className={styles.repereTexte}>{bloc.texte}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  )
+}

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -37,6 +37,19 @@
   color: var(--encre-douce);
 }
 
+/* La ligne de méthode : filet cuivre à gauche, comme le fil transverse plus bas dans la
+   page. Elle n'est pas une accroche de plus — c'est le rappel visuel qui relie le seuil
+   à la section « Le fil ». */
+.methode {
+  max-width: 52ch;
+  padding-left: var(--e-3);
+  border-left: 2px solid var(--cuivre-vif);
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  line-height: 1.6;
+  color: var(--encre);
+}
+
 .actions {
   display: flex;
   flex-wrap: wrap;
@@ -104,7 +117,15 @@
 }
 
 .volume {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--e-2);
   min-width: 0;
+}
+
+.controle {
+  margin: 0;
 }
 
 /* La scène est un décor : en dessous de 1024px elle est simplement retirée du flux.

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -1,0 +1,123 @@
+/* home-hero.module.css — le seuil.
+ * Deux colonnes 58/42 sur desktop : le discours porte le LCP, le volume ne fait que
+ * l'accompagner et disparaît dès que la place manque. */
+
+.seuil {
+  display: grid;
+  grid-template-columns: minmax(0, 58fr) minmax(0, 42fr);
+  align-items: center;
+  gap: var(--e-6);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-7) var(--e-4) var(--e-6);
+}
+
+.discours {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+}
+
+.situation {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--encre-douce);
+}
+
+.titre {
+  margin: 0;
+}
+
+.chapo {
+  max-width: 52ch;
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--e-4);
+}
+
+.actionPrincipale {
+  display: inline-block;
+  padding: var(--e-2) var(--e-4);
+  border-radius: var(--rayon-petit);
+  background: var(--cuivre);
+  color: var(--fond);
+  text-decoration: none;
+  font-weight: 500;
+  transition:
+    transform 140ms ease-out,
+    box-shadow 140ms ease-out;
+}
+
+.actionPrincipale:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--cuivre) 30%, transparent);
+}
+
+.actionPrincipale:active {
+  transform: translateY(0);
+  transition-duration: 80ms;
+}
+
+.actionSecondaire {
+  color: var(--encre);
+  text-underline-offset: 0.24em;
+}
+
+.jetons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--e-5);
+  margin: var(--e-2) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.jeton {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 16ch;
+}
+
+.chiffre {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: 1.5rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: var(--cuivre);
+}
+
+.libelle {
+  font-size: var(--t--1);
+  line-height: 1.4;
+  color: var(--encre-douce);
+}
+
+.volume {
+  min-width: 0;
+}
+
+/* La scène est un décor : en dessous de 1024px elle est simplement retirée du flux.
+   Rien n'est perdu — elle ne porte aucune information que le texte ne dise déjà — et
+   le budget mobile n'a pas à payer un contexte WebGL. */
+@media (max-width: 1023px) {
+  .seuil {
+    grid-template-columns: minmax(0, 1fr);
+    padding-top: var(--e-6);
+    gap: var(--e-5);
+  }
+
+  .volume {
+    display: none;
+  }
+}

--- a/src/@vitrine/components/HomeHero/index.tsx
+++ b/src/@vitrine/components/HomeHero/index.tsx
@@ -3,6 +3,7 @@
 
 import Link from 'next/link'
 import { ChainCanvas } from '@/@shared/components/ChainCanvas'
+import { MotionToggle } from '@/@shared/components/MotionToggle'
 import { SITE_IDENTITY } from '@/@shared/seo/site'
 import { HERO_ACCUEIL } from '../../contenu/accueil'
 import styles from './home-hero.module.css'
@@ -27,6 +28,7 @@ export function HomeHero() {
           {HERO_ACCUEIL.titre}
         </h1>
         <p className={styles.chapo}>{HERO_ACCUEIL.chapo}</p>
+        <p className={styles.methode}>{HERO_ACCUEIL.methode}</p>
 
         <p className={styles.actions}>
           <a className={styles.actionPrincipale} href={`mailto:${SITE_IDENTITY.email}`}>
@@ -49,6 +51,12 @@ export function HomeHero() {
 
       <div className={styles.volume}>
         <ChainCanvas description="Trois plaques de verre alignées dans le même axe : trois pôles, une seule chaîne." />
+        {/* Le contrôle est posé au pied de la scène, là où le mouvement se voit.
+            WCAG 2.2.2 demande un mécanisme de mise en pause : la préférence système
+            n'en est pas un, elle ne se change pas depuis la page. */}
+        <p className={styles.controle}>
+          <MotionToggle />
+        </p>
       </div>
     </section>
   )

--- a/src/@vitrine/components/HomeHero/index.tsx
+++ b/src/@vitrine/components/HomeHero/index.tsx
@@ -1,0 +1,55 @@
+// HomeHero/index.tsx — jeromemarichez-fr
+// Le seuil : la promesse, et la chaîne annoncée d'entrée.
+
+import Link from 'next/link'
+import { ChainCanvas } from '@/@shared/components/ChainCanvas'
+import { SITE_IDENTITY } from '@/@shared/seo/site'
+import { HERO_ACCUEIL } from '../../contenu/accueil'
+import styles from './home-hero.module.css'
+
+/**
+ * Le `h1` est le seul de la page et il est rendu statiquement : c'est lui le LCP, pas
+ * la scène WebGL, qui n'arrive qu'après et ne bloque rien.
+ *
+ * Les trois jetons de preuve sont posés dès le seuil parce que la promesse
+ * d'interlocuteur unique est invérifiable telle quelle : sans chiffre à côté, elle se
+ * lit comme un slogan d'agence, ce que ce site refuse d'être.
+ */
+export function HomeHero() {
+  return (
+    <section aria-labelledby="seuil-titre" className={styles.seuil}>
+      <div className={styles.discours}>
+        <p className={styles.situation}>
+          {SITE_IDENTITY.titre} à {SITE_IDENTITY.ville} · 9 ans
+        </p>
+
+        <h1 className={styles.titre} id="seuil-titre">
+          {HERO_ACCUEIL.titre}
+        </h1>
+        <p className={styles.chapo}>{HERO_ACCUEIL.chapo}</p>
+
+        <p className={styles.actions}>
+          <a className={styles.actionPrincipale} href={`mailto:${SITE_IDENTITY.email}`}>
+            Décrire mon besoin
+          </a>
+          <Link className={styles.actionSecondaire} href="#chaine">
+            Voir la chaîne
+          </Link>
+        </p>
+
+        <ul className={styles.jetons}>
+          {HERO_ACCUEIL.jetons.map((jeton) => (
+            <li className={styles.jeton} key={jeton.libelle}>
+              <span className={styles.chiffre}>{jeton.chiffre}</span>
+              <span className={styles.libelle}>{jeton.libelle}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className={styles.volume}>
+        <ChainCanvas description="Trois plaques de verre alignées dans le même axe : trois pôles, une seule chaîne." />
+      </div>
+    </section>
+  )
+}

--- a/src/@vitrine/components/PoleHero/index.tsx
+++ b/src/@vitrine/components/PoleHero/index.tsx
@@ -1,0 +1,59 @@
+// PoleHero/index.tsx — jeromemarichez-fr
+// Ouverture d'une page de pôle : où l'on est dans la chaîne, et vers où l'on va.
+
+import Link from 'next/link'
+import { ROUTES } from '@/@shared/routes'
+import type { IPole } from '@/interfaces/IPole'
+import styles from './pole-hero.module.css'
+
+interface PoleHeroProps {
+  pole: IPole
+  suivant?: IPole
+}
+
+/**
+ * Le rang du pôle est affiché en grand, et le maillon suivant est annoncé dès
+ * l'ouverture. Un visiteur qui arrive ici depuis un moteur de recherche doit comprendre
+ * en une seconde qu'il lit un maillon, pas une plaquette isolée.
+ */
+export function PoleHero({ pole, suivant }: PoleHeroProps) {
+  return (
+    <section aria-labelledby="pole-titre" className={styles.hero}>
+      <nav aria-label="Fil d'Ariane" className={styles.ariane}>
+        <Link href={ROUTES.accueil}>Accueil</Link>
+        <span aria-hidden="true"> / </span>
+        <span aria-current="page">{pole.nom}</span>
+      </nav>
+
+      <p className={styles.rang}>
+        <span aria-hidden="true" className={styles.numero}>
+          {pole.rang}
+        </span>
+        <span className={styles.rangTexte}>Pôle {pole.rang} sur 3</span>
+      </p>
+
+      <h1 className={styles.titre} id="pole-titre">
+        {pole.nom}
+      </h1>
+      <p className={styles.promesse}>{pole.promesse}</p>
+      <p className={styles.accroche}>{pole.accroche}</p>
+
+      {suivant ? (
+        <p className={styles.suite}>
+          Ce pôle se termine dans le suivant :{' '}
+          <Link className={styles.lienSuite} href={suivant.route}>
+            {suivant.nom}
+          </Link>
+        </p>
+      ) : (
+        <p className={styles.suite}>
+          Dernier maillon. Ce qui est décidé ici retourne dans le produit —{' '}
+          <Link className={styles.lienSuite} href={ROUTES['ingenierie-web']}>
+            l'ingénierie web
+          </Link>{' '}
+          — et c'est la même personne qui l'implémente.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/@vitrine/components/PoleHero/pole-hero.module.css
+++ b/src/@vitrine/components/PoleHero/pole-hero.module.css
@@ -1,0 +1,76 @@
+/* pole-hero.module.css — ouverture d'une page de pôle. */
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-6) var(--e-4) var(--e-5);
+}
+
+.ariane {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.06em;
+  color: var(--encre-douce);
+}
+
+.rang {
+  display: flex;
+  align-items: baseline;
+  gap: var(--e-2);
+}
+
+.numero {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t-chiffre);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: color-mix(in srgb, var(--cuivre) 45%, transparent);
+}
+
+.rangTexte {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--encre-douce);
+}
+
+.titre {
+  margin: 0;
+}
+
+.promesse {
+  max-width: 44ch;
+  font-family: var(--police-titre-pile);
+  font-variation-settings:
+    "SOFT" 0,
+    "WONK" 0,
+    "opsz" 28;
+  font-size: var(--t-2);
+  line-height: 1.3;
+  color: var(--cuivre);
+}
+
+.accroche {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+.suite {
+  margin-top: var(--e-3);
+  padding-top: var(--e-3);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+  max-width: var(--mesure-texte);
+  font-size: 0.9375rem;
+  color: var(--encre-douce);
+}
+
+.lienSuite {
+  font-weight: 500;
+}

--- a/src/@vitrine/components/ProofWall/index.tsx
+++ b/src/@vitrine/components/ProofWall/index.tsx
@@ -1,0 +1,30 @@
+// ProofWall/index.tsx — jeromemarichez-fr
+// Le mur de preuves : ce qui est vérifiable.
+
+import type { IProof } from '@/interfaces/IProof'
+import styles from './proof-wall.module.css'
+
+interface ProofWallProps {
+  preuves: IProof[]
+}
+
+/**
+ * Aucun compteur animé, aucune incrémentation au défilement.
+ *
+ * Un chiffre qui s'anime demande qu'on le regarde ; un chiffre posé demande qu'on le
+ * vérifie. Le second registre est le seul tenable ici — et il évite au passage une
+ * animation qui n'aurait rien apporté à la lecture.
+ */
+export function ProofWall({ preuves }: ProofWallProps) {
+  return (
+    <ul className={styles.mur}>
+      {preuves.map((preuve) => (
+        <li className={styles.tuile} key={preuve.libelle}>
+          <p className={styles.chiffre}>{preuve.chiffre}</p>
+          <p className={styles.libelle}>{preuve.libelle}</p>
+          <p className={styles.contexte}>{preuve.contexte}</p>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/@vitrine/components/ProofWall/proof-wall.module.css
+++ b/src/@vitrine/components/ProofWall/proof-wall.module.css
@@ -1,0 +1,38 @@
+/* proof-wall.module.css — le mur de preuves. */
+
+.mur {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  gap: var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tuile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  padding-top: var(--e-3);
+  border-top: 2px solid var(--cuivre-vif);
+}
+
+.chiffre {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t-chiffre);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: var(--encre);
+}
+
+.libelle {
+  font-size: 1.0625rem;
+  color: var(--encre);
+}
+
+.contexte {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--encre-douce);
+}

--- a/src/@vitrine/components/ThreadSection/index.tsx
+++ b/src/@vitrine/components/ThreadSection/index.tsx
@@ -1,0 +1,56 @@
+// ThreadSection/index.tsx — jeromemarichez-fr
+// Le fil : une méthode qui traverse les trois pôles.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+import styles from './thread-section.module.css'
+
+interface ThreadSectionProps {
+  section: IEditorialSection
+}
+
+/**
+ * Un fil se rend perpendiculairement aux charnières, et c'est volontaire.
+ *
+ * Les charnières tracent un filet **vertical** : la chaîne qui descend, un pôle passant
+ * la main au suivant. Le fil trace un filet **horizontal** et numérote ses étapes de la
+ * même main : il coupe la chaîne au lieu de s'y insérer. C'est la seule façon de dire
+ * visuellement « ceci n'est pas une quatrième offre » sans avoir à l'écrire.
+ *
+ * Pas de verre ici — `selectGlassSectionIds` ne vitre que les pôles.
+ */
+export function ThreadSection({ section }: ThreadSectionProps) {
+  const titreId = `${section.id}-titre`
+
+  return (
+    <section aria-labelledby={titreId} className={styles.fil} id={section.id}>
+      <header className={styles.entete}>
+        <p className={styles.kicker}>{section.kicker}</p>
+        <h2 className={styles.titre} id={titreId}>
+          {section.titre}
+        </h2>
+        <p className={styles.chapo}>{section.chapo}</p>
+      </header>
+
+      <ol className={styles.etapes}>
+        {section.blocs.map((bloc, index) => (
+          <li className={styles.etape} key={bloc.titre}>
+            {/* Le rang est décoratif : la numérotation est déjà portée par le `<ol>`,
+                et la répéter aux lecteurs d'écran ferait entendre « un un ». */}
+            <span aria-hidden="true" className={styles.rang}>
+              {String(index + 1).padStart(2, '0')}
+            </span>
+            <h3 className={styles.etapeTitre}>{bloc.titre}</h3>
+            <p className={styles.etapeTexte}>{bloc.texte}</p>
+            {bloc.preuve ? <p className={styles.preuve}>{bloc.preuve}</p> : null}
+            {bloc.decision ? (
+              <p className={styles.decision}>
+                <span className={styles.decisionLabel}>Vous tranchez</span>
+                {bloc.decision}
+              </p>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}

--- a/src/@vitrine/components/ThreadSection/thread-section.module.css
+++ b/src/@vitrine/components/ThreadSection/thread-section.module.css
@@ -1,0 +1,140 @@
+/* thread-section.module.css — le fil transverse.
+ * Filet cuivre horizontal, tracé à l'entrée : perpendiculaire à celui des charnières,
+ * qui est vertical. La chaîne descend, le fil la coupe — la géométrie porte l'argument. */
+
+.fil {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+  padding: var(--e-6) 0 var(--e-5);
+  scroll-margin-top: 6rem;
+}
+
+.fil::before,
+.fil::after {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  height: 2px;
+  background: var(--cuivre-vif);
+  transform-origin: left;
+  animation: tracer-fil var(--duree-tracer) var(--courbe-tracer) both;
+}
+
+.fil::before {
+  top: 0;
+}
+
+.fil::after {
+  bottom: 0;
+  opacity: 0.35;
+}
+
+.entete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+}
+
+.kicker {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--cuivre);
+}
+
+.titre {
+  margin: 0;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+.etapes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+  gap: var(--e-5) var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Chaque étape est une colonne du fil : filet fin en tête, rang en chiffres, puis le
+   texte. Le filet horizontal se répète à petite échelle — c'est ce qui fait lire les
+   quatre étapes comme un seul mouvement et non comme quatre encadrés. */
+.etape {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+  padding-top: var(--e-3);
+  border-top: 1px solid var(--verre-arete);
+}
+
+.rang {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.12em;
+  color: var(--cuivre);
+}
+
+.etapeTitre {
+  margin: 0;
+  font-size: var(--t-0);
+  line-height: 1.3;
+  color: var(--encre);
+}
+
+.etapeTexte {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--encre-douce);
+}
+
+.preuve,
+.decision {
+  margin: 0;
+  font-size: var(--t--1);
+  line-height: 1.5;
+}
+
+.preuve {
+  color: var(--signal);
+}
+
+.decision {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+  color: var(--encre);
+}
+
+.decisionLabel {
+  font-family: var(--police-mono-pile);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--cuivre);
+}
+
+@keyframes tracer-fil {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fil::before,
+  .fil::after {
+    animation: none;
+  }
+}

--- a/src/@vitrine/contenu/accueil-sections.ts
+++ b/src/@vitrine/contenu/accueil-sections.ts
@@ -1,12 +1,17 @@
 // accueil-sections.ts — jeromemarichez-fr
-// Les cinq sections qui déroulent la chaîne : pôle, charnière, pôle, charnière, pôle.
+// Les sections qui déroulent la chaîne : fil transverse, puis pôle, charnière, pôle,
+// charnière, pôle.
 //
 // L'ordre est le contenu. Retirer une charnière ne raccourcirait pas la page : cela
 // transformerait l'offre en catalogue.
 
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+import { SECTION_FIL_IA } from './fil-ia'
 
 export const SECTIONS_ACCUEIL: IEditorialSection[] = [
+  // Le fil ouvre la chaîne : la méthode se lit avant les pôles, sinon le lecteur
+  // découvre l'IA au pôle 2 et la range comme une offre parmi trois.
+  SECTION_FIL_IA,
   {
     id: 'ingenierie-web',
     kind: 'pole',
@@ -65,7 +70,9 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
   {
     id: 'charniere-run',
     kind: 'charniere',
-    kicker: 'Charnière',
+    // Numérotée dans la même série que les pôles : sans numéro, un titre de charnière
+    // se lit comme un intertitre d'ambiance et le lecteur ne voit plus la chaîne.
+    kicker: 'Charnière 1 → 2',
     titre: 'On ne livre pas, on exploite',
     chapo:
       "La mise en production n'est pas la fin du projet : c'est le moment où le produit " +
@@ -85,6 +92,13 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
         texte:
           'absorbés sans incident, contrôles post-déploiement exécutés en production, ' +
           'conformité RGPD et DORA tenue en appels d’offres grands comptes.',
+      },
+      {
+        titre: 'La preuve que le lien existe',
+        texte:
+          'les règles anti-fraude n’ont pas été imaginées avant la mise en production : ' +
+          'elles sont issues de la reprise de l’historique que l’exploitation a produit. ' +
+          'Sans run, pas de matière — et donc pas de pôle 2.',
       },
     ],
   },
@@ -144,7 +158,7 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
   {
     id: 'charniere-arbitrage',
     kind: 'charniere',
-    kicker: 'Charnière',
+    kicker: 'Charnière 2 → 3',
     titre: 'Sans donnée claire, le budget brûle',
     chapo:
       'La donnée mise au propre devient la matière première des arbitrages : quel canal ' +
@@ -160,6 +174,13 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       {
         titre: 'Réconciliation des identités',
         texte: 'agrégation multi-sources et dédoublonnage avant toute lecture de performance.',
+      },
+      {
+        titre: 'La preuve que le lien existe',
+        texte:
+          'le système d’analyse multi-sources mesure la rentabilité client dans la durée. ' +
+          'C’est sur ce chiffre-là que les budgets sont arbitrés — pas sur les métriques ' +
+          'que chaque régie produit sur elle-même.',
       },
     ],
   },
@@ -220,5 +241,48 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       'Ce que la mesure révèle repart en construction. Et comme c’est toujours la même ' +
       'personne, l’arbitrage décidé le lundi est implémenté dans la semaine — il n’attend ' +
       'pas le devis d’un tiers.',
+  },
+  {
+    id: 'un-seul-interlocuteur',
+    kind: 'preuves',
+    kicker: 'L’objection',
+    titre: 'Un seul interlocuteur — et si je disparais ?',
+    chapo:
+      'C’est la question à poser, et elle mérite mieux qu’un haussement d’épaules. Vendre ' +
+      'un interlocuteur unique, c’est concentrer un risque : autant dire tout de suite ' +
+      'comment il est traité, plutôt que d’attendre que vous le souleviez en réunion.',
+    blocs: [
+      {
+        titre: 'Le produit n’est pas dans ma tête',
+        texte:
+          'Développement piloté par les tests, non-régression rejouée à chaque livraison, ' +
+          'tests de mutation pour vérifier que les tests eux-mêmes valent quelque chose, ' +
+          'pipelines CI/CD exécutés à chaque livraison. Une base couverte et déployable ' +
+          'automatiquement se reprend ; une base sans filet ne se reprend pas.',
+        preuve:
+          'Jest, Cypress, Playwright, mutation Stryker, Postman. Certification ISTQB Foundation.',
+      },
+      {
+        titre: 'Les spécifications sont écrites pour quelqu’un d’autre que moi',
+        texte:
+          'C’est le métier que j’ai exercé avant : recueillir un besoin auprès d’équipes ' +
+          'scientifiques et dirigeantes, puis le traduire en spécifications exploitables ' +
+          'par des prestataires qui ne connaissent pas le domaine. BPMN 2.0, cartographie ' +
+          'du système d’information, nomenclature d’événements documentée et opposable.',
+        preuve:
+          'AMOA de la startup biotech Artedrone. Serveurs MCP et plugins n8n, Make et Zapier documentés.',
+      },
+      {
+        titre: 'Le relais, je l’ai déjà passé',
+        texte:
+          'Encadrer des prestataires externes, c’est exactement l’exercice : leur donner ' +
+          'de quoi travailler sans moi. Une équipe marketing de 5 à 10 personnes et trois ' +
+          'prestataires coordonnés chez Truffle Capital, les prestataires SEA, SEO et SMA ' +
+          'encadrés chez Verhoeven Joaillier.',
+        decision:
+          'Ce que vous exigez de moi contractuellement — documentation, accès, revue de ' +
+          'reprise — et à quel moment vous voulez pouvoir le vérifier.',
+      },
+    ],
   },
 ]

--- a/src/@vitrine/contenu/accueil-sections.ts
+++ b/src/@vitrine/contenu/accueil-sections.ts
@@ -1,0 +1,224 @@
+// accueil-sections.ts — jeromemarichez-fr
+// Les cinq sections qui déroulent la chaîne : pôle, charnière, pôle, charnière, pôle.
+//
+// L'ordre est le contenu. Retirer une charnière ne raccourcirait pas la page : cela
+// transformerait l'offre en catalogue.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+export const SECTIONS_ACCUEIL: IEditorialSection[] = [
+  {
+    id: 'ingenierie-web',
+    kind: 'pole',
+    pole: 'ingenierie-web',
+    kicker: 'Pôle 1 · Construire',
+    titre: 'Site internet, produit SaaS, application mobile',
+    chapo:
+      "Concevoir, développer et mettre en production, puis rester pour l'exploiter. " +
+      "L'architecture, le front, le back, la donnée, la qualité et le run sont tenus par " +
+      'la même personne — ce qui supprime la moitié des allers-retours de spécification.',
+    blocs: [
+      {
+        titre: 'Front et stratégie de rendu',
+        texte:
+          'React et Next.js, avec une stratégie de rendu différenciée par type de page — ' +
+          'CSR, SSR, SSG ou ISR. Le choix arbitre trois choses en même temps : performance ' +
+          'perçue, coût serveur et référencement. Angular et Ionic pour le mobile iOS et ' +
+          'Android.',
+        preuve:
+          'Lighthouse 98/100 sur la plateforme SaaS « Sms En Masse », conformité RGAA / WCAG.',
+        decision: 'Quelle page se rend au build, laquelle à la requête, et ce que chacune coûte.',
+      },
+      {
+        titre: 'Back, données et architecture',
+        texte:
+          'Node.js et Express, API REST, webhooks, cloud functions et traitements ' +
+          'asynchrones distribués via Google Cloud Pub/Sub. PostgreSQL en relationnel, en ' +
+          'séries temporelles et en vectoriel, MySQL, Firebase, validation des entrées par ' +
+          'schéma Zod. Arbitrage monolithe ou microservices posé explicitement, pas subi.',
+        decision: "Ce qu'on découpe maintenant, ce qu'on garde monolithique, et jusqu'à quand.",
+      },
+      {
+        titre: 'Qualité certifiée et outillée',
+        texte:
+          'Développement piloté par les tests, et développement en IA augmentée — Claude ' +
+          'Code et Gemini au quotidien avec agents, hooks, skills, loop et serveurs MCP ' +
+          'internes — le test faisant foi avant, pendant et après la génération. Jest, ' +
+          'Cypress, Playwright, tests de mutation Stryker, Postman, Lighthouse, ' +
+          'accessibilité RGAA / WCAG / W3C.',
+        preuve: 'Certification ISTQB Foundation. Non-régression rejouée à chaque livraison.',
+        decision: 'Quel niveau de test vous vous autorisez à ne pas payer, et sur quoi.',
+      },
+      {
+        titre: 'Migrations sans coupure',
+        texte:
+          "Sortir d'un socle en fin de vie sans arrêter le service ni geler la feuille de " +
+          'route. PHP 5 vers 7 puis réécriture Node.js et front jQuery vers React chez un ' +
+          "joaillier dont le site marchand ne pouvait pas s'arrêter ; Ionic 6 vers 8 et " +
+          "Angular 15 vers 19 sur l'application mobile Prézage.",
+        preuve:
+          'Trois migrations majeures, aucune interruption de service, chiffre d’affaires maintenu.',
+        decision: "Ce qu'on migre ce trimestre, ce qu'on gèle, et le coût réel de l'attente.",
+      },
+    ],
+  },
+  {
+    id: 'charniere-run',
+    kind: 'charniere',
+    kicker: 'Charnière',
+    titre: 'On ne livre pas, on exploite',
+    chapo:
+      "La mise en production n'est pas la fin du projet : c'est le moment où le produit " +
+      "commence à produire des données. Exploiter, c'est mesurer — et c'est le run qui " +
+      "fait naître le besoin de data et d'IA, pas l'inverse, et pas avant.",
+    blocs: [
+      {
+        titre: 'SLI / SLO / SLA',
+        texte: 'définis, suivis, et opposables — pas des intentions écrites après l’incident.',
+      },
+      {
+        titre: 'PCA et PRA',
+        texte: 'testés par exercices de bascule, pas simplement documentés.',
+      },
+      {
+        titre: 'Pics d’affluence',
+        texte:
+          'absorbés sans incident, contrôles post-déploiement exécutés en production, ' +
+          'conformité RGPD et DORA tenue en appels d’offres grands comptes.',
+      },
+    ],
+  },
+  {
+    id: 'data-ia',
+    kind: 'pole',
+    pole: 'data-ia',
+    kicker: 'Pôle 2 · Mettre en production',
+    titre: "La donnée d'abord, l'IA ensuite — dans le produit qui tourne",
+    chapo:
+      "L'IA que je livre tourne dans des produits vendus, avec les contraintes qui vont " +
+      "avec : coût d'inférence, latence, RGPD, disponibilité. Pas dans des notebooks. Et " +
+      'elle ne vaut rien tant que la donnée qui l’alimente n’a pas été mise au propre.',
+    blocs: [
+      {
+        titre: 'Qualité de la donnée, traitée comme un prérequis',
+        texte:
+          "Contrôles d'intégrité et de véracité dès l'ingestion, dédoublonnage, détection " +
+          "d'anomalies. Les écarts sont corrigés avant de contaminer les tableaux de bord, " +
+          'pas après. Pipelines d’ingestion, nettoyage, agrégation et réconciliation ' +
+          'multi-sources.',
+        decision: 'Sur quels chiffres vous acceptez de décider, et lesquels sont encore du bruit.',
+      },
+      {
+        titre: 'Règles métier tirées de la donnée',
+        texte:
+          'Analyse exploratoire sous Orange Data Mining, pondération et sélection des ' +
+          'variables, élimination des corrélations fortes et des variables porteuses de ' +
+          'bruit, puis règles implémentées dans le produit.',
+        preuve: 'Fraude en baisse, conversion des inscriptions en hausse, latence réduite.',
+        decision: 'Ce qui se règle par une règle métier, et ce qui mérite vraiment un modèle.',
+      },
+      {
+        titre: 'Machine learning en production',
+        texte:
+          'Modèle supervisé anticipant les échecs de dépôt vocal, en production : extraction ' +
+          'des caractéristiques du signal audio selon une méthode publiée sur arXiv par ' +
+          "l'Universitat de Barcelona, que j'ai implémentée, adaptée aux données réelles " +
+          'puis industrialisée. Entraînement TensorFlow, inférence en cloud functions, ' +
+          'versioning et monitoring.',
+        preuve: 'Routes vocales coûteuses évitées.',
+      },
+      {
+        titre: 'LLM, agents et interopérabilité',
+        texte:
+          'Claude sur Vertex AI, OpenAI, Gemini, Llama : comparaison continue et arbitrage ' +
+          'coût, latence, qualité et confidentialité par cas d’usage. Fine-tuning de Llama 3 ' +
+          "sur corpus métier pour l'application mobile Prézage, complété d'un procédé maison " +
+          "d'augmentation du contexte proche du RAG. RAG documentaire fait maison pour le " +
+          'support de niveau 1 : recherche vectorielle PostgreSQL et API OpenAI, réponses ' +
+          'ancrées sur votre documentation. Serveurs MCP et plugins n8n, Make et Zapier : ' +
+          'votre produit devient appelable par un agent ou un scénario no-code.',
+        decision: 'Quelle donnée reste chez vous, et ce que vous acceptez d’envoyer à un tiers.',
+      },
+    ],
+  },
+  {
+    id: 'charniere-arbitrage',
+    kind: 'charniere',
+    kicker: 'Charnière',
+    titre: 'Sans donnée claire, le budget brûle',
+    chapo:
+      'La donnée mise au propre devient la matière première des arbitrages : quel canal ' +
+      "financer, quelle étape du parcours supprimer, quelle page rendre en SSR plutôt qu'en " +
+      "CSR. Sans elle, le SEA achète du volume et l'UX devient une affaire de goût.",
+    blocs: [
+      {
+        titre: 'LTV plutôt que coût par clic',
+        texte:
+          'les budgets s’arbitrent sur la rentabilité client réelle, pas sur les métriques ' +
+          'natives des régies.',
+      },
+      {
+        titre: 'Réconciliation des identités',
+        texte: 'agrégation multi-sources et dédoublonnage avant toute lecture de performance.',
+      },
+    ],
+  },
+  {
+    id: 'sea-ux',
+    kind: 'pole',
+    pole: 'sea-ux',
+    kicker: 'Pôle 3 · Arbitrer',
+    titre: 'Je ne dessine pas vos maquettes, je tranche vos parcours',
+    chapo:
+      'Disons-le tout de suite : je ne vends pas de création graphique. Ce que je vends, ' +
+      'ce sont des arbitrages pris sur la donnée — quel parcours, quelle étape supprimée, ' +
+      'quel formulaire raccourci, quel test A/B tranché — et je les implémente moi-même ' +
+      'dans le produit, au lieu de les transmettre à quelqu’un d’autre.',
+    blocs: [
+      {
+        titre: 'La mesure est construite dans le code',
+        texte:
+          'Google Tag Manager en conteneur web et server-side, dataLayer, Measurement ' +
+          "Protocol, plan de taggage et nomenclature d'événements documentée et opposable. " +
+          'Google Analytics, Matomo, Search Console ; côté mobile, Firebase Analytics et ' +
+          "Crashlytics. Je lis le code à l'endroit où l'événement doit être posé, au lieu de " +
+          'le deviner depuis une interface.',
+        decision: 'Quels événements existent, ce qu’ils portent, et qui répond de leur exactitude.',
+      },
+      {
+        titre: 'Conformité par construction',
+        texte:
+          'RGPD, CMP et déclenchement conditionnel des tags par catégorie de consentement, ' +
+          'cadrage des traitements avec le juridique. La conformité n’est pas une case ' +
+          'cochée après coup : elle conditionne l’architecture de collecte.',
+        decision:
+          'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
+      },
+      {
+        titre: 'Arbitrages de parcours, pris sur la mesure',
+        texte:
+          'Refonte des parcours pilotée par la donnée : A/B testing des pages et des ' +
+          'designs, heatmaps, taux de rebond, part de trafic mobile. Une étape disparaît ' +
+          'parce que les chiffres le disent, pas parce qu’elle déplaît.',
+        preuve: 'Panier moyen en hausse de 50 % sur un e-commerce de joaillerie de luxe.',
+        decision: 'Quelle étape du tunnel disparaît, et ce que vous gagnez à la supprimer.',
+      },
+      {
+        titre: 'Pilotage de l’acquisition',
+        texte:
+          'Google Ads, Bing Ads, SEO, SEA et SMA. Tableaux de bord construits pour votre ' +
+          'produit et non repris d’un gabarit, profilage clients par clustering KNN, ' +
+          'référencement technique traité comme une propriété du produit — stratégie de ' +
+          'rendu, Core Web Vitals, accessibilité.',
+        preuve:
+          '100 000 € de budget ADS / SEO pilotés chez Truffle Capital, environ 25 000 € ' +
+          'd’encadrement de prestataires SEA chez Verhoeven Joaillier.',
+        decision: 'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre.',
+      },
+    ],
+    transition:
+      'Ce que la mesure révèle repart en construction. Et comme c’est toujours la même ' +
+      'personne, l’arbitrage décidé le lundi est implémenté dans la semaine — il n’attend ' +
+      'pas le devis d’un tiers.',
+  },
+]

--- a/src/@vitrine/contenu/accueil.ts
+++ b/src/@vitrine/contenu/accueil.ts
@@ -1,0 +1,52 @@
+// accueil.ts — jeromemarichez-fr
+// Contenu de la page d'accueil : seuil, thèse, et la chaîne complète.
+//
+// Tous les faits cités ici sont sourcés dans les CV de référence
+// (/Users/nicolasb/Documents/CV/cv-ingenieur-fullstack.md, cv-ai-engineer.md,
+// cv-tracking-specialist.md) et dans le README. Les règles de véracité du CLAUDE.md
+// s'appliquent mot pour mot : rien n'est élargi pour mieux vendre.
+//
+// Les sections longues vivent dans `accueil-sections.ts` — limite de 300 lignes par
+// fichier (docs/tooling.md).
+
+import type { IEditorialPage } from '@/interfaces/IEditorialPage'
+import { SECTIONS_ACCUEIL } from './accueil-sections'
+
+/** Le seuil : promesse, et trois chiffres pour qu'elle ne reste pas un slogan. */
+export const HERO_ACCUEIL = {
+  titre: "Je construis, j'exploite, je mesure. Seul, du cadrage au run.",
+  chapo:
+    'Ingénieur logiciel à Lille, 9 ans. Un seul interlocuteur pour votre produit ' +
+    'digital, aucune sous-traitance : celui qui cadre est celui qui code, qui mesure ' +
+    'et qui exploite. Vous parlez à la personne qui fait le travail.',
+  jetons: [
+    { chiffre: '3', libelle: 'migrations sans interruption de service' },
+    { chiffre: '98/100', libelle: 'Lighthouse sur la plateforme SaaS livrée' },
+    { chiffre: '0', libelle: 'sous-traitant' },
+  ],
+} as const
+
+/** La thèse : trois pôles, une seule chaîne, une seule personne. */
+export const THESE_CHAINE = {
+  titre: 'Trois pôles, une seule chaîne',
+  chapo:
+    "Ce ne sont pas trois offres qu'on achète séparément. C'est une prise en charge " +
+    'continue, où chaque étape passe explicitement la main à la suivante : on construit, ' +
+    'ce qui est construit se met à tourner, ce qui tourne produit de la donnée, et cette ' +
+    "donnée décide de ce qu'on modifie ensuite.",
+  appui:
+    "Cette chaîne ne tient que parce que c'est la même personne aux trois postes. " +
+    "Découpée entre trois prestataires, elle se casse à chaque jointure — et c'est " +
+    'toujours au client de recoller les morceaux.',
+} as const
+
+export const PAGE_ACCUEIL: IEditorialPage = {
+  route: '/',
+  meta: {
+    title: 'Jérôme Marichez — Ingénieur logiciel à Lille',
+    description:
+      'Ingénierie web, data & IA, SEA & UX : un seul interlocuteur du cadrage au run, ' +
+      'sans sous-traitance. Lille et Hauts-de-France.',
+  },
+  sections: SECTIONS_ACCUEIL,
+}

--- a/src/@vitrine/contenu/accueil.ts
+++ b/src/@vitrine/contenu/accueil.ts
@@ -19,6 +19,12 @@ export const HERO_ACCUEIL = {
     'Ingénieur logiciel à Lille, 9 ans. Un seul interlocuteur pour votre produit ' +
     'digital, aucune sous-traitance : celui qui cadre est celui qui code, qui mesure ' +
     'et qui exploite. Vous parlez à la personne qui fait le travail.',
+  // Le fil IA se dit dès le seuil, sinon il se découvre au pôle 2 et se lit comme une
+  // offre. Formulation tenue par les règles de véracité : l'IA instruit et produit, le
+  // test décide — jamais l'inverse.
+  methode:
+    'Je conçois, je développe et je pilote avec l’IA — Claude Code et Gemini au ' +
+    'quotidien, le test tranchant à chaque étape.',
   jetons: [
     { chiffre: '3', libelle: 'migrations sans interruption de service' },
     { chiffre: '98/100', libelle: 'Lighthouse sur la plateforme SaaS livrée' },
@@ -46,7 +52,8 @@ export const PAGE_ACCUEIL: IEditorialPage = {
     title: 'Jérôme Marichez — Ingénieur logiciel à Lille',
     description:
       'Ingénierie web, data & IA, SEA & UX : un seul interlocuteur du cadrage au run, ' +
-      'sans sous-traitance. Lille et Hauts-de-France.',
+      'sans sous-traitance. Conception, développement et pilotage avec l’IA. Lille et ' +
+      'Hauts-de-France.',
   },
   sections: SECTIONS_ACCUEIL,
 }

--- a/src/@vitrine/contenu/certifications.ts
+++ b/src/@vitrine/contenu/certifications.ts
@@ -1,0 +1,78 @@
+// certifications.ts — jeromemarichez-fr
+// Les certifications affichées, et ce que chacune change dans la prestation.
+//
+// Règles de véracité (CLAUDE.md), toutes bloquantes :
+//   — ISTQB : seul le niveau **Foundation** est détenu. Le niveau Avancé
+//     (Automatisation de Test) n'est PAS obtenu et ne doit jamais réapparaître ici.
+//   — Aucune URL de justificatif n'a été fournie à ce jour : `justificatif` reste
+//     absent partout. Une URL de certification ne s'invente ni ne s'approxime.
+//   — Millésimes arbitrés par Jérôme MARICHEZ le 2026-08-20 : Google Ads en 2021
+//     (le CV Tracking Specialist indiquait 2022), et Microsoft Ads confirmée mais
+//     sans année connue — elle s'affiche donc sans millésime.
+
+import type { ICertification } from '@/interfaces/ICertification'
+
+export const CERTIFICATIONS: ICertification[] = [
+  {
+    intitule: 'ISTQB Foundation',
+    organisme: 'International Software Testing Qualifications Board',
+    annee: 2026,
+    pole: 'ingenierie-web',
+    apport:
+      'Un vocabulaire de recette commun et opposable. Les niveaux de test, les critères ' +
+      "d'entrée et surtout les critères d'arrêt sont écrits avant la livraison, pas " +
+      'négociés pendant.',
+  },
+  {
+    intitule: "Claude with Google Cloud's Vertex AI",
+    organisme: 'Google Cloud',
+    annee: 2026,
+    pole: 'data-ia',
+    apport:
+      "L'inférence d'un grand modèle de langage servie depuis votre propre projet Google " +
+      'Cloud plutôt que depuis une API tierce, quand la confidentialité des données le ' +
+      'commande.',
+  },
+  {
+    intitule: 'WeLoveDev — Top 5 % React',
+    organisme: 'WeLoveDev',
+    annee: 2023,
+    pole: 'ingenierie-web',
+    apport: 'Un niveau React évalué en conditions de test, pas déclaré sur un CV.',
+  },
+  {
+    intitule: 'Google Analytics Individual Qualification',
+    organisme: 'Google',
+    annee: 2021,
+    pole: 'sea-ux',
+    apport:
+      "Une lecture des rapports d'audience qui distingue ce que l'outil a réellement " +
+      "mesuré de ce qu'il a modélisé — la différence sur laquelle se prennent les " +
+      'mauvaises décisions budgétaires.',
+  },
+  {
+    intitule: 'Google Ads',
+    organisme: 'Google',
+    annee: 2021,
+    pole: 'sea-ux',
+    apport:
+      'Des campagnes arbitrées sur la donnée du produit et la rentabilité réelle, pas sur ' +
+      'les métriques natives de la régie.',
+  },
+  {
+    intitule: 'Microsoft Ads',
+    organisme: 'Microsoft',
+    pole: 'sea-ux',
+    apport:
+      "La couverture de Bing traitée sérieusement quand votre audience s'y trouve, au lieu " +
+      "d'être abandonnée par défaut.",
+  },
+  {
+    intitule: 'EF SET — Anglais B2 (CECRL)',
+    organisme: 'EF Standard English Test',
+    pole: 'transverse',
+    apport:
+      'La documentation technique, les publications et les échanges avec vos partenaires ' +
+      'tenus en anglais sans intermédiaire.',
+  },
+]

--- a/src/@vitrine/contenu/data-ia-sections.ts
+++ b/src/@vitrine/contenu/data-ia-sections.ts
@@ -1,0 +1,185 @@
+// data-ia-sections.ts — jeromemarichez-fr
+// Pôle 2 — Mettre en production. La donnée d'abord, l'IA ensuite.
+//
+// Faits sourcés dans cv-ai-engineer.md et cv-tracking-specialist.md. Règles de véracité
+// du CLAUDE.md appliquées : RAG **maison** (aucun framework tiers), méthode arXiv
+// implémentée et non « en collaboration avec » l'Universitat de Barcelona, Prézage et
+// Llama 3 nommables mais corpus, données et chiffres du projet hors ligne.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+export const SECTIONS_DATA_IA: IEditorialSection[] = [
+  {
+    id: 'prerequis',
+    kind: 'pole',
+    pole: 'data-ia',
+    kicker: 'Le prérequis',
+    titre: 'La qualité de la donnée n’est pas un correctif',
+    chapo:
+      'Un modèle entraîné sur une donnée sale produit une décision sale, plus vite et avec ' +
+      'plus d’assurance. Tout commence donc par la matière première : ce qui entre, ce qui ' +
+      'est dédoublonné, ce qui est écarté, et ce qu’on accepte de ne pas savoir.',
+    blocs: [
+      {
+        titre: 'Contrôles dès l’ingestion',
+        texte:
+          'Intégrité et véracité vérifiées à l’entrée, dédoublonnage, détection d’anomalies. ' +
+          'Les écarts sont corrigés avant de contaminer les tableaux de bord, pas une fois ' +
+          'que quelqu’un s’est étonné d’un chiffre.',
+        decision:
+          'Sur quels indicateurs vous acceptez de décider, et lesquels sont encore du bruit.',
+      },
+      {
+        titre: 'Data engineering et réconciliation',
+        texte:
+          'Pipelines d’ingestion, nettoyage, agrégation et réconciliation multi-sources. ' +
+          'Les identités venues de canaux différents sont rapprochées selon votre modèle ' +
+          'métier, pas selon un connecteur générique.',
+        preuve:
+          'Système d’analyse multi-sources conforme RGPD mesurant la rentabilité client à ' +
+          'long terme, branché sur Google Ads et Bing Ads.',
+      },
+      {
+        titre: 'Modélisation',
+        texte:
+          'PostgreSQL en relationnel, en séries temporelles et en vectoriel, MySQL, ' +
+          'Firebase. Le choix du stockage suit la question qu’on veut poser à la donnée, ' +
+          'pas l’inverse.',
+      },
+    ],
+  },
+  {
+    id: 'regles',
+    kind: 'pole',
+    pole: 'data-ia',
+    kicker: 'Avant le modèle',
+    titre: 'Beaucoup de problèmes se règlent sans intelligence artificielle',
+    chapo:
+      'Une règle métier explicite est moins chère à faire tourner, plus facile à ' +
+      'expliquer à un régulateur et plus simple à corriger qu’un modèle. Je commence par ' +
+      'chercher si elle suffit — et je le dis quand c’est le cas.',
+    blocs: [
+      {
+        titre: 'Analyse exploratoire',
+        texte:
+          'Reprise de l’historique, analyse sous Orange Data Mining, pondération et ' +
+          'sélection des variables, élimination des corrélations fortes et des variables ' +
+          'porteuses de bruit, mise en qualité du jeu de données.',
+      },
+      {
+        titre: 'Règles anti-fraude implémentées dans le produit',
+        texte:
+          'Les règles issues de l’analyse ne restent pas dans un rapport : elles sont ' +
+          'définies puis implémentées dans le produit, par la même personne.',
+        preuve: 'Fraude en baisse, conversion des inscriptions en hausse, latence réduite.',
+        decision: 'Ce qui se règle par une règle, et ce qui mérite vraiment un modèle.',
+      },
+      {
+        titre: 'Profilage et lisibilité',
+        texte:
+          'Clustering et profilage clients (KNN), restitution visuelle pensée pour la ' +
+          'décision : ce que le dirigeant doit trancher apparaît, le reste disparaît.',
+      },
+    ],
+  },
+  {
+    id: 'machine-learning',
+    kind: 'pole',
+    pole: 'data-ia',
+    kicker: 'Apprentissage supervisé',
+    titre: 'Un modèle en production, pas dans un notebook',
+    chapo:
+      'Modèle supervisé anticipant les échecs de dépôt vocal, déployé, versionné et ' +
+      'surveillé. Il évite d’emprunter des routes vocales coûteuses quand l’échec est ' +
+      'probable — l’économie est directe et mesurable.',
+    blocs: [
+      {
+        titre: 'De la littérature scientifique au service',
+        texte:
+          'La méthode d’extraction des caractéristiques du signal audio — niveau de bruit, ' +
+          'probabilité de présence de voix, durée, puissance sonore dans le temps — est ' +
+          'publiée sur arXiv par l’Universitat de Barcelona. Je l’ai implémentée moi-même, ' +
+          'adaptée aux données réelles, validée, puis industrialisée.',
+        preuve: 'Routes vocales coûteuses évitées.',
+      },
+      {
+        titre: 'Chaîne complète',
+        texte:
+          'Caractéristiques stockées sous forme vectorielle, entraînement TensorFlow, ' +
+          'inférence en cloud functions, versioning et monitoring du modèle. Aucun maillon ' +
+          'de cette chaîne n’est sous-traité.',
+      },
+    ],
+  },
+  {
+    id: 'llm',
+    kind: 'pole',
+    pole: 'data-ia',
+    kicker: 'Modèles de langage',
+    titre: 'Le bon modèle pour le bon cas d’usage, et la preuve du contraire',
+    chapo:
+      'Claude sur Vertex AI et par l’API Anthropic, OpenAI, Gemini, Llama. Les modèles ' +
+      'sont comparés en continu et arbitrés cas d’usage par cas d’usage sur quatre axes : ' +
+      'coût d’inférence, latence, qualité attendue, confidentialité des données.',
+    blocs: [
+      {
+        titre: 'Adaptation de modèles',
+        texte:
+          'Fine-tuning de Llama 3 sur corpus métier pour l’application mobile Prézage, ' +
+          'complété d’un procédé maison d’augmentation du contexte proche du RAG : ' +
+          'constitution et nettoyage du jeu d’entraînement, évaluation face au modèle ' +
+          'propriétaire, arbitrage coût, latence et confidentialité.',
+        preuve: 'Charge de travail des prestataires réduite.',
+        decision: 'Quelle donnée reste chez vous, et ce que vous acceptez d’envoyer à un tiers.',
+      },
+      {
+        titre: 'RAG documentaire, fait maison',
+        texte:
+          'Réponse automatisée aux tickets de support de niveau 1 : recherche vectorielle ' +
+          'PostgreSQL et API OpenAI, réponses ancrées sur votre documentation interne et ' +
+          'non sur la mémoire du modèle. Aucun framework tiers — la chaîne est écrite, donc ' +
+          'lisible et corrigeable.',
+      },
+      {
+        titre: 'Agents et interopérabilité',
+        texte:
+          'Conception, développement et documentation de serveurs MCP et de plugins n8n, ' +
+          'Make et Zapier : votre produit devient appelable par un agent IA ou par un ' +
+          'scénario no-code chez vos propres clients.',
+        decision: 'Ce que vous ouvrez à l’automatisation, et ce qui reste fermé.',
+      },
+      {
+        titre: 'MLOps et conformité',
+        texte:
+          'Déploiement, versioning et monitoring des modèles, CI/CD Docker et GitHub ' +
+          'Actions, Vertex AI, Pub/Sub, Cloud Run, VM auto-scalées. Conformité RGPD et ' +
+          'DORA, exigée en appels d’offres grands comptes.',
+      },
+    ],
+  },
+  {
+    id: 'charniere-arbitrage',
+    kind: 'charniere',
+    kicker: 'Charnière vers le pôle 3',
+    titre: 'Une donnée propre devient un budget arbitrable',
+    chapo:
+      'Une fois la donnée clarifiée, elle cesse d’être un tableau de bord de plus : elle ' +
+      'devient la matière des décisions d’acquisition et de parcours. Quel canal financer, ' +
+      'quelle étape supprimer, quelle page rendre autrement. Sans elle, le SEA achète du ' +
+      'volume et l’expérience utilisateur devient une affaire de goût.',
+    blocs: [
+      {
+        titre: 'Rentabilité à long terme',
+        texte:
+          'la mesure de la valeur client dans la durée remplace le coût par clic comme ' +
+          'critère d’arbitrage.',
+      },
+      {
+        titre: 'Et ensuite',
+        texte:
+          'le pôle 3 tranche sur ces chiffres — puis implémente l’arbitrage dans le ' +
+          'produit, sans passer par un tiers.',
+      },
+    ],
+  },
+]

--- a/src/@vitrine/contenu/data-ia.ts
+++ b/src/@vitrine/contenu/data-ia.ts
@@ -1,0 +1,16 @@
+// data-ia.ts — jeromemarichez-fr
+// Pôle 2 — Data & IA. Métadonnées ; les sections vivent dans le fichier voisin.
+
+import type { IEditorialPage } from '@/interfaces/IEditorialPage'
+import { SECTIONS_DATA_IA } from './data-ia-sections'
+
+export const PAGE_DATA_IA: IEditorialPage = {
+  route: '/services/data-ia',
+  meta: {
+    title: 'Data & IA en production — Lille',
+    description:
+      'Qualité de la donnée, règles métier, machine learning, LLM, RAG maison et serveurs ' +
+      'MCP en production — coût d’inférence, latence et RGPD tenus.',
+  },
+  sections: SECTIONS_DATA_IA,
+}

--- a/src/@vitrine/contenu/fil-ia.ts
+++ b/src/@vitrine/contenu/fil-ia.ts
@@ -1,0 +1,74 @@
+// fil-ia.ts — jeromemarichez-fr
+// Le fil IA : l'axe transverse de la page d'accueil.
+//
+// Ce n'est pas un quatrième pôle et ce n'est pas une charnière. Les charnières passent
+// la main d'un pôle au suivant ; ce fil-ci traverse les trois. Il répond à une confusion
+// que le site crée lui-même : l'IA y apparaît deux fois — comme offre (pôle 2) et comme
+// méthode de production (les trois pôles). Sans cette section, le lecteur les mélange.
+//
+// Véracité (CLAUDE.md) : rien ici n'est nouveau. Chaque preuve citée est déjà portée
+// par un pôle et sourcée dans les CV de référence. La seule affirmation propre à cette
+// section est la méthode de travail elle-même — outillage Claude Code / Gemini piloté
+// par les tests — que le CLAUDE.md revendique déjà comme différenciateur assumé.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+export const SECTION_FIL_IA: IEditorialSection = {
+  id: 'fil-ia',
+  kind: 'fil',
+  kicker: 'Le fil · les trois pôles',
+  titre: 'Je conçois, je développe et je pilote avec l’IA',
+  chapo:
+    'L’IA apparaît deux fois sur ce site, et il faut les distinguer : elle est ce que je ' +
+    'livre au pôle 2, et elle est la façon dont je travaille sur les trois. Cette ' +
+    'section-ci parle de la seconde — de la première option d’architecture jusqu’à ' +
+    'l’arbitrage d’un budget SEA. Une règle la tient d’un bout à l’autre : l’IA propose, ' +
+    'les tests tranchent.',
+  blocs: [
+    {
+      titre: 'Concevoir — instruire les options, pas les recevoir',
+      texte:
+        'Au cadrage et à l’architecture, l’IA sert à instruire : faire produire plusieurs ' +
+        'scénarios, les confronter, exposer leurs coûts et leurs angles morts avant que le ' +
+        'premier fichier soit écrit. La décision reste la mienne et s’écrit noir sur blanc — ' +
+        'arbitrage monolithe ou microservices, stratégie de rendu page par page, découpage ' +
+        'des services.',
+      decision: 'Le scénario d’architecture retenu, ceux qui ont été écartés, et sur quel critère.',
+    },
+    {
+      titre: 'Construire — Claude Code et Gemini, pilotés par les tests',
+      texte:
+        'Agents, hooks, skills, loop et serveurs MCP internes au quotidien, avec le test ' +
+        'écrit avant, exécuté pendant et rejoué après la génération. Les tests de mutation ' +
+        'vérifient que les tests eux-mêmes valent quelque chose : sans eux, une base générée ' +
+        'donne surtout l’illusion d’être couverte.',
+      preuve:
+        'Jest, Cypress, Playwright, mutation Stryker. Certification ISTQB Foundation. Ce ' +
+        'site est construit ainsi, de bout en bout.',
+      decision: 'Ce que vous acceptez de faire produire par une IA, et le filet exigé en dessous.',
+    },
+    {
+      titre: 'Livrer — l’IA dans le produit qui tourne',
+      texte:
+        'C’est le pôle 2 : donnée mise au propre, apprentissage supervisé en production, LLM ' +
+        'et agents avec le coût d’inférence, la latence et le RGPD tenus. La méthode et ' +
+        'l’offre partagent les mêmes outils, elles ne se confondent pas — ce que le pôle 2 ' +
+        'vend, c’est de l’IA qui tourne chez vous, pas ma manière d’écrire du code.',
+      preuve:
+        'Modèle supervisé en production, fine-tuning de Llama 3 sur corpus métier, RAG ' +
+        'documentaire fait maison.',
+    },
+    {
+      titre: 'Piloter — le SEA et l’UX décidés sur ce que la donnée dit',
+      texte:
+        'Au bout de la chaîne, la même donnée sert à trancher : profilage clients par ' +
+        'clustering, rentabilité client dans la durée, A/B testing des parcours. Un budget se ' +
+        'coupe et une étape de tunnel disparaît parce que le chiffre le dit — puis c’est la ' +
+        'même personne qui l’implémente dans le produit.',
+      preuve:
+        'Panier moyen en hausse de 50 % sur un e-commerce de joaillerie, 100 000 € de budget ' +
+        'ADS / SEO pilotés.',
+      decision: 'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre.',
+    },
+  ],
+}

--- a/src/@vitrine/contenu/ingenierie-web-sections.ts
+++ b/src/@vitrine/contenu/ingenierie-web-sections.ts
@@ -1,0 +1,205 @@
+// ingenierie-web-sections.ts — jeromemarichez-fr
+// Pôle 1 — Construire. Site internet, produit SaaS, application mobile.
+//
+// Faits sourcés dans cv-ingenieur-fullstack.md et cv-ai-engineer.md. Règles de
+// véracité du CLAUDE.md appliquées : ISTQB **Foundation** seulement, aucun management
+// de développeurs revendiqué, pas de Kubernetes administré en propre.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
+  {
+    id: 'natures',
+    kind: 'pole',
+    pole: 'ingenierie-web',
+    kicker: 'Ce que je construis',
+    titre: 'Trois natures de produit, une seule façon de les tenir',
+    chapo:
+      'Un site, un produit SaaS et une application mobile ne se pilotent pas pareil : ils ' +
+      "n'ont ni le même cycle de vie, ni les mêmes contraintes de mise en production, ni " +
+      'les mêmes utilisateurs. Je les ai menés tous les trois, de la conception au run.',
+    blocs: [
+      {
+        titre: 'Site internet',
+        texte:
+          'Vitrine, e-commerce ou site institutionnel lu par des investisseurs et par la ' +
+          "presse. Le référencement et la performance n'y sont pas des options à ajouter " +
+          'ensuite : ils se décident au moment de choisir la stratégie de rendu.',
+        preuve:
+          'Sites du fonds Truffle Capital et de ses participations (truffle.com, ' +
+          'truffle100.fr, artedrone.fr), de la conception à l’exploitation.',
+        decision: 'Ce qui se prérend et ce qui se rend à la requête, page par page.',
+      },
+      {
+        titre: 'Produit SaaS',
+        texte:
+          'Un produit vendu à des grands comptes, avec ce que cela implique : montée en ' +
+          'charge, disponibilité contractuelle, conformité exigée en appel d’offres. ' +
+          'Conception et réalisation de bout en bout de la plateforme BtoB « Sms En Masse », ' +
+          'en remplacement d’une solution tierce exploitée en marque blanche.',
+        preuve: 'Conformité RGPD et DORA tenue en appels d’offres distribution, assurance, banque.',
+        decision: 'Ce que vous internalisez, et ce que vous continuez de louer à un tiers.',
+      },
+      {
+        titre: 'Application mobile',
+        texte:
+          'iOS et Android sous Ionic et Angular, jusqu’aux magasins d’applications. Suivi ' +
+          'des parcours et des échecs via Firebase Analytics et Crashlytics, du signal ' +
+          'jusqu’au correctif livré.',
+        preuve:
+          'Application « Prézage » : migration Ionic 6 vers 8 et Angular 15 vers 19 menée ' +
+          'sans interruption ni gel de la roadmap.',
+      },
+    ],
+  },
+  {
+    id: 'cadrage',
+    kind: 'pole',
+    pole: 'ingenierie-web',
+    kicker: 'Avant la première ligne',
+    titre: 'Le cadrage, tenu par celui qui devra le coder',
+    chapo:
+      'Neuf ans dont deux en double casquette technique et pilotage. Je recueille le ' +
+      'besoin, je le traduis en spécifications, et je sais ce que chaque ligne coûtera à ' +
+      'implémenter — parce que c’est moi qui l’implémenterai.',
+    blocs: [
+      {
+        titre: 'Recueil du besoin et spécifications',
+        texte:
+          'Modélisation des flux en BPMN 2.0, cartographie du système d’information, ' +
+          'matrice de risques, recette et tests d’acceptation. Le besoin d’équipes ' +
+          'scientifiques ou dirigeantes est traduit en spécifications exploitables par des ' +
+          'prestataires qui ne connaissent pas leur domaine.',
+        preuve:
+          'AMOA de la startup biotech Artedrone ; intégration de l’ERP M3 Soft et ' +
+          'synchronisation boutique physique / e-commerce, survente évitée sur des pièces uniques.',
+        decision: 'Ce qui entre dans la version 1, et ce qui attend sans bloquer le reste.',
+      },
+      {
+        titre: 'Interfaces et parcours',
+        texte:
+          'Maquettage, catalogue de composants sous Storybook, accessibilité RGAA, WCAG et ' +
+          'W3C traitée pendant la conception et non en rattrapage. Les parcours sont ' +
+          'refondus sur la mesure — c’est le pôle 3 qui fournit les chiffres.',
+        preuve: 'Panier moyen en hausse de 50 % après refonte des tunnels d’achat.',
+      },
+      {
+        titre: 'Coordination',
+        texte:
+          'Encadrement d’équipes marketing et SEO/SEA de 5 à 10 personnes, de prestataires ' +
+          'externes, d’alternants et de stagiaires. Côté technique, le titre est Lead Tech ' +
+          'dans une équipe de deux développeurs et un product owner.',
+      },
+    ],
+  },
+  {
+    id: 'technique',
+    kind: 'pole',
+    pole: 'ingenierie-web',
+    kicker: 'La construction',
+    titre: 'Front, back, architecture et exploitation',
+    chapo:
+      'La même personne décide de la stratégie de rendu, du modèle de données et de la ' +
+      'façon dont le tout est déployé. Les arbitrages sont donc pris en connaissant leurs ' +
+      'trois conséquences en même temps, pas les unes après les autres.',
+    blocs: [
+      {
+        titre: 'Front-end',
+        texte:
+          'React et Next.js avec stratégie de rendu différenciée par type de page — CSR, ' +
+          'SSR, SSG, ISR — pour arbitrer performance perçue, coût serveur et ' +
+          'référencement. Angular, Ionic, Redux, Zustand, React Query, Tailwind, Material UI, ' +
+          'SCSS et CSS-in-JS.',
+        preuve: 'Lighthouse 98/100, conformité RGAA / WCAG tenue en parallèle.',
+      },
+      {
+        titre: 'Back-end et données',
+        texte:
+          'Node.js et Express, API REST, webhooks, cloud functions, traitements ' +
+          'asynchrones distribués via Google Cloud Pub/Sub. PostgreSQL en relationnel, en ' +
+          'séries temporelles et en vectoriel, MySQL, Firebase. Toute entrée externe est ' +
+          'validée par un schéma Zod à la frontière.',
+        decision: 'Ce qui reste synchrone, et ce qui part en file — avec le coût de chaque choix.',
+      },
+      {
+        titre: 'Architecture et exploitation',
+        texte:
+          'Arbitrage monolithe ou microservices posé explicitement. Docker, CI/CD GitHub ' +
+          'Actions, Google Cloud — Cloud Run, VM Compute Engine auto-scalées, cloud ' +
+          'functions, Pub/Sub —, Vercel, serveurs on-premise et IaaS sous Apache, Nginx et ' +
+          'Linux. Pas de cluster Kubernetes administré en propre : c’est écrit ici parce ' +
+          'que vous méritez de le savoir avant de signer.',
+        preuve:
+          'SLI / SLO / SLA définis et suivis, PCA et PRA testés par exercices de bascule, ' +
+          'déploiements sans interruption de service.',
+        decision: 'Où tourne votre produit, et ce que coûte réellement chaque option.',
+      },
+    ],
+  },
+  {
+    id: 'qualite',
+    kind: 'pole',
+    pole: 'ingenierie-web',
+    kicker: 'La qualité',
+    titre: 'Certifiée et outillée, pas promise',
+    chapo:
+      'Chez MailingVox, il n’y avait ni QA ni équipe data : la qualité a été industrialisée ' +
+      'parce qu’elle ne pouvait venir de personne d’autre. C’est cette méthode-là que vous ' +
+      'achetez, pas une intention.',
+    blocs: [
+      {
+        titre: 'ISTQB Foundation',
+        texte:
+          'La certification apporte un vocabulaire de recette commun et opposable : niveaux ' +
+          'de test, critères d’entrée et surtout critères d’arrêt sont écrits avant la ' +
+          'livraison, pas négociés pendant. C’est le seul niveau que je détiens, et c’est ' +
+          'donc le seul que j’affiche.',
+        decision: 'À partir de quand une version est livrable — et qui le dit.',
+      },
+      {
+        titre: 'Développement piloté par les tests, en IA augmentée',
+        texte:
+          'Claude Code et Gemini au quotidien : agents, hooks, skills, loop et serveurs MCP ' +
+          'internes. Le test fait foi avant, pendant et après la génération — c’est ce qui ' +
+          'rend la vélocité gagnée réellement exploitable plutôt que dangereuse.',
+        preuve: 'Vélocité augmentée à effectif constant.',
+      },
+      {
+        titre: 'Outillage réellement en place',
+        texte:
+          'Jest, Cypress, Playwright, tests de mutation Stryker, Postman, Lighthouse. Tests ' +
+          'fonctionnels et recette des parcours critiques, tests d’acceptation avec le ' +
+          'product owner et les clients. Non fonctionnels : non-régression à chaque ' +
+          'livraison, performance et charge sur les pics d’envoi, accessibilité.',
+        decision: 'Quel niveau de test vous vous autorisez à ne pas payer, et sur quel périmètre.',
+      },
+    ],
+  },
+  {
+    id: 'charniere-run',
+    kind: 'charniere',
+    kicker: 'Charnière vers le pôle 2',
+    titre: 'La livraison n’est pas la fin, c’est le début du run',
+    chapo:
+      'Un produit mis en production se met à tourner, et ce qui tourne produit de la ' +
+      'donnée : volumes, échecs, parcours abandonnés, coûts d’infrastructure. Exploiter, ' +
+      'c’est mesurer. C’est ce moment précis qui fait naître le besoin de data et d’IA — ' +
+      'pas une mode, et pas avant que le produit existe.',
+    blocs: [
+      {
+        titre: 'Contrôles post-déploiement',
+        texte: 'exécutés en production, pas seulement en recette.',
+      },
+      {
+        titre: 'Pics d’affluence',
+        texte: 'absorbés sans incident, y compris saisonniers sur un site marchand.',
+      },
+      {
+        titre: 'Et ensuite',
+        texte:
+          'la donnée produite par le run devient la matière du pôle 2 — qualité, règles ' +
+          'métier, modèles et IA en production.',
+      },
+    ],
+  },
+]

--- a/src/@vitrine/contenu/ingenierie-web.ts
+++ b/src/@vitrine/contenu/ingenierie-web.ts
@@ -1,0 +1,17 @@
+// ingenierie-web.ts — jeromemarichez-fr
+// Pôle 1 — Ingénierie web. Métadonnées ; les sections vivent dans le fichier voisin
+// (limite de 300 lignes par fichier, docs/tooling.md).
+
+import type { IEditorialPage } from '@/interfaces/IEditorialPage'
+import { SECTIONS_INGENIERIE_WEB } from './ingenierie-web-sections'
+
+export const PAGE_INGENIERIE_WEB: IEditorialPage = {
+  route: '/services/ingenierie-web',
+  meta: {
+    title: 'Ingénierie web — site, SaaS et mobile | Lille',
+    description:
+      'Site, SaaS et mobile conçus, développés et exploités par une seule personne. ' +
+      'Qualité certifiée ISTQB Foundation, TDD, migrations sans coupure.',
+  },
+  sections: SECTIONS_INGENIERIE_WEB,
+}

--- a/src/@vitrine/contenu/limites.ts
+++ b/src/@vitrine/contenu/limites.ts
@@ -1,0 +1,63 @@
+// limites.ts — jeromemarichez-fr
+// Ce que je ne fais pas — et ce que je fais à la place.
+//
+// Ce fichier est la traduction publique de la table des règles de véracité du
+// `CLAUDE.md`. Chaque ligne y correspond à une formulation interdite : au lieu de
+// simplement l'éviter, le site la retourne en argument de lucidité. Ne rien ajouter
+// ici qui ne soit pas adossé à cette table ou aux CV de référence.
+
+import type { IBoundary } from '@/interfaces/IBoundary'
+
+export const LIMITES: IBoundary[] = [
+  {
+    hors: 'Aucune sous-traitance, aucune couche commerciale',
+    alaPlace:
+      "Vous parlez à la personne qui écrit le code. C'est la même du cadrage au run, " +
+      "sur les trois pôles — c'est tout ce que ce site vend.",
+  },
+  {
+    hors: 'Pas de cluster Kubernetes administré en propre',
+    alaPlace:
+      'Cloud Run, VM Compute Engine auto-scalées, cloud functions et Pub/Sub. Le run ' +
+      'tourne, il est mesuré, et il ne repose pas sur une compétence que je ne tiens pas.',
+  },
+  {
+    hors: 'Pas de framework RAG tiers',
+    alaPlace:
+      'Le RAG est fait maison : recherche vectorielle PostgreSQL et API OpenAI, réponses ' +
+      'ancrées sur votre documentation interne, pas sur la mémoire du modèle.',
+  },
+  {
+    hors: 'Pas de création graphique ni de design d’interface',
+    alaPlace:
+      'Des arbitrages de parcours pris sur la donnée : quelle étape disparaît, quel ' +
+      'formulaire raccourcit, quelle page se rend en SSR plutôt qu’en CSR.',
+  },
+  {
+    hors: 'Deux régies publicitaires, pas douze',
+    alaPlace:
+      'Google Ads et Bing Ads, en SEO, SEA et SMA. Ce que je pilote, je l’ai déjà piloté — ' +
+      'je ne me forme pas à un canal sur votre budget.',
+  },
+  {
+    hors: 'Une équipe technique de trois, pas un service',
+    alaPlace:
+      'Ce que j’encadre : des équipes marketing et SEO/SEA de 5 à 10 personnes, des ' +
+      'prestataires externes, des alternants et des stagiaires. Côté technique, mon titre ' +
+      'est Lead Tech dans une équipe de deux développeurs et un product owner.',
+  },
+  {
+    hors: 'Un seul outillage de mesure mobile',
+    alaPlace:
+      'Firebase Analytics et Crashlytics, et rien d’autre — je ne cite pas d’outil que je ' +
+      'n’ai pas exploité. Côté web : Google Tag Manager en conteneur web et server-side, ' +
+      'Measurement Protocol, Google Analytics, Matomo, gestion du consentement.',
+  },
+  {
+    hors: 'ISTQB Foundation, et rien au-delà',
+    alaPlace:
+      'C’est le seul niveau que je détiens, c’est donc le seul qui est affiché. Ce qui est ' +
+      'outillé l’est réellement : développement piloté par les tests, Jest, Cypress, ' +
+      'Playwright, tests de mutation Stryker, Postman, Lighthouse.',
+  },
+]

--- a/src/@vitrine/contenu/poles-nav.ts
+++ b/src/@vitrine/contenu/poles-nav.ts
@@ -1,0 +1,51 @@
+// poles-nav.ts — jeromemarichez-fr
+// Les trois pôles vus depuis la navigation : le strict nécessaire pour se repérer.
+//
+// Le contenu long de chaque pôle vit dans son propre fichier (`ingenierie-web.ts`,
+// `data-ia.ts`, `sea-ux.ts`). Cette liste-ci ne porte que l'identité et l'ordre — elle
+// est chargée par l'en-tête et le pied de page, donc sur toutes les pages du site.
+
+import { ROUTES } from '@/@shared/routes'
+import type { IPole } from '@/interfaces/IPole'
+
+export const POLES_NAV: IPole[] = [
+  {
+    id: 'ingenierie-web',
+    rang: 1,
+    nom: 'Ingénierie web',
+    route: ROUTES['ingenierie-web'],
+    promesse: 'Je construis le produit, et je le fais tourner.',
+    accroche:
+      'Site, produit SaaS, application mobile : conception, développement, mise en production ' +
+      'et exploitation. Une seule personne du cadrage au run, avec une qualité outillée et ' +
+      'certifiée plutôt que promise.',
+    remise:
+      "Un produit en production ne se fige pas : il tourne, il est mesuré, et c'est de là que " +
+      'vient la donnée.',
+  },
+  {
+    id: 'data-ia',
+    rang: 2,
+    nom: 'Data & IA',
+    route: ROUTES['data-ia'],
+    promesse: "Je rends votre donnée exploitable, puis j'y branche l'IA.",
+    accroche:
+      'Qualité de la donnée traitée comme un prérequis, pipelines et réconciliation ' +
+      'multi-sources, apprentissage supervisé, LLM et agents en production — avec le coût ' +
+      "d'inférence, la latence et le RGPD tenus.",
+    remise:
+      'Une donnée clarifiée cesse d’être un tableau de bord de plus : elle devient la matière ' +
+      'des arbitrages.',
+  },
+  {
+    id: 'sea-ux',
+    rang: 3,
+    nom: 'SEA & UX',
+    route: ROUTES['sea-ux'],
+    promesse: 'Je ne dessine pas vos maquettes, je tranche vos parcours.',
+    accroche:
+      'Mesure construite dans le code, conformité du consentement, rentabilité à long terme ' +
+      'plutôt que coût par clic, et des arbitrages de parcours décidés sur la donnée — puis ' +
+      'implémentés par la même personne.',
+  },
+]

--- a/src/@vitrine/contenu/preuves.ts
+++ b/src/@vitrine/contenu/preuves.ts
@@ -1,0 +1,52 @@
+// preuves.ts — jeromemarichez-fr
+// Le mur de preuves. Aucun chiffre ici n'est estimé, arrondi ni reconstitué.
+//
+// Source unique : les CV de référence de /Users/nicolasb/Documents/CV. Un chiffre qui
+// ne s'y trouve pas mot pour mot n'a rien à faire sur cette page.
+
+import type { IProof } from '@/interfaces/IProof'
+
+export const PREUVES: IProof[] = [
+  {
+    chiffre: '+50 %',
+    libelle: 'de panier moyen',
+    contexte:
+      'Verhoeven Joaillier, 2019-2022. Refonte des parcours d’achat pilotée par la mesure : ' +
+      'A/B testing des pages et des designs, heatmaps, taux de rebond.',
+  },
+  {
+    chiffre: '98/100',
+    libelle: 'au score Lighthouse',
+    contexte:
+      'Plateforme SaaS « Sms En Masse », front React / Next.js avec stratégie de rendu ' +
+      'différenciée par type de page. Conformité RGAA / WCAG tenue en parallèle.',
+  },
+  {
+    chiffre: '100 000 €',
+    libelle: 'de budget ADS / SEO piloté',
+    contexte:
+      'Truffle Capital, 2017-2019. Budget mesuré et justifié auprès des dirigeants, ' +
+      'coordination d’une équipe marketing de 5 à 10 personnes et de 3 prestataires.',
+  },
+  {
+    chiffre: '3',
+    libelle: 'migrations sans interruption de service',
+    contexte:
+      'PHP 5 vers 7 puis réécriture Node.js, jQuery vers React, Ionic 6 vers 8 et Angular ' +
+      '15 vers 19 — aucune coupure, aucun gel de la roadmap.',
+  },
+  {
+    chiffre: '9 ans',
+    libelle: 'en petite équipe ou en autonomie complète',
+    contexte:
+      'Les décisions techniques sont les miennes et je les assume en production. Chez ' +
+      'MailingVox : équipe de 3, sans QA ni équipe data dédiées.',
+  },
+  {
+    chiffre: '0',
+    libelle: 'sous-traitant',
+    contexte:
+      'Celui qui cadre est celui qui code, qui mesure et qui exploite. C’est la seule ' +
+      'raison pour laquelle les trois pôles tiennent ensemble.',
+  },
+]

--- a/src/@vitrine/contenu/sea-ux-sections.ts
+++ b/src/@vitrine/contenu/sea-ux-sections.ts
@@ -1,0 +1,196 @@
+// sea-ux-sections.ts — jeromemarichez-fr
+// Pôle 3 — Arbitrer. SEA et arbitrages d'expérience.
+//
+// Point de vigilance éditorial numéro un : rien ici ne doit laisser croire à de la
+// création graphique ou à du design d'interface. Ce qui est vendu, ce sont des
+// arbitrages pris sur la donnée, puis implémentés.
+//
+// Règles de véracité du CLAUDE.md appliquées : GTM appartient à la période
+// Acetelecom / MailingVox (chez Verhoeven : Google Analytics, A/B testing, heatmaps) ;
+// mobile = Firebase Analytics et Crashlytics uniquement ; régies = Google Ads et
+// Bing Ads, jamais Meta ni LinkedIn.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+export const SECTIONS_SEA_UX: IEditorialSection[] = [
+  {
+    id: 'cadrage-ux',
+    kind: 'pole',
+    pole: 'sea-ux',
+    kicker: 'Disons-le tout de suite',
+    titre: 'Je ne dessine pas vos maquettes',
+    chapo:
+      'Ce pôle ne vend pas de création graphique ni de design d’interface. Il vend des ' +
+      'arbitrages : quel parcours, quelle étape supprimée, quel formulaire raccourci, quel ' +
+      'test A/B tranché, quelle page rendue en SSR plutôt qu’en CSR. Des décisions, prises ' +
+      'sur des chiffres, puis implémentées dans le produit.',
+    blocs: [
+      {
+        titre: 'Ce que je fais',
+        texte:
+          'Je regarde ce que la donnée dit du parcours réel, je propose la modification, ' +
+          'je la teste, et j’écris le code qui l’applique. La boucle complète, sans ' +
+          'intermédiaire ni transfert de dossier.',
+        decision: 'Quelle étape du tunnel disparaît, et ce que vous gagnez à la supprimer.',
+      },
+      {
+        titre: 'Ce que je ne fais pas',
+        texte:
+          'Je ne produis pas d’identité visuelle, pas de direction artistique, pas de ' +
+          'maquette esthétique livrée en fichier. Si c’est ce dont vous avez besoin, il ' +
+          'vous faut un designer — et je travaille volontiers avec le vôtre.',
+      },
+      {
+        titre: 'Pourquoi ça marche',
+        texte:
+          'Parce que les chiffres viennent du pôle 2 et que le code vient du pôle 1. Un ' +
+          'arbitrage n’est utile que s’il repose sur une mesure fiable et qu’il finit ' +
+          'réellement implémenté ; ici, les trois maillons sont tenus par la même personne.',
+      },
+    ],
+  },
+  {
+    id: 'mesure',
+    kind: 'pole',
+    pole: 'sea-ux',
+    kicker: 'La mesure',
+    titre: 'Construite dans le code, pas déclarée dans une interface',
+    chapo:
+      'C’est ce qui distingue cette prestation de celle d’une agence : je lis le code à ' +
+      'l’endroit exact où l’événement doit être posé, au lieu de le deviner depuis un ' +
+      'tableau de bord. La donnée qui en sort n’est pas approximative.',
+    blocs: [
+      {
+        titre: 'Plan de taggage opposable',
+        texte:
+          'Conventions de nommage, propriétés attendues, cycle de vie de chaque événement, ' +
+          'documentation tenue à jour et opposable aux équipes. Sans ce document, chaque ' +
+          'nouvelle fonctionnalité ajoute un dialecte de plus.',
+        decision: 'Quels événements existent, ce qu’ils portent, et qui répond de leur exactitude.',
+      },
+      {
+        titre: 'Collecte web et server-side',
+        texte:
+          'Google Tag Manager en conteneur web et server-side, dataLayer, Measurement ' +
+          'Protocol : les événements partent de serveur à serveur, moins exposés aux ' +
+          'bloqueurs et à la perte de signal côté navigateur. Google Analytics, Matomo, ' +
+          'Search Console.',
+      },
+      {
+        titre: 'Mobile',
+        texte:
+          'Firebase Analytics et Crashlytics : événements in-app, parcours et échecs suivis ' +
+          'jusqu’au correctif livré. Pas d’autre outillage mobile revendiqué — ce serait ' +
+          'inventé.',
+      },
+      {
+        titre: 'Recette de la donnée',
+        texte:
+          'Les implémentations de tracking sont recettées événement par événement, avec la ' +
+          'même méthode que le reste du produit. Contrôles d’intégrité dès l’ingestion, ' +
+          'dédoublonnage, correction des anomalies avant qu’elles n’atteignent un rapport.',
+        preuve: 'Méthode de recette adossée à la certification ISTQB Foundation.',
+      },
+    ],
+  },
+  {
+    id: 'conformite',
+    kind: 'pole',
+    pole: 'sea-ux',
+    kicker: 'La conformité',
+    titre: 'Par construction, pas en rattrapage',
+    chapo:
+      'Le consentement ne se rajoute pas sur une collecte existante : il conditionne son ' +
+      'architecture. Une collecte conçue sans lui devra être refaite, pas corrigée.',
+    blocs: [
+      {
+        titre: 'RGPD et gestion du consentement',
+        texte:
+          'Plateforme de gestion du consentement, déclenchement conditionnel des tags par ' +
+          'catégorie, cadrage des traitements avec le juridique. Finalité et durée de ' +
+          'conservation décidées avant la première ligne de collecte.',
+        decision:
+          'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
+      },
+      {
+        titre: 'Exigences grands comptes',
+        texte:
+          'RGPD et DORA, tels qu’ils sont réellement demandés en appel d’offres par la ' +
+          'distribution, l’assurance et la banque. Ce sont des questionnaires auxquels il ' +
+          'faut savoir répondre avec des preuves, pas avec des intentions.',
+      },
+    ],
+  },
+  {
+    id: 'pilotage',
+    kind: 'pole',
+    pole: 'sea-ux',
+    kicker: 'Le pilotage',
+    titre: 'Arbitrer sur la rentabilité réelle, pas sur les métriques des régies',
+    chapo:
+      'Une régie publicitaire mesure ce qu’elle a servi. Elle ne mesure pas ce que le ' +
+      'client vous rapportera sur deux ans. Tant que l’arbitrage se fait sur ses chiffres ' +
+      'à elle, le budget suit son intérêt, pas le vôtre.',
+    blocs: [
+      {
+        titre: 'Valeur client à long terme',
+        texte:
+          'Agrégation des sources d’acquisition, réconciliation et dédoublonnage des ' +
+          'identités, mesure de la rentabilité dans la durée. Les budgets sont ensuite ' +
+          'arbitrés là-dessus.',
+        decision: 'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre.',
+      },
+      {
+        titre: 'Campagnes et référencement',
+        texte:
+          'Google Ads, Bing Ads, SEO, SEA et SMA. Optimisation du taux de conversion, ' +
+          'A/B testing des pages et des designs, analyse comportementale — heatmaps, taux ' +
+          'de rebond, part de trafic mobile.',
+        preuve:
+          '100 000 € de budget ADS / SEO pilotés, mesurés et justifiés auprès des ' +
+          'dirigeants chez Truffle Capital ; environ 25 000 € d’encadrement de prestataires ' +
+          'SEA chez Verhoeven Joaillier.',
+      },
+      {
+        titre: 'Tableaux de bord sur mesure',
+        texte:
+          'Un tableau de bord par client et par produit, construit sur son modèle métier — ' +
+          'pas un gabarit rempli par un connecteur générique. Profilage clients par ' +
+          'clustering pour rendre la décision lisible.',
+      },
+      {
+        titre: 'Référencement technique',
+        texte:
+          'Le SEO traité comme une propriété du produit : stratégie de rendu Next.js par ' +
+          'type de page, Core Web Vitals, Lighthouse, accessibilité. Ce n’est pas une ' +
+          'prestation à part, c’est une conséquence des choix du pôle 1.',
+        preuve: 'Lighthouse 98/100 sur la plateforme SaaS livrée.',
+      },
+    ],
+  },
+  {
+    id: 'boucle',
+    kind: 'charniere',
+    kicker: 'La boucle',
+    titre: 'Ce que la mesure révèle repart en construction',
+    chapo:
+      'Le dernier maillon renvoie au premier. Un arbitrage décidé le lundi est implémenté ' +
+      'dans la semaine, parce qu’il n’attend ni le devis d’une agence ni la disponibilité ' +
+      'd’un intégrateur. C’est là que l’interlocuteur unique cesse d’être un argument de ' +
+      'confort et devient un gain de délai mesurable.',
+    blocs: [
+      {
+        titre: 'Aucun transfert de dossier',
+        texte:
+          'la personne qui a lu le chiffre est celle qui modifie le code — rien ne se perd ' +
+          'à la jointure.',
+      },
+      {
+        titre: 'Retour au pôle 1',
+        texte:
+          'la modification suit le même cycle que le reste : test d’abord, non-régression, ' +
+          'mise en production sans coupure.',
+      },
+    ],
+  },
+]

--- a/src/@vitrine/contenu/sea-ux.ts
+++ b/src/@vitrine/contenu/sea-ux.ts
@@ -1,0 +1,16 @@
+// sea-ux.ts — jeromemarichez-fr
+// Pôle 3 — SEA & UX. Métadonnées ; les sections vivent dans le fichier voisin.
+
+import type { IEditorialPage } from '@/interfaces/IEditorialPage'
+import { SECTIONS_SEA_UX } from './sea-ux-sections'
+
+export const PAGE_SEA_UX: IEditorialPage = {
+  route: '/services/sea-ux',
+  meta: {
+    title: 'SEA & arbitrages UX sur la donnée — Lille',
+    description:
+      'Mesure construite dans le code (GTM web et server-side), consentement conforme, ' +
+      'rentabilité à long terme, arbitrages de parcours décidés puis implémentés.',
+  },
+  sections: SECTIONS_SEA_UX,
+}

--- a/src/@vitrine/contenu/select-certifications.ts
+++ b/src/@vitrine/contenu/select-certifications.ts
@@ -1,0 +1,19 @@
+// select-certifications.ts — jeromemarichez-fr
+// Sélection des certifications à afficher selon le contexte.
+
+import type { ICertification } from '@/interfaces/ICertification'
+import type { PoleId } from '@/interfaces/types'
+import { CERTIFICATIONS } from './certifications'
+
+/**
+ * Certifications d'un pôle, complétées par les certifications transverses.
+ *
+ * Une page de pôle qui listerait tout le tableau diluerait son propre argument : le
+ * visiteur venu pour l'ingénierie web n'a pas besoin d'y lire les certifications
+ * d'acquisition. Elles restent visibles sur la page du pôle concerné et sur l'accueil.
+ */
+export function selectCertificationsByPole(pole: PoleId): ICertification[] {
+  return CERTIFICATIONS.filter(
+    (certification) => certification.pole === pole || certification.pole === 'transverse',
+  )
+}

--- a/src/@vitrine/services/find-pole.ts
+++ b/src/@vitrine/services/find-pole.ts
@@ -1,0 +1,23 @@
+// find-pole.ts — jeromemarichez-fr
+// Retrouver un pôle et son suivant dans la chaîne.
+
+import type { IPole } from '@/interfaces/IPole'
+import type { PoleId } from '@/interfaces/types'
+import { POLES_NAV } from '../contenu/poles-nav'
+
+/**
+ * Rend le pôle demandé et celui qui le suit.
+ *
+ * Le « suivant » n'est pas un détail de navigation : chaque page de pôle annonce la
+ * suite de la chaîne dès son ouverture, sinon elle se lit comme une plaquette isolée.
+ * Le dernier pôle n'en a pas — la boucle revient au produit, ce que sa page dit en
+ * toutes lettres.
+ */
+export function findPole(id: PoleId): { pole: IPole; suivant?: IPole } {
+  const index = POLES_NAV.findIndex((pole) => pole.id === id)
+  const pole = POLES_NAV[index]
+
+  if (!pole) throw new Error(`Pôle inconnu : ${id}`)
+
+  return { pole, suivant: POLES_NAV[index + 1] }
+}

--- a/src/@vitrine/services/glass-policy.ts
+++ b/src/@vitrine/services/glass-policy.ts
@@ -1,0 +1,24 @@
+// glass-policy.ts — jeromemarichez-fr
+// Quelles sections reçoivent le verre réfractant, et combien au maximum.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+/**
+ * Plafond de surfaces vitrées par page.
+ *
+ * liquidGL tient une trentaine de lentilles, mais chacune lit la même capture plein
+ * document : le coût réel est celui de la texture, pas celui du nombre de panneaux. Le
+ * plafond est donc là pour une raison de lecture, pas de performance — au-delà de trois
+ * panneaux, l'effet cesse d'être un signal et devient un fond.
+ */
+export const MAX_GLASS_PER_PAGE = 3
+
+/**
+ * Le verre marque les sections qui portent un pôle. Les charnières, elles, restent en
+ * texte nu sur le fond : ce sont des respirations, et les vitrer reviendrait à les
+ * transformer en quatrième offre.
+ */
+export function selectGlassSectionIds(sections: IEditorialSection[]): Set<string> {
+  const eligibles = sections.filter((section) => section.kind === 'pole')
+  return new Set(eligibles.slice(0, MAX_GLASS_PER_PAGE).map((section) => section.id))
+}

--- a/src/@vitrine/views/HomeView/home-view.module.css
+++ b/src/@vitrine/views/HomeView/home-view.module.css
@@ -1,0 +1,83 @@
+/* home-view.module.css — enchaînement des sections de l'accueil. */
+
+.page {
+  position: relative;
+}
+
+.corps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-7);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: 0 var(--e-4) var(--e-7);
+}
+
+.bloc {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+  scroll-margin-top: 6rem;
+}
+
+.kicker {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--cuivre);
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+.appui {
+  max-width: var(--mesure-texte);
+  font-family: var(--police-titre-pile);
+  font-variation-settings:
+    "SOFT" 0,
+    "WONK" 0,
+    "opsz" 24;
+  font-size: var(--t-2);
+  line-height: 1.3;
+}
+
+.contact {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+  align-items: flex-start;
+  padding: var(--e-5);
+  border: 1px solid var(--verre-arete);
+  border-radius: var(--rayon-verre);
+  background: color-mix(in srgb, var(--fond-creux) 60%, transparent);
+  scroll-margin-top: 6rem;
+}
+
+.action {
+  display: inline-block;
+  padding: var(--e-2) var(--e-4);
+  border-radius: var(--rayon-petit);
+  background: var(--cuivre);
+  color: var(--fond);
+  font-family: var(--police-mono-pile);
+  text-decoration: none;
+  transition:
+    transform 140ms ease-out,
+    box-shadow 140ms ease-out;
+}
+
+.action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--cuivre) 30%, transparent);
+}
+
+.action:active {
+  transform: translateY(0);
+  transition-duration: 80ms;
+}

--- a/src/@vitrine/views/HomeView/index.tsx
+++ b/src/@vitrine/views/HomeView/index.tsx
@@ -1,0 +1,90 @@
+// HomeView/index.tsx — jeromemarichez-fr
+// La page d'accueil : la chaîne complète, d'un bout à l'autre.
+
+import { LiquidGlassRuntime } from '@/@shared/components/LiquidGlassRuntime'
+import { SITE_IDENTITY } from '@/@shared/seo/site'
+import { BoundaryList } from '../../components/BoundaryList'
+import { CertificationList } from '../../components/CertificationList'
+import { ChainDiagram } from '../../components/ChainDiagram'
+import { EditorialSection } from '../../components/EditorialSection'
+import { HomeHero } from '../../components/HomeHero'
+import { ProofWall } from '../../components/ProofWall'
+import { PAGE_ACCUEIL, THESE_CHAINE } from '../../contenu/accueil'
+import { CERTIFICATIONS } from '../../contenu/certifications'
+import { LIMITES } from '../../contenu/limites'
+import { PREUVES } from '../../contenu/preuves'
+import { selectGlassSectionIds } from '../../services/glass-policy'
+import styles from './home-view.module.css'
+
+/**
+ * L'accueil est la seule page qui déroule la chaîne entière : construire, exploiter et
+ * mesurer, arbitrer. Les charnières y sont des sections à part entière — ce sont elles
+ * qui distinguent une prise en charge continue d'un catalogue de trois prestations.
+ */
+export function HomeView() {
+  const verre = selectGlassSectionIds(PAGE_ACCUEIL.sections)
+
+  return (
+    <div className={styles.page}>
+      <HomeHero />
+
+      <div className={styles.corps}>
+        <section aria-labelledby="chaine-titre" className={styles.bloc} id="chaine">
+          <p className={styles.kicker}>La thèse</p>
+          <h2 id="chaine-titre">{THESE_CHAINE.titre}</h2>
+          <p className={styles.chapo}>{THESE_CHAINE.chapo}</p>
+          <ChainDiagram />
+          <p className={styles.appui}>{THESE_CHAINE.appui}</p>
+        </section>
+
+        {PAGE_ACCUEIL.sections.map((section) => (
+          <EditorialSection glass={verre.has(section.id)} key={section.id} section={section} />
+        ))}
+
+        <section aria-labelledby="preuves-titre" className={styles.bloc} id="preuves">
+          <p className={styles.kicker}>Vérifiable</p>
+          <h2 id="preuves-titre">Ce qui est mesuré, pas ce qui est promis</h2>
+          <p className={styles.chapo}>
+            Chaque chiffre porte son contexte : où, quand, et sur quel produit. Sans cela, un
+            chiffre n'est qu'une affirmation de plus.
+          </p>
+          <ProofWall preuves={PREUVES} />
+        </section>
+
+        <section aria-labelledby="limites-titre" className={styles.bloc} id="limites">
+          <p className={styles.kicker}>Les limites</p>
+          <h2 id="limites-titre">Ce que je ne fais pas</h2>
+          <p className={styles.chapo}>
+            Un prestataire qui sait tout faire ne sait rien faire. Voici ce que je laisse à
+            d'autres, et ce que je fais à la place — c'est le bloc qui rend le reste croyable.
+          </p>
+          <BoundaryList limites={LIMITES} />
+        </section>
+
+        <section aria-labelledby="certifications-titre" className={styles.bloc} id="certifications">
+          <p className={styles.kicker}>Certifications</p>
+          <h2 id="certifications-titre">Ce qui a été évalué par quelqu'un d'autre que moi</h2>
+          <p className={styles.chapo}>
+            Aucun justificatif n'est publié en ligne à ce jour : ils sont communiqués sur demande.
+            Un lien mort sur un site qui vend de la rigueur coûterait plus cher que l'absence de
+            lien.
+          </p>
+          <CertificationList certifications={CERTIFICATIONS} />
+        </section>
+
+        <section aria-labelledby="contact-titre" className={styles.contact} id="contact">
+          <h2 id="contact-titre">Décrivez-moi votre situation</h2>
+          <p className={styles.chapo}>
+            Vous écrivez à la personne qui fera le travail. Je vous dis ce que j'en ferais — et si
+            ce n'est pas pour moi, je vous le dis aussi.
+          </p>
+          <a className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
+            {SITE_IDENTITY.email}
+          </a>
+        </section>
+      </div>
+
+      <LiquidGlassRuntime />
+    </div>
+  )
+}

--- a/src/@vitrine/views/PolePageView/index.tsx
+++ b/src/@vitrine/views/PolePageView/index.tsx
@@ -1,0 +1,56 @@
+// PolePageView/index.tsx — jeromemarichez-fr
+// Gabarit commun aux trois pages de pôle.
+
+import { LiquidGlassRuntime } from '@/@shared/components/LiquidGlassRuntime'
+import type { IEditorialPage } from '@/interfaces/IEditorialPage'
+import type { IPole } from '@/interfaces/IPole'
+import { CertificationList } from '../../components/CertificationList'
+import { EditorialSection } from '../../components/EditorialSection'
+import { PoleHero } from '../../components/PoleHero'
+import { selectCertificationsByPole } from '../../contenu/select-certifications'
+import { selectGlassSectionIds } from '../../services/glass-policy'
+import styles from './pole-page-view.module.css'
+
+interface PolePageViewProps {
+  pole: IPole
+  page: IEditorialPage
+  /** Pôle suivant dans la chaîne. Absent pour le dernier maillon. */
+  suivant?: IPole
+}
+
+/**
+ * Les trois pôles partagent un gabarit strictement identique.
+ *
+ * C'est un choix éditorial, pas une économie de code : trois pages construites pareil
+ * disent qu'il s'agit d'un seul métier découpé en trois temps. Trois mises en page
+ * différentes auraient dit trois prestataires.
+ */
+export function PolePageView({ pole, page, suivant }: PolePageViewProps) {
+  const verre = selectGlassSectionIds(page.sections)
+  const certifications = selectCertificationsByPole(pole.id)
+
+  return (
+    <div className={styles.page}>
+      <PoleHero pole={pole} suivant={suivant} />
+
+      <div className={styles.corps}>
+        {page.sections.map((section) => (
+          <EditorialSection glass={verre.has(section.id)} key={section.id} section={section} />
+        ))}
+
+        {certifications.length > 0 ? (
+          <section aria-labelledby="certifications-titre" className={styles.certifications}>
+            <h2 id="certifications-titre">Ce qui est certifié sur ce pôle</h2>
+            <p className={styles.chapo}>
+              Une certification ne remplace pas une réalisation. Elle dit seulement que la méthode a
+              été évaluée par quelqu'un d'autre que moi.
+            </p>
+            <CertificationList certifications={certifications} />
+          </section>
+        ) : null}
+      </div>
+
+      <LiquidGlassRuntime />
+    </div>
+  )
+}

--- a/src/@vitrine/views/PolePageView/pole-page-view.module.css
+++ b/src/@vitrine/views/PolePageView/pole-page-view.module.css
@@ -1,0 +1,29 @@
+/* pole-page-view.module.css — gabarit commun aux trois pages de pôle.
+ * Identique pour les trois, volontairement : trois mises en page différentes
+ * diraient trois prestataires. */
+
+.page {
+  position: relative;
+}
+
+.corps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-7);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: 0 var(--e-4) var(--e-7);
+}
+
+.certifications {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}

--- a/src/app/glass-surface.css
+++ b/src/app/glass-surface.css
@@ -4,18 +4,29 @@
  * retrouve ses lentilles par un sélecteur littéral au montage, un nom haché ne serait
  * jamais trouvé. Voir `@shared/components/GlassSurface/glass-class.ts`.
  *
- * Trois contraintes de la bibliothèque sont tenues ici, et nulle part ailleurs :
- *   1. toutes les lentilles partagent le MÊME z-index — il est posé une seule fois,
- *      ci-dessous ; n'en redéclarez pas dans un module CSS de composant ;
- *   2. aucune lentille n'est en `position: fixed` ou `sticky` — liquidGL les ignore ;
- *   3. le rendu reste correct AVANT et SANS le WebGL : le fond ci-dessous n'est pas un
+ * Le panneau est un calque DÉCORATIF ET VIDE, posé derrière le contenu — jamais son
+ * conteneur. liquidGL mute l'élément dont il fait une lentille : `opacity: 0`
+ * (liquidGL.js l. 3397) puis `pointer-events: none` (l. 3419, jamais restauré), et il
+ * efface `background`, `background-image` et `backdrop-filter` en styles en ligne.
+ * Confier du texte ou un lien à cet élément revient à en confier la visibilité et la
+ * cliquabilité à la bibliothèque.
+ *
+ * Quatre contraintes de liquidGL sont tenues ici, et nulle part ailleurs :
+ *   1. toutes les lentilles partagent le MÊME z-index — posé une seule fois ci-dessous,
+ *      n'en redéclarez pas dans un module CSS de composant ;
+ *   2. aucune lentille n'est en `position: fixed` ou `sticky` — la bibliothèque les
+ *      ignore délibérément ;
+ *   3. aucune lentille ne contient de contenu, pour les raisons ci-dessus ;
+ *   4. le rendu reste correct AVANT et SANS le WebGL : le fond ci-dessous n'est pas un
  *      pis-aller, c'est le rendu par défaut sur mobile, sans WebGL et en mouvement
  *      réduit, où le moteur n'est jamais amorcé.
  */
 
 .glass-surface {
-  position: relative;
+  position: absolute;
+  inset: 0;
   z-index: 2;
+  pointer-events: none;
   overflow: clip;
   border: 1px solid var(--verre-arete);
   border-radius: var(--rayon-verre);
@@ -24,14 +35,6 @@
   -webkit-backdrop-filter: blur(14px) saturate(1.15);
   box-shadow: inset 0 1px 0 var(--verre-lueur);
   will-change: transform;
-}
-
-/* Le contenu du panneau doit rester au-dessus du canvas de réfraction, qui est peint
-   au niveau du panneau lui-même. Sans cette règle, le texte disparaîtrait dès que
-   liquidGL prend la main. */
-.glass-surface > * {
-  position: relative;
-  z-index: 1;
 }
 
 /* Safari devient instable dès qu'une lentille dépasse la moitié du viewport, et le

--- a/src/app/glass-surface.css
+++ b/src/app/glass-surface.css
@@ -1,0 +1,52 @@
+/* glass-surface.css — jeromemarichez-fr
+ *
+ * La seule classe globale du site. Elle ne peut pas être un module CSS : liquidGL
+ * retrouve ses lentilles par un sélecteur littéral au montage, un nom haché ne serait
+ * jamais trouvé. Voir `@shared/components/GlassSurface/glass-class.ts`.
+ *
+ * Trois contraintes de la bibliothèque sont tenues ici, et nulle part ailleurs :
+ *   1. toutes les lentilles partagent le MÊME z-index — il est posé une seule fois,
+ *      ci-dessous ; n'en redéclarez pas dans un module CSS de composant ;
+ *   2. aucune lentille n'est en `position: fixed` ou `sticky` — liquidGL les ignore ;
+ *   3. le rendu reste correct AVANT et SANS le WebGL : le fond ci-dessous n'est pas un
+ *      pis-aller, c'est le rendu par défaut sur mobile, sans WebGL et en mouvement
+ *      réduit, où le moteur n'est jamais amorcé.
+ */
+
+.glass-surface {
+  position: relative;
+  z-index: 2;
+  overflow: clip;
+  border: 1px solid var(--verre-arete);
+  border-radius: var(--rayon-verre);
+  background: var(--verre-teinte);
+  backdrop-filter: blur(14px) saturate(1.15);
+  -webkit-backdrop-filter: blur(14px) saturate(1.15);
+  box-shadow: inset 0 1px 0 var(--verre-lueur);
+  will-change: transform;
+}
+
+/* Le contenu du panneau doit rester au-dessus du canvas de réfraction, qui est peint
+   au niveau du panneau lui-même. Sans cette règle, le texte disparaîtrait dès que
+   liquidGL prend la main. */
+.glass-surface > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* Safari devient instable dès qu'une lentille dépasse la moitié du viewport, et le
+   moteur n'est de toute façon pas amorcé en dessous de 1024px (voir
+   `@shared/glass/settings`). Le panneau se contente alors du fond ci-dessus, allégé :
+   `backdrop-filter` sur un grand bloc coûte cher sur mobile pour un effet peu visible. */
+@media (max-width: 1023px) {
+  .glass-surface {
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glass-surface {
+    will-change: auto;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,6 +100,9 @@ html {
 }
 
 body {
+  /* Positionné pour que `.fond-atelier` prenne la hauteur du DOCUMENT et non celle du
+     viewport : sans cela, la trame technique s'arrête au bas du premier écran. */
+  position: relative;
   min-height: 100dvh;
   background-color: var(--fond);
   color: var(--encre);
@@ -115,11 +118,15 @@ body {
 
 /* Le fond d'atelier est un calque peint, séparé du contenu : c'est ce que le verre
    réfracte. Il est en `absolute` et non `fixed` — liquidGL ignore les éléments fixes,
-   un fond fixe ne serait jamais capturé. */
+   un fond fixe ne serait jamais capturé.
+
+   `z-index: -1` et non `0` : il doit passer sous le contenu SANS que celui-ci ait
+   besoin de son propre contexte d'empilement. Voir la règle `main` ci-dessous, qui
+   explique pourquoi ce détail décide du bon fonctionnement de liquidGL. */
 .fond-atelier {
   position: absolute;
   inset: 0;
-  z-index: 0;
+  z-index: -1;
   pointer-events: none;
   background:
     repeating-linear-gradient(to right, var(--trame) 0 1px, transparent 1px 32px),
@@ -178,9 +185,17 @@ a:hover {
   border-radius: 2px;
 }
 
+/* `main` ne crée volontairement AUCUN contexte d'empilement.
+ *
+ * liquidGL pose ses canvas directement sur `document.body` : le canvas de réfraction
+ * partagé à `z-index: 0`, et un canvas miroir par lentille à `z-index de la lentille
+ * moins 1`. Pour qu'une surface de verre passe au-dessus de ces deux calques, son
+ * `z-index: 2` doit être comparé dans le contexte RACINE. Un `position: relative;
+ * z-index: 1` sur `main` enfermerait tout le contenu dans un contexte à 1, le miroir
+ * passerait par-dessus, et le texte des panneaux vitrés disparaîtrait — c'est
+ * exactement le défaut que ce commentaire empêche de réintroduire. */
 main {
-  position: relative;
-  z-index: 1;
+  position: static;
 }
 
 img,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,191 @@
+/* globals.css — jeromemarichez-fr
+ *
+ * Jetons de design et base typographique. Toute valeur de couleur, d'espace ou de
+ * taille utilisée dans un module CSS vient d'ici : aucune couleur ni aucun espacement
+ * en dur dans un composant (docs/design.md).
+ *
+ * Direction « L'Établi » : papier chaud, encre graphite, un seul accent cuivre, et du
+ * verre qui laisse voir la trame technique du fond — la transparence est le sujet.
+ */
+
+:root {
+  color-scheme: light dark;
+
+  /* — Couleurs, thème clair — */
+  --fond: #f2efe8;
+  --fond-creux: #e7e2d7;
+  --encre: #14171a; /* 15.67:1 sur --fond */
+  --encre-douce: #4a5157; /* 7.02:1 sur --fond */
+  --cuivre: #8f4520; /* 6.02:1 sur --fond — seul accent de texte */
+  --cuivre-vif: #b4623a; /* 3.85:1 — NON-TEXTE : filets, arêtes, traits */
+  --signal: #1f5f52; /* 6.49:1 — disponibilité, coches */
+  --trame: rgba(20, 23, 26, 0.055);
+  --verre-teinte: rgba(255, 255, 255, 0.42);
+  --verre-arete: rgba(143, 69, 32, 0.28);
+  --verre-lueur: rgba(255, 255, 255, 0.7);
+  --fond-degrade-haut: #f7f5f0;
+  --fond-degrade-bas: #ede9e0;
+
+  /* — Typographie — */
+  --police-titre-pile: var(--police-titre), Georgia, "Times New Roman", serif;
+  --police-texte-pile: var(--police-texte), system-ui, -apple-system, sans-serif;
+  --police-mono-pile: var(--police-mono), ui-monospace, "SFMono-Regular", monospace;
+
+  --t--1: 0.8125rem;
+  --t-0: clamp(1rem, 0.955rem + 0.22vw, 1.125rem);
+  --t-1: clamp(1.1875rem, 1.11rem + 0.38vw, 1.4375rem);
+  --t-2: clamp(1.375rem, 1.24rem + 0.68vw, 1.75rem);
+  --t-3: clamp(1.75rem, 1.5rem + 1.25vw, 2.4375rem);
+  --t-4: clamp(2.375rem, 1.8rem + 2.9vw, 4rem);
+  --t-chiffre: clamp(2.25rem, 1.7rem + 2.6vw, 3.5rem);
+
+  /* — Rythme vertical, base 8 — */
+  --e-1: 0.5rem;
+  --e-2: 0.75rem;
+  --e-3: 1rem;
+  --e-4: 1.5rem;
+  --e-5: 2.5rem;
+  --e-6: 4rem;
+  --e-7: 6.5rem;
+
+  /* — Formes — */
+  --rayon-verre: 18px;
+  --rayon-petit: 8px;
+  --largeur-page: 76rem;
+  --mesure-texte: 64ch;
+
+  /* — Mouvement — */
+  --duree-poser: 420ms;
+  --duree-tracer: 700ms;
+  --courbe-poser: cubic-bezier(0.2, 0.6, 0.2, 1);
+  --courbe-tracer: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fond: #0e1114;
+    --fond-creux: #171b20;
+    --encre: #ece7de; /* 15.38:1 sur --fond */
+    --encre-douce: #9ba3aa; /* 7.41:1 sur --fond */
+    --cuivre: #e08b4c; /* 7.18:1 sur --fond */
+    --cuivre-vif: #f0a468; /* 9.21:1 */
+    --signal: #5fd1ae; /* 10.12:1 */
+    --trame: rgba(236, 231, 222, 0.06);
+    --verre-teinte: rgba(236, 231, 222, 0.07);
+    --verre-arete: rgba(224, 139, 76, 0.32);
+    --verre-lueur: rgba(255, 255, 255, 0.14);
+    --fond-degrade-haut: #14181d;
+    --fond-degrade-bas: #0b0e11;
+  }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+body {
+  min-height: 100dvh;
+  background-color: var(--fond);
+  color: var(--encre);
+  font-family: var(--police-texte-pile);
+  font-size: var(--t-0);
+  font-feature-settings:
+    "ss01" 1,
+    "cv05" 1;
+  line-height: 1.62;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Le fond d'atelier est un calque peint, séparé du contenu : c'est ce que le verre
+   réfracte. Il est en `absolute` et non `fixed` — liquidGL ignore les éléments fixes,
+   un fond fixe ne serait jamais capturé. */
+.fond-atelier {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(to right, var(--trame) 0 1px, transparent 1px 32px),
+    repeating-linear-gradient(to bottom, var(--trame) 0 1px, transparent 1px 32px),
+    radial-gradient(1200px 900px at 22% 8%, var(--fond-degrade-haut), var(--fond-degrade-bas));
+}
+
+h1,
+h2,
+h3 {
+  font-family: var(--police-titre-pile);
+  font-variation-settings:
+    "SOFT" 0,
+    "WONK" 0,
+    "opsz" 32;
+  font-weight: 600;
+  text-wrap: balance;
+}
+
+h1 {
+  font-size: var(--t-4);
+  line-height: 1.06;
+  letter-spacing: -0.015em;
+  max-width: 20ch;
+}
+
+h2 {
+  font-size: var(--t-3);
+  line-height: 1.14;
+  max-width: 34ch;
+}
+
+h3 {
+  font-size: var(--t-2);
+  line-height: 1.25;
+}
+
+p {
+  text-wrap: pretty;
+}
+
+a {
+  color: var(--cuivre);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+  transition: text-decoration-thickness 120ms ease-out;
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+:focus-visible {
+  outline: 2px solid var(--cuivre);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+main {
+  position: relative;
+  z-index: 1;
+}
+
+img,
+svg,
+canvas {
+  display: block;
+  max-width: 100%;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,49 @@
 // src/app/layout.tsx — jeromemarichez-fr
 // pages/app ne fait QUE le routage : les sections d'écran vivent dans src/views/.
-import type { ReactNode } from 'react'
 
-export const metadata = {
-  title: 'jeromemarichez-fr',
-  description: 'Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.',
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+import { SiteFooter } from '@/@shared/components/SiteFooter'
+import { SiteHeader } from '@/@shared/components/SiteHeader'
+import { SkipLink } from '@/@shared/components/SkipLink'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { SITE_IDENTITY, SITE_PROMESSE, SITE_URL } from '@/@shared/seo/site'
+import { buildPersonSchema, buildProfessionalServiceSchema } from '@/@shared/seo/structured-data'
+import { FONT_VARIABLES } from '@/@shared/typography/fonts'
+import './globals.css'
+import './glass-surface.css'
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: `${SITE_IDENTITY.nom} — ${SITE_IDENTITY.titre} à ${SITE_IDENTITY.ville}`,
+    template: `%s — ${SITE_IDENTITY.nom}`,
+  },
+  description: SITE_PROMESSE,
+  authors: [{ name: SITE_IDENTITY.nom, url: SITE_URL }],
+  alternates: { canonical: '/' },
+  openGraph: {
+    type: 'website',
+    locale: 'fr_FR',
+    siteName: SITE_IDENTITY.nom,
+    url: SITE_URL,
+  },
+  robots: { index: true, follow: true },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="fr">
-      <body>{children}</body>
+    <html className={FONT_VARIABLES} lang="fr">
+      <body>
+        <SkipLink />
+        <div aria-hidden="true" className="fond-atelier" />
+        <SiteHeader />
+        <main id="contenu">{children}</main>
+        <SiteFooter />
+        <StructuredData
+          schemas={[buildPersonSchema(), buildProfessionalServiceSchema(SITE_PROMESSE)]}
+        />
+      </body>
     </html>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
 // src/app/page.tsx — jeromemarichez-fr
-// Squelette : remplacer par la vraie page d'accueil (composée depuis src/views/).
+// Routage seul : la page d'accueil est composée dans src/@vitrine/views/HomeView.
+
+import { HomeView } from '@/@vitrine/views/HomeView'
+
 export default function HomePage() {
-  return <h1>jeromemarichez-fr</h1>
+  return <HomeView />
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+// robots.ts — jeromemarichez-fr
+// robots.txt généré, pointant vers le sitemap.
+
+import type { MetadataRoute } from 'next'
+import { SITE_URL } from '@/@shared/seo/site'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  }
+}

--- a/src/app/services/data-ia/page.tsx
+++ b/src/app/services/data-ia/page.tsx
@@ -1,0 +1,35 @@
+// src/app/services/data-ia/page.tsx — jeromemarichez-fr
+// Routage seul : la page est composée par le gabarit commun aux trois pôles.
+
+import type { Metadata } from 'next'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { buildBreadcrumbSchema, buildServiceSchema } from '@/@shared/seo/structured-data'
+import { PAGE_DATA_IA } from '@/@vitrine/contenu/data-ia'
+import { findPole } from '@/@vitrine/services/find-pole'
+import { PolePageView } from '@/@vitrine/views/PolePageView'
+
+const { pole, suivant } = findPole('data-ia')
+
+export const metadata: Metadata = {
+  title: PAGE_DATA_IA.meta.title,
+  description: PAGE_DATA_IA.meta.description,
+  alternates: { canonical: pole.route },
+}
+
+export default function PolePage() {
+  return (
+    <>
+      <PolePageView page={PAGE_DATA_IA} pole={pole} suivant={suivant} />
+      <StructuredData
+        schemas={[
+          buildServiceSchema({
+            nom: pole.nom,
+            description: PAGE_DATA_IA.meta.description,
+            route: pole.route,
+          }),
+          buildBreadcrumbSchema({ nom: pole.nom, route: pole.route }),
+        ]}
+      />
+    </>
+  )
+}

--- a/src/app/services/ingenierie-web/page.tsx
+++ b/src/app/services/ingenierie-web/page.tsx
@@ -1,0 +1,35 @@
+// src/app/services/ingenierie-web/page.tsx — jeromemarichez-fr
+// Routage seul : la page est composée par le gabarit commun aux trois pôles.
+
+import type { Metadata } from 'next'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { buildBreadcrumbSchema, buildServiceSchema } from '@/@shared/seo/structured-data'
+import { PAGE_INGENIERIE_WEB } from '@/@vitrine/contenu/ingenierie-web'
+import { findPole } from '@/@vitrine/services/find-pole'
+import { PolePageView } from '@/@vitrine/views/PolePageView'
+
+const { pole, suivant } = findPole('ingenierie-web')
+
+export const metadata: Metadata = {
+  title: PAGE_INGENIERIE_WEB.meta.title,
+  description: PAGE_INGENIERIE_WEB.meta.description,
+  alternates: { canonical: pole.route },
+}
+
+export default function PolePage() {
+  return (
+    <>
+      <PolePageView page={PAGE_INGENIERIE_WEB} pole={pole} suivant={suivant} />
+      <StructuredData
+        schemas={[
+          buildServiceSchema({
+            nom: pole.nom,
+            description: PAGE_INGENIERIE_WEB.meta.description,
+            route: pole.route,
+          }),
+          buildBreadcrumbSchema({ nom: pole.nom, route: pole.route }),
+        ]}
+      />
+    </>
+  )
+}

--- a/src/app/services/sea-ux/page.tsx
+++ b/src/app/services/sea-ux/page.tsx
@@ -1,0 +1,35 @@
+// src/app/services/sea-ux/page.tsx — jeromemarichez-fr
+// Routage seul : la page est composée par le gabarit commun aux trois pôles.
+
+import type { Metadata } from 'next'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { buildBreadcrumbSchema, buildServiceSchema } from '@/@shared/seo/structured-data'
+import { PAGE_SEA_UX } from '@/@vitrine/contenu/sea-ux'
+import { findPole } from '@/@vitrine/services/find-pole'
+import { PolePageView } from '@/@vitrine/views/PolePageView'
+
+const { pole, suivant } = findPole('sea-ux')
+
+export const metadata: Metadata = {
+  title: PAGE_SEA_UX.meta.title,
+  description: PAGE_SEA_UX.meta.description,
+  alternates: { canonical: pole.route },
+}
+
+export default function PolePage() {
+  return (
+    <>
+      <PolePageView page={PAGE_SEA_UX} pole={pole} suivant={suivant} />
+      <StructuredData
+        schemas={[
+          buildServiceSchema({
+            nom: pole.nom,
+            description: PAGE_SEA_UX.meta.description,
+            route: pole.route,
+          }),
+          buildBreadcrumbSchema({ nom: pole.nom, route: pole.route }),
+        ]}
+      />
+    </>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,14 @@
+// sitemap.ts — jeromemarichez-fr
+// Sitemap généré à partir de la liste des routes, jamais tenu à la main.
+
+import type { MetadataRoute } from 'next'
+import { INDEXABLE_ROUTES, ROUTES } from '@/@shared/routes'
+import { SITE_URL } from '@/@shared/seo/site'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return INDEXABLE_ROUTES.map((route) => ({
+    url: `${SITE_URL}${route === ROUTES.accueil ? '' : route}`,
+    changeFrequency: 'monthly' as const,
+    priority: route === ROUTES.accueil ? 1 : 0.8,
+  }))
+}

--- a/src/interfaces/IBoundary.ts
+++ b/src/interfaces/IBoundary.ts
@@ -1,0 +1,17 @@
+// IBoundary.ts — jeromemarichez-fr
+// Une limite assumée : ce qui n'est pas fait, et ce qui l'est à la place.
+
+/**
+ * Dire ce qu'on ne fait pas est un argument, pas un aveu.
+ *
+ * C'est aussi la traduction directe des règles de véracité du `CLAUDE.md` : plutôt que
+ * de simplement taire ce qui n'est pas revendicable, le site l'écrit noir sur blanc.
+ * Un dirigeant qui lit « pas de cluster Kubernetes administré en propre » sait à quoi
+ * s'en tenir — et sait, par la même occasion, que le reste de la page est fiable.
+ */
+export interface IBoundary {
+  /** Ce qui n'est pas proposé, formulé sans détour. */
+  hors: string
+  /** Ce qui est réellement fait à la place. */
+  alaPlace: string
+}

--- a/src/interfaces/ICertification.ts
+++ b/src/interfaces/ICertification.ts
@@ -1,0 +1,31 @@
+// ICertification.ts — jeromemarichez-fr
+// Une certification affichée sur le site.
+
+import type { PoleId } from './types'
+
+/**
+ * Règle de véracité bloquante (CLAUDE.md) : **une URL de certification ne s'invente
+ * ni ne s'approxime**. Tant que le justificatif officiel n'a pas été fourni par
+ * Jérôme MARICHEZ, `justificatif` reste absent et la certification s'affiche sans
+ * lien — jamais avec un lien mort.
+ *
+ * `annee` est également optionnelle : mieux vaut afficher une certification sans
+ * millésime qu'un millésime approximatif.
+ */
+export interface ICertification {
+  /** Intitulé exact tel qu'il figure sur le justificatif. */
+  intitule: string
+  /** Organisme qui délivre la certification. */
+  organisme: string
+  /** Année d'obtention. */
+  annee?: number
+  /** URL du justificatif officiel. Absente tant qu'elle n'a pas été fournie. */
+  justificatif?: string
+  /** Pôle auquel la certification apporte sa crédibilité, ou `transverse`. */
+  pole: PoleId | 'transverse'
+  /**
+   * Ce que la certification change concrètement dans la prestation.
+   * Une certification sans effet énonçable est une ligne de CV, pas un argument.
+   */
+  apport: string
+}

--- a/src/interfaces/ICertification.ts
+++ b/src/interfaces/ICertification.ts
@@ -1,6 +1,7 @@
 // ICertification.ts — jeromemarichez-fr
 // Une certification affichée sur le site.
 
+import type { ICertificationLogo } from './ICertificationLogo'
 import type { PoleId } from './types'
 
 /**
@@ -21,6 +22,12 @@ export interface ICertification {
   annee?: number
   /** URL du justificatif officiel. Absente tant qu'elle n'a pas été fournie. */
   justificatif?: string
+  /**
+   * Logo de l'organisme. Absent tant que le fichier n'a pas été déposé dans `public/`
+   * **et** que son usage n'a pas été autorisé par le propriétaire de la marque : sans
+   * lui, la certification se rend en toutes lettres.
+   */
+  logo?: ICertificationLogo
   /** Pôle auquel la certification apporte sa crédibilité, ou `transverse`. */
   pole: PoleId | 'transverse'
   /**

--- a/src/interfaces/ICertificationLogo.ts
+++ b/src/interfaces/ICertificationLogo.ts
@@ -1,0 +1,21 @@
+// ICertificationLogo.ts — jeromemarichez-fr
+// Le logo d'un organisme certificateur.
+
+/**
+ * Un logo n'est pas une donnée éditoriale comme une autre : c'est une **marque
+ * appartenant à un tiers**, dont l'usage est encadré par son propriétaire (Google,
+ * Microsoft et ISTQB imposent chacun leurs règles, ISTQB n'autorisant que le badge
+ * « Certified Tester »). Le champ reste donc optionnel sur `ICertification` et n'est
+ * renseigné que pour un fichier réellement déposé et réellement autorisé.
+ *
+ * Même logique que `justificatif` : rien ne s'invente. Sans fichier, la certification
+ * s'affiche en toutes lettres — jamais avec une image cassée.
+ */
+export interface ICertificationLogo {
+  /** Chemin public du fichier, servi depuis `public/` (ex. `/certifications/istqb.svg`). */
+  fichier: string
+  /** Largeur intrinsèque en pixels — exigée pour réserver la place et éviter tout CLS. */
+  largeur: number
+  /** Hauteur intrinsèque en pixels. */
+  hauteur: number
+}

--- a/src/interfaces/IEditorialBlock.ts
+++ b/src/interfaces/IEditorialBlock.ts
@@ -1,0 +1,21 @@
+// IEditorialBlock.ts — jeromemarichez-fr
+// Unité éditoriale la plus fine du site : un point d'expertise.
+
+/**
+ * Un bloc d'expertise à l'intérieur d'une section.
+ *
+ * Règle éditoriale du projet (README.md) : une affirmation porte sa preuve ou elle se
+ * reformule, et un bloc de service se termine sur ce que le client peut **trancher**,
+ * jamais sur une liste d'outils. Les deux champs correspondants sont donc optionnels
+ * dans le type mais leur absence est un signal de relecture, pas un défaut de forme.
+ */
+export interface IEditorialBlock {
+  /** Intitulé court du point d'expertise. */
+  titre: string
+  /** Corps du bloc, 2 à 5 phrases. Texte fini, publiable tel quel. */
+  texte: string
+  /** Preuve chiffrée réelle (montant, pourcentage, durée, contrainte tenue). */
+  preuve?: string
+  /** Ce que le client peut trancher grâce à ce point d'expertise. */
+  decision?: string
+}

--- a/src/interfaces/IEditorialPage.ts
+++ b/src/interfaces/IEditorialPage.ts
@@ -1,0 +1,24 @@
+// IEditorialPage.ts — jeromemarichez-fr
+// Une page complète du site, contenu et métadonnées comprises.
+
+import type { IEditorialSection } from './IEditorialSection'
+
+/** Métadonnées SEO d'une page. Longueurs contraintes par l'affichage en SERP. */
+export interface IPageMeta {
+  /** Balise `<title>`, 60 caractères maximum. */
+  title: string
+  /** Meta description, 155 caractères maximum. */
+  description: string
+}
+
+/**
+ * Le contenu éditorial est de la **donnée, pas du JSX** (docs/architecture.md).
+ * Ajouter une section ou un point d'expertise ne doit demander aucune retouche
+ * de rendu : les vues consomment cette structure, elles ne la dupliquent pas.
+ */
+export interface IEditorialPage {
+  /** Route Next.js servie par cette page. */
+  route: string
+  meta: IPageMeta
+  sections: IEditorialSection[]
+}

--- a/src/interfaces/IEditorialSection.ts
+++ b/src/interfaces/IEditorialSection.ts
@@ -1,0 +1,31 @@
+// IEditorialSection.ts — jeromemarichez-fr
+// Une section de page : le niveau auquel le site se raconte.
+
+import type { IEditorialBlock } from './IEditorialBlock'
+import type { PoleId, SectionKind } from './types'
+
+/**
+ * Une section éditoriale rendue comme un bloc de page à part entière.
+ *
+ * `transition` porte la **charnière** : la phrase qui passe la main à la section
+ * suivante. C'est elle qui transforme trois offres empilées en une chaîne continue
+ * — construire, exploiter et mesurer, arbitrer — tenue par un seul interlocuteur.
+ */
+export interface IEditorialSection {
+  /** Identifiant kebab-case, sert d'ancre (`#id`) et de cible aux liens internes. */
+  id: string
+  /** Nature de la section : commande son rendu. */
+  kind: SectionKind
+  /** Surtitre, 4 mots maximum. */
+  kicker: string
+  /** Titre de la section. */
+  titre: string
+  /** Chapô, 2 à 4 phrases. */
+  chapo: string
+  /** Points d'expertise de la section. */
+  blocs: IEditorialBlock[]
+  /** Phrase de charnière vers la section suivante. */
+  transition?: string
+  /** Pôle rattaché, quand la section en porte un. */
+  pole?: PoleId
+}

--- a/src/interfaces/IPole.ts
+++ b/src/interfaces/IPole.ts
@@ -1,0 +1,28 @@
+// IPole.ts — jeromemarichez-fr
+// Un des trois pôles de la chaîne, vu depuis la navigation et la page d'accueil.
+
+import type { PoleId, PoleRank } from './types'
+
+/**
+ * Un pôle de compétence.
+ *
+ * Les trois pôles ne se vendent pas séparément : ils forment une chaîne — construire,
+ * exploiter et mesurer, arbitrer — et c'est le même interlocuteur qui la tient de bout
+ * en bout. `remise` porte ce que le pôle transmet au suivant : c'est ce champ qui
+ * empêche le site de retomber sur un catalogue de trois offres juxtaposées.
+ */
+export interface IPole {
+  id: PoleId
+  /** Rang dans la chaîne. */
+  rang: PoleRank
+  /** Nom affiché du pôle. */
+  nom: string
+  /** Route de la page de détail. */
+  route: string
+  /** Promesse du pôle en une phrase. */
+  promesse: string
+  /** Ce que ce pôle prend en charge, en 2 ou 3 phrases. */
+  accroche: string
+  /** Ce que le pôle remet au suivant. Absent pour le dernier maillon. */
+  remise?: string
+}

--- a/src/interfaces/IProof.ts
+++ b/src/interfaces/IProof.ts
@@ -1,0 +1,18 @@
+// IProof.ts — jeromemarichez-fr
+// Une preuve chiffrée, avec son contexte.
+
+/**
+ * Un chiffre sans contexte est un chiffre invérifiable.
+ *
+ * Chaque preuve porte donc l'employeur et la période où elle a été obtenue : c'est ce
+ * qui la distingue d'un argument de plaquette, et ce qui permet à un prospect de la
+ * recouper avec le parcours.
+ */
+export interface IProof {
+  /** Le chiffre, tel qu'il s'affiche. */
+  chiffre: string
+  /** Ce que le chiffre mesure. */
+  libelle: string
+  /** Où et quand. Repris à l'identique des CV de référence. */
+  contexte: string
+}

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -13,5 +13,8 @@ export type PoleRank = 1 | 2 | 3
  * Nature d'une section éditoriale.
  * `charniere` désigne les deux sections qui passent la main d'un pôle au suivant :
  * elles portent le récit de continuité et se rendent différemment des autres.
+ * `fil` désigne un axe transverse — une méthode qui traverse les trois pôles au lieu
+ * de s'intercaler entre deux. Un `fil` ne reçoit jamais le verre : le vitrer en ferait
+ * une quatrième offre, alors qu'il décrit la façon de tenir les trois autres.
  */
-export type SectionKind = 'accroche' | 'pole' | 'charniere' | 'preuves' | 'contact'
+export type SectionKind = 'accroche' | 'pole' | 'charniere' | 'fil' | 'preuves' | 'contact'

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -3,5 +3,15 @@
 // Les entités métier sont des interfaces (IXxx) dans des fichiers dédiés de ce dossier.
 // Convention : docs/architecture.md.
 
-// export type EntityId = number
-// export type Statut = 'actif' | 'inactif'
+/** Les trois pôles vendus par le site, dans l'ordre de la chaîne. */
+export type PoleId = 'ingenierie-web' | 'data-ia' | 'sea-ux'
+
+/** Rang du pôle dans la chaîne : construire, exploiter et mesurer, arbitrer. */
+export type PoleRank = 1 | 2 | 3
+
+/**
+ * Nature d'une section éditoriale.
+ * `charniere` désigne les deux sections qui passent la main d'un pôle au suivant :
+ * elles portent le récit de continuité et se rendent différemment des autres.
+ */
+export type SectionKind = 'accroche' | 'pole' | 'charniere' | 'preuves' | 'contact'

--- a/tests/fixtures/style-vide.js
+++ b/tests/fixtures/style-vide.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -25,9 +21,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -38,9 +32,5 @@
     ".next/dev/types/**/*.ts"
   ],
   "// exclude": "cypress.config.ts et tests/e2e chargent les types de Cypress, dont le expect() de Chai écrase celui de Jest : les tests unitaires ne compileraient plus. Cypress type-vérifie ses specs lui-même.",
-  "exclude": [
-    "node_modules",
-    "cypress.config.ts",
-    "tests/e2e"
-  ]
+  "exclude": ["node_modules", "cypress.config.ts", "tests/e2e"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,12 +17,30 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./src/*"] }
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "// exclude": "cypress.config.ts et tests/e2e chargent les types de Cypress, dont le expect() de Chai écrase celui de Jest : les tests unitaires ne compileraient plus. Cypress type-vérifie ses specs lui-même.",
-  "exclude": ["node_modules", "cypress.config.ts", "tests/e2e"]
+  "exclude": [
+    "node_modules",
+    "cypress.config.ts",
+    "tests/e2e"
+  ]
 }


### PR DESCRIPTION
## Contexte

Refonte du site en chaîne à trois pôles, avec deux ajouts décidés en session : le **fil IA**
transverse et les **certifications sur plaque de logo**.

L'IA apparaissait deux fois sur le site sans que la distinction soit faite — comme offre
(pôle 2) et comme méthode de production (les trois pôles). Le lecteur les mélangeait et
rangeait l'IA comme une prestation parmi trois.

## Ce que contient la PR

- **`docs`** — le `CLAUDE.md` porte les règles de véracité bloquantes, la ligne éditoriale
  et le renvoi au `README.md` comme source de vérité du contenu. `docs/architecture.md`
  décrit le découpage par domaine.
- **`feat(a11y)`** — mécanisme de mise en pause des animations au sens WCAG 2.2.2.
  `prefers-reduced-motion` n'en est pas un : c'est une préférence système qui ne se change
  pas depuis la page. Contrôle explicite au pied de la scène WebGL, choix partagé par un
  store et retenu d'une visite à l'autre ; la scène 3D et liquidGL s'y soumettent.
- **`feat`** — le fil IA : nouveau `kind` de section `fil`, qui traverse les trois pôles au
  lieu de s'intercaler entre deux, placé avant le pôle 1 pour que la méthode se lise avant
  les offres. Quatre étapes : concevoir, construire, livrer, piloter. Rendu par
  `ThreadSection`, filets cuivre **horizontaux** perpendiculaires aux filets verticaux des
  charnières — la chaîne descend, le fil la coupe. Jamais vitré, sinon il se lirait comme un
  quatrième pôle.
- **`feat`** — certifications sur plaque de hauteur fixe. Le champ `logo` reste absent tant
  que le fichier n'a pas été déposé **et** son usage autorisé par le propriétaire de la
  marque. Sans fichier, la plaque affiche le nom de l'organisme exactement à la place du
  futur logo : la mise en page ne bougera pas au dépôt.
- **`chore`** — version `0.2.0`.

## Véracité du contenu

Aucune preuve nouvelle n'a été introduite. Les quatre étapes du fil ne citent que des
chiffres déjà portés par les pôles et sourcés dans les CV de référence. La règle tenue d'un
bout à l'autre est **« l'IA propose, les tests tranchent »** ; le pilotage SEA reste attribué
à la donnée et au clustering, jamais à un agent autonome.

## Vérifications

- `npx biome check src/ public/` — propre
- `npx tsc --noEmit` — aucune erreur
- `./scripts/check-max-lines.sh` — aucun fichier au-dessus de 300 lignes
- `npm run build` — verte, 8 pages en statique
- `make test` — 2/2

## Points ouverts, à la main de Jérôme MARICHEZ

- **Couverture de test quasi nulle.** `tests/unitaire/` ne contient que `exemple.spec.ts`
  issu du bootstrap : ni les pôles, ni les charnières, ni le fil IA, ni le store de mise en
  pause ne sont couverts. Le vert de `make test` ne dit donc rien sur ce code. Les intentions
  de test peuvent être proposées sur demande — l'écriture reste à Jérôme MARICHEZ.
- **Logos de certification à fournir.** Voir `public/certifications/LISEZMOI.md`. ISTQB
  n'autorise que le badge « Certified Tester » ; Google et Microsoft encadrent le leur.
- **`main` distant** porte encore l'historique du bootstrap `front/` + `back/` abandonné,
  sans ancêtre commun avec `dev`. À reprendre séparément.

https://claude.ai/code/session_01Wveg3Ve6siyrndvtgEs1cW
