### PR TITLE
feature: remplacer la promesse zero sous-traitant par l'interlocuteur unique

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,11 @@ Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel 
 
 Le site raconte un parcours (ingénieur logiciel, 9 ans, passé par la chefferie de projet
 et l'AMOA) et vend trois offres qui s'appuient dessus. Promesse centrale, à faire
-apparaître partout : **un seul interlocuteur humain pour vos projets digitaux, aucune
-sous-traitance** — celui qui cadre est celui qui code, mesure et exploite.
+apparaître partout : **un seul interlocuteur humain pour vos projets digitaux, du cadrage
+au run** — celui qui cadre est celui qui code, mesure et exploite, et il répond de tout.
+La promesse porte sur l'**interlocuteur** et la **responsabilité**, jamais sur l'absence
+totale de tiers : sur un projet dont la taille le demande — c'est rare — Jérôme peut
+s'entourer de prestataires qu'il choisit, cadre et dont il répond.
 
 Le **périmètre éditorial complet** (les trois offres en détail, les preuves chiffrées,
 les certifications, l'arborescence des pages, les contraintes SEO / perf / a11y / RGPD)
@@ -36,6 +39,7 @@ considération marketing.
 
 | Interdit | Formulation juste |
 |----------|-------------------|
+| « aucune sous-traitance », « 0 sous-traitant », toute promesse d'**absence totale de tiers** | **Un seul interlocuteur, du cadrage au run, qui répond de tout.** Aucune couche commerciale, aucun transfert de dossier, l'interlocuteur ne change pas. Sur un projet dont la taille le demande — **c'est rare, et la rareté se dit** — des prestataires viennent en renfort : Jérôme les choisit, les cadre et en répond ; le client ne gère personne d'autre que lui. *(Règle mise à jour à la demande explicite de Jérôme MARICHEZ, issue #40.)* |
 | ISTQB niveau **Avancé** / Automatisation de test | **ISTQB Foundation** uniquement — l'Avancé n'est pas obtenu |
 | Management, lead ou mentorat de **développeurs** | Encadrement d'**équipes marketing / SEO-SEA, de prestataires externes, d'alternants et de stagiaires**. Titre réel : « Lead Tech » chez MailingVox (équipe de 2 devs + 1 PO) |
 | « en collaboration avec l'Universitat de Barcelona » | Méthode d'extraction audio **publiée sur arXiv**, qu'il a **implémentée lui-même** puis industrialisée |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ ingénierie web, data & IA, SEA & UX.
 Le site a deux fonctions et une seule promesse. Il **raconte un parcours** — ingénieur
 logiciel, 9 ans, passé par la chefferie de projet et l'AMOA — et il **vend une chaîne à trois pôles**
 qui s'appuie dessus. La promesse : *un seul interlocuteur humain pour vos projets
-digitaux, aucune sous-traitance*. Celui qui cadre est celui qui code, mesure et exploite.
+digitaux, du cadrage au run*. Celui qui cadre est celui qui code, mesure et exploite —
+et il répond de tout.
+
+Ce que la promesse **n'engage pas** : l'absence totale de tiers. Sur un projet dont la
+taille le demande — c'est rare — Jérôme s'entoure de prestataires qu'il choisit, qu'il
+cadre et dont il répond. Le client, lui, ne gère personne d'autre que lui : aucune couche
+commerciale, aucun transfert de dossier, l'interlocuteur ne change pas. La page d'accueil
+le dit explicitement dans la section « Et si le projet dépasse une personne ? ».
 
 ---
 
@@ -17,6 +24,7 @@ digitaux, aucune sous-traitance*. Celui qui cadre est celui qui code, mesure et 
 | Ce qui est vendu | Ce qui le rend crédible |
 |------------------|-------------------------|
 | Un interlocuteur unique, pas une chaîne de prestataires | 9 ans en petite équipe ou en autonomie complète, décisions techniques assumées en production |
+| Une responsabilité unique, même quand un renfort est nécessaire | Encadrement de prestataires externes déjà exercé (équipe marketing de 5 à 10 personnes et 3 prestataires chez Truffle Capital, SEA/SEO/SMA chez Verhoeven Joaillier) et spécifications écrites pour des tiers extérieurs au domaine (AMOA Artedrone) |
 | Du conseil qui va jusqu'au run | Trois migrations majeures menées sans interruption de service |
 | De la décision simplifiée, pas des tableaux de bord de plus | Double casquette rare : développeur produit **et** pilote d'acquisition |
 | De la mesure conforme | RGPD et DORA tenus en appels d'offres grands comptes |
@@ -258,7 +266,7 @@ confirmée, sans année connue.
 
 | Route | Rôle |
 |-------|------|
-| `/` | Accroche, promesse d'interlocuteur unique, le fil IA transverse, la chaîne complète (3 pôles + 2 charnières), preuves chiffrées, limites assumées, certifications, appel à contact |
+| `/` | Accroche, promesse d'interlocuteur unique, le fil IA transverse, la chaîne complète (3 pôles + 2 charnières), preuves chiffrées, limites assumées, certifications, les deux objections traitées (« et si je disparais ? » et « et si le projet dépasse une personne ? »), appel à contact |
 | `/services/ingenierie-web` | Pôle 1 en détail |
 | `/services/data-ia` | Pôle 2 en détail |
 | `/services/sea-ux` | Pôle 3 en détail |

--- a/src/@shared/components/SiteFooter/index.tsx
+++ b/src/@shared/components/SiteFooter/index.tsx
@@ -19,8 +19,9 @@ export function SiteFooter() {
       <div className={styles.contenu}>
         <div className={styles.appel}>
           <p className={styles.promesse}>
-            Un seul interlocuteur, du cadrage au run. Décrivez votre situation, je vous dis ce que
-            j'en ferais — et si ce n'est pas pour moi, je vous le dis aussi.
+            Un seul interlocuteur, du cadrage au run, et il répond de tout. Décrivez votre
+            situation, je vous dis ce que j'en ferais — et si ce n'est pas pour moi, je vous le dis
+            aussi.
           </p>
           <a className={styles.contact} href={`mailto:${SITE_IDENTITY.email}`}>
             {SITE_IDENTITY.email}

--- a/src/@shared/seo/site.ts
+++ b/src/@shared/seo/site.ts
@@ -20,10 +20,16 @@ export const SITE_IDENTITY = {
  * Promesse centrale du site. Elle apparaît dans les métadonnées de la page d'accueil
  * comme dans le contenu : c'est le même engagement, il ne se reformule pas d'un
  * support à l'autre.
+ *
+ * Ce qu'elle engage : un interlocuteur unique et une responsabilité unique. Ce qu'elle
+ * n'engage pas — et n'a plus le droit d'engager : l'absence totale de tiers. Sur un
+ * projet dont la taille le demande, des prestataires peuvent venir en renfort ; ils
+ * sont choisis, cadrés et couverts par le même interlocuteur (section « renforts »
+ * de l'accueil).
  */
 export const SITE_PROMESSE =
-  'Un seul interlocuteur pour vos projets digitaux, aucune sous-traitance. ' +
-  'Celui qui cadre est celui qui code, qui mesure et qui exploite.'
+  'Un seul interlocuteur pour vos projets digitaux, du cadrage au run. ' +
+  'Celui qui cadre est celui qui code, qui mesure et qui exploite — et qui répond de tout.'
 
 /** Rayon d'intervention réellement couvert. */
 export const SITE_ZONE = ['Lille', 'Hauts-de-France', 'France'] as const

--- a/src/@vitrine/contenu/accueil-sections.ts
+++ b/src/@vitrine/contenu/accueil-sections.ts
@@ -8,6 +8,7 @@
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 import { SECTION_ACCUEIL_DATA_IA } from './accueil-data-ia'
 import { SECTION_FIL_IA } from './fil-ia'
+import { SECTION_RENFORTS } from './renforts'
 
 export const SECTIONS_ACCUEIL: IEditorialSection[] = [
   // Le fil ouvre la chaîne : la méthode se lit avant les pôles, sinon le lecteur
@@ -237,4 +238,9 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       },
     ],
   },
+  // Les deux faces d'un même risque : au-dessus, l'interlocuteur unique qui pourrait
+  // manquer ; ici, le projet qui devient trop gros pour lui. Dire la seconde après la
+  // première évite que la promesse se lise comme « personne d'autre ne travaillera sur
+  // votre projet », ce qu'elle n'a jamais eu le droit de promettre.
+  SECTION_RENFORTS,
 ]

--- a/src/@vitrine/contenu/accueil.ts
+++ b/src/@vitrine/contenu/accueil.ts
@@ -14,11 +14,12 @@ import { SECTIONS_ACCUEIL } from './accueil-sections'
 
 /** Le seuil : promesse, et trois chiffres pour qu'elle ne reste pas un slogan. */
 export const HERO_ACCUEIL = {
-  titre: "Je construis, j'exploite, je mesure. Seul, du cadrage au run.",
+  titre: "Je construis, j'exploite, je mesure. Le même interlocuteur, du cadrage au run.",
   chapo:
     'Ingénieur logiciel à Lille, 9 ans. Un seul interlocuteur pour votre produit ' +
-    'digital, aucune sous-traitance : celui qui cadre est celui qui code, qui mesure ' +
-    'et qui exploite. Vous parlez à la personne qui fait le travail.',
+    'digital, du cadrage au run : celui qui cadre est celui qui code, qui mesure et ' +
+    'qui exploite. Vous parlez à la personne qui fait le travail, et c’est elle qui ' +
+    'répond de tout.',
   // Le fil IA se dit dès le seuil, sinon il se découvre au pôle 2 et se lit comme une
   // offre. Formulation tenue par les règles de véracité : l'IA instruit et produit, le
   // test décide — jamais l'inverse.
@@ -28,7 +29,9 @@ export const HERO_ACCUEIL = {
   jetons: [
     { chiffre: '3', libelle: 'migrations sans interruption de service' },
     { chiffre: '98/100', libelle: 'Lighthouse sur la plateforme SaaS livrée' },
-    { chiffre: '0', libelle: 'sous-traitant' },
+    // Le troisième jeton dit la promesse, pas l'absence de tiers : ce qui est garanti,
+    // c'est un interlocuteur unique et une responsabilité unique, du cadrage au run.
+    { chiffre: '1', libelle: 'interlocuteur, du cadrage au run' },
   ],
 } as const
 
@@ -52,7 +55,7 @@ export const PAGE_ACCUEIL: IEditorialPage = {
     title: 'Jérôme Marichez — Ingénieur logiciel à Lille',
     description:
       'Ingénierie web, data & IA, SEA & UX : un seul interlocuteur du cadrage au run, ' +
-      'sans sous-traitance. Conception, développement et pilotage avec l’IA. Lille et ' +
+      'qui répond de tout. Conception, développement et pilotage avec l’IA. Lille et ' +
       'Hauts-de-France.',
   },
   sections: SECTIONS_ACCUEIL,

--- a/src/@vitrine/contenu/limites.ts
+++ b/src/@vitrine/contenu/limites.ts
@@ -10,10 +10,12 @@ import type { IBoundary } from '@/interfaces/IBoundary'
 
 export const LIMITES: IBoundary[] = [
   {
-    hors: 'Aucune sous-traitance, aucune couche commerciale',
+    hors: 'Aucune couche commerciale, aucun transfert de dossier',
     alaPlace:
       "Vous parlez à la personne qui écrit le code. C'est la même du cadrage au run, " +
-      "sur les trois pôles — c'est tout ce que ce site vend.",
+      'sur les trois pôles. Si la taille du projet demande un renfort — c’est rare — je ' +
+      'choisis le prestataire, je le cadre et j’en réponds : votre interlocuteur, lui, ' +
+      'ne change pas.',
   },
   {
     hors: 'Pas de cluster Kubernetes administré en propre',

--- a/src/@vitrine/contenu/preuves.ts
+++ b/src/@vitrine/contenu/preuves.ts
@@ -42,11 +42,15 @@ export const PREUVES: IProof[] = [
       'Les décisions techniques sont les miennes et je les assume en production. Chez ' +
       'MailingVox : équipe de 3, sans QA ni équipe data dédiées.',
   },
+  // Seule tuile dont le chiffre n'est pas repris d'un CV : c'est la promesse elle-même,
+  // et elle porte sur l'interlocuteur, pas sur l'absence de tiers (voir la section
+  // « renforts » de l'accueil).
   {
-    chiffre: '0',
-    libelle: 'sous-traitant',
+    chiffre: '1',
+    libelle: 'interlocuteur, du cadrage au run',
     contexte:
-      'Celui qui cadre est celui qui code, qui mesure et qui exploite. C’est la seule ' +
-      'raison pour laquelle les trois pôles tiennent ensemble.',
+      'Celui qui cadre est celui qui code, qui mesure et qui exploite. Aucune couche ' +
+      'commerciale, aucun transfert de dossier — et si un renfort devient nécessaire, ' +
+      'c’est moi qui le choisis et qui en réponds.',
   },
 ]

--- a/src/@vitrine/contenu/renforts.ts
+++ b/src/@vitrine/contenu/renforts.ts
@@ -1,0 +1,66 @@
+// renforts.ts — jeromemarichez-fr
+// La suite immédiate de l'objection « et si je disparais ? » : et si, à l'inverse, le
+// projet devient trop gros pour une personne ?
+//
+// Les deux sections se répondent sans se recouvrir. Celle qui précède traite la
+// reprise — pouvoir travailler *sans* moi. Celle-ci traite la charge — faire travailler
+// quelqu'un *avec* moi, sans que le client ait un interlocuteur de plus. La promesse du
+// site porte sur l'interlocuteur unique et la responsabilité unique, jamais sur
+// l'absence totale de tiers : la nuance se dit ici, elle ne se cache pas.
+//
+// Extraite dans son propre fichier pour ne pas pousser `accueil-sections.ts` contre la
+// limite de 300 lignes (docs/tooling.md).
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+export const SECTION_RENFORTS: IEditorialSection = {
+  id: 'renforts',
+  kind: 'preuves',
+  kicker: 'L’objection inverse',
+  titre: 'Et si le projet dépasse une personne ?',
+  chapo:
+    'Cela arrive rarement, et quand cela arrive je préfère le dire plutôt que de tenir ' +
+    'une promesse contre les faits. Sur un projet dont la taille le demande, je ' +
+    'm’entoure de prestataires que je choisis, que je cadre et dont je réponds. Ce qui ' +
+    'ne change pas : vous ne gérez personne d’autre que moi.',
+  blocs: [
+    {
+      titre: 'C’est rare, et la rareté se dit',
+      texte:
+        'La très grande majorité des projets que je prends tient sur une personne du ' +
+        'cadrage au run — c’est même toute la raison d’être de la chaîne décrite plus ' +
+        'haut. Le renfort n’est pas le mode normal : il se déclenche quand le volume de ' +
+        'travail dépasserait ce que je peux tenir sans faire attendre le projet. Le ' +
+        'reconnaître coûte moins cher que de le découvrir en cours de route.',
+      decision:
+        'À quel moment vous préférez un renfort plutôt qu’un délai — l’arbitrage est le vôtre.',
+    },
+    {
+      titre: 'Choisis, cadrés, et sous ma responsabilité',
+      texte:
+        'Un renfort travaille sur des spécifications que j’ai écrites, dans le dépôt que ' +
+        'je tiens, avec les mêmes tests et la même chaîne d’intégration continue. C’est ' +
+        'l’exercice de la section précédente pris dans l’autre sens : donner à quelqu’un ' +
+        'de quoi travailler sans avoir à connaître le domaine. Je ne transmets pas votre ' +
+        'dossier — je reste la personne qui répond de ce qui est livré, y compris de ce ' +
+        'que je n’ai pas tapé moi-même.',
+      preuve:
+        'AMOA de la startup biotech Artedrone : spécifications écrites pour des tiers ' +
+        'extérieurs au domaine, BPMN 2.0 et cartographie du système d’information.',
+    },
+    {
+      titre: 'Vous ne gérez personne d’autre que moi',
+      texte:
+        'Pas de chef de projet intermédiaire, pas de comptes rendus à recouper, pas de ' +
+        'second contrat à négocier. Vous parlez à la même personne qu’au premier jour, ' +
+        'elle connaît le produit parce qu’elle l’a construit, et c’est elle qui porte le ' +
+        'planning, le budget et la qualité du renfort. Encadrer des prestataires, c’est ' +
+        'le travail que je faisais déjà avant de vendre ce site.',
+      preuve:
+        'Environ 25 000 € d’encadrement de prestataires SEA, SEO et SMA chez Verhoeven ' +
+        'Joaillier : périmètre, budget et qualité sont restés de mon côté.',
+      decision:
+        'Qui intervient sur votre produit, sur quel périmètre et à quel coût — écrit, avant.',
+    },
+  ],
+}


### PR DESCRIPTION
Closes #40

Lot **éditorial** : aucun style, aucune configuration technique, aucun hook, aucune CI touchés.

## Pourquoi

Le site vendait « aucune sous-traitance » et affichait « 0 sous-traitant » comme troisième
chiffre du hero. Jérôme MARICHEZ demande de nuancer : sur un projet dont la taille le
demande — c'est rare — il peut s'entourer de prestataires.

La promesse tenable n'est pas « personne d'autre ne travaille sur votre projet » mais
**« vous n'avez qu'un interlocuteur, et il répond de tout »**. Elle est plus honnête, et
plus rassurante pour une PME dont le projet grossit : le prestataire ne refusera pas le
travail et ne s'écroulera pas sous la charge.

Ce qui est préservé : aucune couche commerciale, aucun transfert de dossier, celui qui
cadre est celui qui code et qui mesure, l'interlocuteur ne change jamais.
Ce qui disparaît : la promesse d'absence totale de tiers.

## Avant / après

### Jeton 3 du hero (`src/@vitrine/contenu/accueil.ts`)

| Avant | Après |
|---|---|
| `0` — sous-traitant | `1` — interlocuteur, du cadrage au run |

Formulation retenue telle que proposée dans l'issue. Elle dit ce qui est garanti (un
interlocuteur, sur toute la chaîne) au lieu de nier ce qui ne peut pas l'être.

**Rendu** : aucune modification CSS n'a été nécessaire. `.jeton` est déjà en
`max-width: 16ch` avec `flex-direction: column`, et le premier jeton
(« migrations sans interruption de service », 38 caractères) est plus long que le nouveau
libellé (32 caractères). Le gabarit absorbe le changement tel quel.

### Titre et chapô du hero

| Avant | Après |
|---|---|
| « Je construis, j'exploite, je mesure. **Seul**, du cadrage au run. » | « Je construis, j'exploite, je mesure. **Le même interlocuteur**, du cadrage au run. » |
| « …Un seul interlocuteur pour votre produit digital, **aucune sous-traitance** : … Vous parlez à la personne qui fait le travail. » | « …Un seul interlocuteur pour votre produit digital, **du cadrage au run** : … Vous parlez à la personne qui fait le travail, **et c'est elle qui répond de tout**. » |

Le titre était le dernier endroit où « Seul » promettait littéralement l'absence de tiers.

### `SITE_PROMESSE` (`src/@shared/seo/site.ts`)

| Avant | Après |
|---|---|
| « Un seul interlocuteur pour vos projets digitaux, **aucune sous-traitance**. Celui qui cadre est celui qui code, qui mesure et qui exploite. » | « Un seul interlocuteur pour vos projets digitaux, **du cadrage au run**. Celui qui cadre est celui qui code, qui mesure et qui exploite — **et qui répond de tout**. » |

155 caractères : la meta description reste dans le gabarit. La docstring de la constante
dit désormais explicitement ce que la promesse n'engage pas.

Meta description de l'accueil : « …un seul interlocuteur du cadrage au run, ~~sans
sous-traitance~~ **qui répond de tout**. »

### Pied de page (`src/@shared/components/SiteFooter/index.tsx`)

| Avant | Après |
|---|---|
| « Un seul interlocuteur, du cadrage au run. Décrivez votre situation… » | « Un seul interlocuteur, du cadrage au run, **et il répond de tout**. Décrivez votre situation… » |

**Seul le texte de la promesse est touché** — la structure du composant est inchangée,
pour que la PR d'export statique qui ajoute les liens légaux fusionne proprement.

### Nouvelle section (`src/@vitrine/contenu/renforts.ts`)

Section « **Et si le projet dépasse une personne ?** », `kind: 'preuves'`, posée juste
après « Un seul interlocuteur — et si je disparais ? ». Les deux traitent le même risque
par ses deux faces, et se répondent sans se répéter :

- la section existante traite la **reprise** — pouvoir travailler *sans* moi ;
- la nouvelle traite la **charge** — faire travailler quelqu'un *avec* moi, sans que le
  client ait un interlocuteur de plus.

Trois blocs : la rareté dite telle quelle ; des renforts choisis, cadrés et couverts par
la même personne ; un client qui ne gère personne d'autre. Les preuves sont réelles et
déjà présentes sur le site, mais chaque ligne de preuve de la page reste unique : la
nouvelle section prend l'AMOA Artedrone sous l'angle « écrire pour des tiers extérieurs au
domaine » et l'encadrement Verhoeven Joaillier (~25 000 € de prestataires SEA/SEO/SMA),
là où la section précédente garde le relais Truffle Capital.

Ton : humble, pas de superlatif, aucune revendication de « mobiliser une équipe ». La
rareté est dite avant l'argument.

**Fichier séparé** : `accueil-sections.ts` était à 240/300 lignes ; la section y aurait
ajouté ~50 lignes. Elle vit donc dans son propre fichier de contenu, comme
`fil-ia.ts` et `accueil-data-ia.ts`. `accueil-sections.ts` finit à 247 lignes.

### `limites.ts`

| Avant | Après |
|---|---|
| **hors** : « Aucune sous-traitance, aucune couche commerciale » | **hors** : « Aucune couche commerciale, aucun transfert de dossier » |
| **à la place** : « Vous parlez à la personne qui écrit le code. C'est la même du cadrage au run, sur les trois pôles — c'est tout ce que ce site vend. » | **à la place** : « Vous parlez à la personne qui écrit le code. C'est la même du cadrage au run, sur les trois pôles. Si la taille du projet demande un renfort — c'est rare — je choisis le prestataire, je le cadre et j'en réponds : votre interlocuteur, lui, ne change pas. » |

### `preuves.ts`

| Avant | Après |
|---|---|
| `0` — sous-traitant — « …C'est la seule raison pour laquelle les trois pôles tiennent ensemble. » | `1` — interlocuteur, du cadrage au run — « …Aucune couche commerciale, aucun transfert de dossier — et si un renfort devient nécessaire, c'est moi qui le choisis et qui en réponds. » |

Un commentaire signale que c'est la seule tuile dont le chiffre n'est pas repris d'un CV :
c'est la promesse elle-même, pas une mesure.

## Cohérence globale — résultat du grep

```
$ grep -rn "sous-trait" src/
$ echo $?
1
```

Aucune occurrence ne subsiste dans `src/`. Les formulations voisines conservées sont
compatibles et vérifiées une à une :

- `accueil.ts` — « Découpée entre trois prestataires, elle se casse à chaque jointure » :
  parle de la chaîne **découpée entre trois prestataires distincts**, pas d'un renfort
  cadré par une seule personne.
- `accueil-sections.ts` — « il n'attend pas le devis d'un tiers » : porte sur le délai
  d'implémentation d'un arbitrage, toujours vrai.
- `accueil-sections.ts` — « Le relais, je l'ai déjà passé » : inchangé, et la nouvelle
  section s'y adosse explicitement.

## Changement de règle du `CLAUDE.md` — justification

**Modification demandée explicitement par Jérôme MARICHEZ dans l'issue #40.** C'est la
seule modification apportée au `CLAUDE.md` ; aucune autre règle n'est touchée.

La table des règles de véracité imposait « aucune sous-traitance » comme formulation
centrale. Cette formulation est désormais **plus large que ce qui est réellement établi**
— exactement le défaut que la table est faite pour empêcher. La règle est donc retournée
plutôt qu'assouplie : une ligne interdit désormais « aucune sous-traitance », « 0
sous-traitant » et toute promesse d'absence totale de tiers, et impose la formulation
juste (interlocuteur unique, responsabilité unique, renfort rare choisi et couvert).
La présentation en tête de fichier est alignée dans le même sens.

`README.md` : promesse et positionnement mis à jour, ligne de crédibilité ajoutée sur
l'encadrement de prestataires déjà exercé, arborescence de l'accueil complétée.

## Vérifications

- `make lint` : vert (Biome + aucun fichier au-dessus de 300 lignes).
- `npm run build` : vert, 8 pages prérendues statiquement.
- `make test` : vert.

## Tests — intentions proposées à Jérôme MARICHEZ

Aucun fichier de test n'a été posé (règle du projet). Trois intentions sont détaillées
dans le rapport ; la plus utile est un test unitaire de **non-régression éditoriale** sur
le contenu : `SITE_PROMESSE`, la meta description de l'accueil, les jetons du hero, les
limites, les preuves et l'ensemble des sections ne contiennent plus la chaîne
« sous-trait », et la section `renforts` est bien présente dans `SECTIONS_ACCUEIL`.
