### PR TITLE
test: harnais e2e qui construit, sert et arrete l'export statique

### DIFF
--- a/.github/workflows/ci-main-e2e.yml
+++ b/.github/workflows/ci-main-e2e.yml
@@ -14,6 +14,7 @@ jobs:
           node-version-file: .nvmrc
       - name: Installation
         run: make install
-      # make test-e2e doit démarrer la stack (front + back) avant Cypress headless.
+      # make test-e2e construit l'export statique, le sert sur E2E_PORT, attend qu'il
+      # réponde, lance Cypress headless puis arrête le serveur (scripts/e2e.mjs).
       - name: Tests e2e
         run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ test-int: ## Tests d'intégration
 
 test-mutation: ## Tests de mutation (Stryker) — qualité des tests unitaires/intégration
 	npx stryker run
-test-e2e: ## Tests e2e navigateur (Cypress headless) — stack démarrée au préalable
-	npx cypress run
+test-e2e: ## Tests e2e navigateur — construit et sert l'export statique, puis Cypress headless
+	node scripts/e2e.mjs
 
 test-system: ## Tests système (vrai serveur HTTP via listen(0))
 	npx jest tests/systeme --passWithNoTests

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ make lint             # Biome + limite 300 lignes/fichier
 make test             # unitaires + intégration
 make test-unit        # unitaires
 make test-int         # intégration
-make test-e2e         # e2e (navigateur)
+make test-e2e         # e2e (navigateur) — construit et sert `out/`, puis Cypress
 make test-system      # système (vrai serveur HTTP)
 make test-acceptance  # acceptation / non-fonctionnels (uat/)
 make test-mutation    # mutation (Stryker)

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,10 +1,14 @@
 // Configuration Cypress — jeromemarichez-fr (e2e navigateur)
-// Specs : tests/e2e/**/*.cy.ts — contre la stack réellement lancée.
+// Specs : tests/e2e/**/*.cy.ts — contre l'export statique réellement servi.
+// Le serveur est démarré, sondé puis arrêté par `scripts/e2e.mjs` (`make test-e2e`),
+// qui sert `out/` sur E2E_PORT avec les règles de résolution de `docker/nginx.conf`.
 import { defineConfig } from 'cypress'
+
+const port = Number(process.env.E2E_PORT ?? 4173)
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:3000', // TODO : port réel du front
+    baseUrl: `http://127.0.0.1:${port}`,
     specPattern: 'tests/e2e/**/*.cy.ts',
     supportFile: false,
     video: false,

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -14,7 +14,12 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
 - **lint** : `make lint` — Biome sur tout le dépôt + `scripts/check-max-lines.sh`
   (échec si un fichier source dépasse **300 lignes**).
 - **tests (dev)** : unitaires + intégration, front et back.
-- **e2e (main)** : stack démarrée puis Cypress headless.
+- **e2e (main)** : `make test-e2e` — le harnais `scripts/e2e.mjs` construit l'export
+  statique si `out/` manque, le sert sur `127.0.0.1:E2E_PORT` (4173 par défaut) avec les
+  règles de résolution de `docker/nginx.conf`, **attend que le port réponde** (sonde
+  HTTP, pas de `sleep`), lance Cypress headless, puis arrête le serveur — y compris en
+  cas d'échec, sans processus orphelin. Le code de sortie du harnais est celui de
+  Cypress : aucun échec n'est absorbé. Détail : [testing](./testing.md).
 - **système (main)** : vrai serveur HTTP + client réel.
 - **build (main)** : build de production (front et back), artefacts vérifiés.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,13 +99,42 @@ sous le seuil `break`). Lancer : `make test-mutation`.
 - **Couverture** : seuil défini dans la config de test — la CI échoue en dessous.
   <!-- TODO : fixer le seuil (ex. 90 %). -->
 
+## Harnais e2e — l'export statique servi en local
+
+Le site est en **export statique** (`output: 'export'`) : il n'y a ni back, ni route
+API, ni serveur applicatif. La « stack » des tests e2e se réduit donc à **servir le
+dossier `out/`**. Tout est piloté par `scripts/e2e.mjs`, appelé par `make test-e2e` —
+en local comme dans le workflow `ci-main-e2e` :
+
+1. **build si nécessaire** : `npm run build` si `out/index.html` manque ;
+2. **serveur statique** : `scripts/serve-out.mjs` sert `out/` sur `127.0.0.1:E2E_PORT`
+   (**4173** par défaut), sans aucune dépendance — `node:http` suffit ;
+3. **attente réelle** : le harnais sonde `GET /` jusqu'à obtenir une réponse HTTP
+   (30 s max). Jamais de `sleep` arbitraire ;
+4. **Cypress headless** : `npx cypress run` (les arguments passés à `scripts/e2e.mjs`
+   lui sont transmis, ex. `--spec`) ;
+5. **arrêt propre garanti** : le serveur est fermé dans un `finally` et sur
+   `SIGINT`/`SIGTERM` — aucun processus orphelin, même quand les tests échouent. Le
+   **code de sortie reste celui de Cypress** : aucun échec n'est absorbé.
+
+`cypress.config.ts` dérive son `baseUrl` du même `E2E_PORT` : le port ne peut pas
+diverger entre le serveur et le navigateur.
+
+**Résolution des URL identique à la production.** `trailingSlash: true` fait sortir
+chaque route en `<route>/index.html`. `serve-out.mjs` applique exactement les règles de
+`docker/nginx.conf` (`try_files $uri $uri/ =404`, `index index.html`,
+`error_page 404 /404.html`) : un dossier est servi par son `index.html`, un dossier sans
+`index.html` et une URL inconnue renvoient **404** avec la page `404.html`. Un serveur
+statique qui ignorerait cette règle ferait échouer les specs pour la mauvaise raison.
+La traversée de répertoire hors de `out/` est refusée.
+
 ## Commandes
 
 ```bash
 make test             # unitaires + intégration
 make test-unit        # unitaires (Jest)
 make test-int         # intégration (Jest)
-make test-e2e         # Cypress headless
+make test-e2e         # build + export statique servi + Cypress headless + arrêt du serveur
 make test-system      # système (Jest + fetch ; collection Postman rejouable)
 make test-mutation    # Stryker (score de mutation)
 make test-acceptance  # acceptation / UAT

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -1,0 +1,109 @@
+// e2e.mjs — jeromemarichez-fr
+//
+// Harnais des tests e2e (cible `make test-e2e`), en local comme dans `ci-main-e2e`.
+// Le site étant en export statique (`output: 'export'`), la « stack » se réduit à
+// servir `out/` : ni back, ni route API, ni serveur applicatif.
+//
+//   1. construit l'export statique s'il manque (`npm run build`) ;
+//   2. sert `out/` sur E2E_PORT (4173 par défaut), avec les règles de `docker/nginx.conf` ;
+//   3. attend que le port RÉPONDE vraiment (sonde HTTP, pas un `sleep`) ;
+//   4. lance `cypress run` ;
+//   5. arrête le serveur quoi qu'il arrive — succès, échec ou interruption — et sort
+//      avec le code de Cypress, jamais un autre.
+//
+//   node scripts/e2e.mjs      (ou : make test-e2e)
+
+import { spawn } from 'node:child_process'
+import { access } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { demarrerServeurStatique, PORT_PAR_DEFAUT } from './serve-out.mjs'
+
+const RACINE = join(dirname(fileURLToPath(import.meta.url)), '..')
+const DOSSIER_EXPORT = join(RACINE, 'out')
+const PORT = Number(process.env.E2E_PORT ?? PORT_PAR_DEFAUT)
+const DELAI_SONDE_MS = 30_000
+
+const existe = (chemin) =>
+  access(chemin).then(
+    () => true,
+    () => false,
+  )
+
+/** Exécute une commande en héritant des flux, et résout son code de sortie. */
+function executer(commande, arguments_, env = {}) {
+  return new Promise((ok, ko) => {
+    const enfant = spawn(commande, arguments_, {
+      cwd: RACINE,
+      stdio: 'inherit',
+      env: { ...process.env, ...env },
+      shell: process.platform === 'win32',
+    })
+    enfant.once('error', ko)
+    enfant.once('close', (code, signal) => ok(signal ? 1 : (code ?? 1)))
+  })
+}
+
+/**
+ * Attend que le serveur réponde réellement sur `/`. Un port en écoute ne suffit pas :
+ * on veut une réponse HTTP, sinon Cypress démarre sur un serveur qui n'est pas prêt.
+ */
+async function attendreReponse(url) {
+  const limite = Date.now() + DELAI_SONDE_MS
+  let derniereErreur
+  while (Date.now() < limite) {
+    try {
+      const reponse = await fetch(url, { redirect: 'manual' })
+      if (reponse.status < 500) return reponse.status
+    } catch (erreur) {
+      derniereErreur = erreur
+    }
+    await new Promise((ok) => setTimeout(ok, 200))
+  }
+  throw new Error(
+    `Le serveur statique n'a pas répondu sur ${url} en ${DELAI_SONDE_MS} ms` +
+      (derniereErreur ? ` (${derniereErreur.message})` : ''),
+  )
+}
+
+async function main() {
+  if (!(await existe(join(DOSSIER_EXPORT, 'index.html')))) {
+    console.log('Export statique absent : construction (`npm run build`)…')
+    const code = await executer('npm', ['run', 'build'])
+    if (code !== 0) throw new Error(`Le build a échoué (code ${code})`)
+  }
+
+  const { serveur, url } = await demarrerServeurStatique({ racine: DOSSIER_EXPORT, port: PORT })
+  const arreter = () => {
+    serveur.closeAllConnections?.()
+    return new Promise((ok) => serveur.close(ok))
+  }
+  // Interruption clavier ou signal CI : on ne laisse jamais le serveur orphelin.
+  const surSignal = () => {
+    arreter().then(() => process.exit(130))
+  }
+  process.once('SIGINT', surSignal)
+  process.once('SIGTERM', surSignal)
+
+  try {
+    const statut = await attendreReponse(`${url}/`)
+    console.log(`Export statique servi sur ${url} (GET / → ${statut}) — lancement de Cypress.`)
+    // Les arguments supplémentaires sont transmis tels quels à Cypress
+    // (ex. `node scripts/e2e.mjs --spec tests/e2e/fumee.cy.ts`).
+    return await executer('npx', ['cypress', 'run', ...process.argv.slice(2)], {
+      E2E_PORT: String(PORT),
+    })
+  } finally {
+    await arreter()
+    console.log('Serveur statique arrêté.')
+  }
+}
+
+// Le code de sortie du harnais est celui de Cypress : aucun échec n'est absorbé.
+main().then(
+  (code) => process.exit(code),
+  (erreur) => {
+    console.error(`Harnais e2e : ${erreur instanceof Error ? erreur.message : erreur}`)
+    process.exit(1)
+  },
+)

--- a/scripts/serve-out.mjs
+++ b/scripts/serve-out.mjs
@@ -1,0 +1,119 @@
+// serve-out.mjs — jeromemarichez-fr
+//
+// Sert l'export statique (`out/`) produit par `next build`, avec exactement les mêmes
+// règles de résolution que `docker/nginx.conf` en production :
+//
+//   try_files $uri $uri/ =404 ; index index.html ; error_page 404 /404.html
+//
+// C'est indispensable : `trailingSlash: true` fait sortir chaque route en
+// `<route>/index.html`. Un serveur qui ne résout pas un dossier vers son `index.html`
+// renverrait une 404 trompeuse et ferait échouer les specs pour la mauvaise raison.
+//
+// Zéro dépendance : `node:http` suffit, l'export n'a ni back, ni route API.
+//
+//   node scripts/serve-out.mjs [port]      (par défaut : E2E_PORT ou 4173)
+//
+// Utilisé par `scripts/e2e.mjs` (cible `make test-e2e`).
+
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { dirname, extname, join, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const PORT_PAR_DEFAUT = Number(process.env.E2E_PORT ?? 4173)
+
+const RACINE_PROJET = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
+}
+
+const typeDe = (chemin) => TYPES[extname(chemin).toLowerCase()] ?? 'application/octet-stream'
+
+/** Chemin d'un fichier existant, ou `null`. */
+async function fichierExistant(chemin) {
+  try {
+    const info = await stat(chemin)
+    return info.isFile() ? chemin : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Résout une URL comme nginx : le fichier lui-même, sinon `<dossier>/index.html`,
+ * sinon rien (la 404 est décidée par l'appelant).
+ */
+async function resoudre(racine, cheminUrl) {
+  const brut = decodeURIComponent(cheminUrl.split('?')[0].split('#')[0])
+  const cible = resolve(racine, `.${brut}`)
+  // Garde-fou traversée de répertoire : on ne sert jamais hors de `out/`.
+  if (cible !== racine && !cible.startsWith(racine + sep)) return null
+  return (await fichierExistant(cible)) ?? (await fichierExistant(join(cible, 'index.html')))
+}
+
+function envoyer(reponse, statut, fichier, enTetes = {}) {
+  reponse.writeHead(statut, { 'Content-Type': typeDe(fichier), ...enTetes })
+  createReadStream(fichier).pipe(reponse)
+}
+
+/**
+ * Démarre le serveur statique et résout une fois le port en écoute.
+ * @param {{ racine?: string, port?: number }} options
+ * @returns {Promise<{ serveur: import('node:http').Server, port: number, url: string }>}
+ */
+export async function demarrerServeurStatique({ racine, port = PORT_PAR_DEFAUT } = {}) {
+  const dossier = resolve(racine ?? join(RACINE_PROJET, 'out'))
+
+  const serveur = createServer(async (requete, reponse) => {
+    try {
+      const fichier = await resoudre(dossier, requete.url ?? '/')
+      if (fichier) {
+        envoyer(reponse, 200, fichier, { 'Cache-Control': 'no-store' })
+        return
+      }
+      const page404 = await fichierExistant(join(dossier, '404.html'))
+      if (page404) {
+        envoyer(reponse, 404, page404, { 'Cache-Control': 'no-store' })
+        return
+      }
+      reponse.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+      reponse.end('404')
+    } catch (erreur) {
+      reponse.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' })
+      reponse.end(`500 ${erreur instanceof Error ? erreur.message : ''}`)
+    }
+  })
+
+  await new Promise((ok, ko) => {
+    serveur.once('error', ko)
+    serveur.listen(port, '127.0.0.1', ok)
+  })
+
+  const attribue = serveur.address().port
+  return { serveur, port: attribue, url: `http://127.0.0.1:${attribue}` }
+}
+
+// Exécution directe : `node scripts/serve-out.mjs [port]`.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const port = Number(process.argv[2] ?? PORT_PAR_DEFAUT)
+  const { url } = await demarrerServeurStatique({ port })
+  console.log(`Export statique servi sur ${url} (Ctrl+C pour arrêter)`)
+}


### PR DESCRIPTION
Closes #51

## Ce que fait le harnais

Le site est en export statique (`output: 'export'`, `trailingSlash: true`) : ni back, ni
route API, ni serveur applicatif. La « stack » e2e se réduit donc à **servir `out/`**.

`make test-e2e` appelle désormais `node scripts/e2e.mjs`, qui :

1. **construit** l'export statique si `out/index.html` manque (`npm run build`) ;
2. **sert** `out/` sur `127.0.0.1:E2E_PORT` (**4173** par défaut) via
   `scripts/serve-out.mjs` ;
3. **attend que le port réponde** — sonde `GET /` jusqu'à une vraie réponse HTTP,
   30 s max, **jamais de `sleep` arbitraire** ;
4. lance **`npx cypress run`** (les arguments passés au script lui sont transmis) ;
5. **arrête le serveur quoi qu'il arrive** — `finally` + `SIGINT`/`SIGTERM` : aucun
   processus orphelin, en local comme en CI. **Le code de sortie reste celui de
   Cypress**, aucun échec n'est absorbé.

`cypress.config.ts` dérive son `baseUrl` du même `E2E_PORT` : le port ne peut plus
diverger entre serveur et navigateur, et le `TODO : port réel du front` tombe. Le
commentaire `TODO` de `.github/workflows/ci-main-e2e.yml` tombe également.

### Résolution des URL identique à la production

`trailingSlash: true` fait sortir chaque route en `<route>/index.html`.
`scripts/serve-out.mjs` reproduit exactement `docker/nginx.conf` :
`try_files $uri $uri/ =404`, `index index.html`, `error_page 404 /404.html`. Un dossier
est servi par son `index.html` ; un dossier sans `index.html` (ex. `/certifications/`,
qui est un dossier d'assets) et une URL inconnue renvoient une **404** avec `404.html`.
La traversée de répertoire hors de `out/` est refusée.

## Dépendances

**Aucune dépendance ajoutée.** `node:http` sert le dossier, `fetch` sonde le port,
`child_process` lance Cypress. Rien à installer, rien à faire valider par
`check-new-dependency.sh`.

## Vérifications réelles

```
$ make lint
✓ Aucun fichier source ne dépasse 300 lignes.   (Biome : 0 erreur)

$ make build
✓ Generating static pages (13/13)   → out/index.html, out/404.html produits

$ node scripts/serve-out.mjs 4173      (sondes curl)
/                            -> 200 text/html
/services/data-ia/           -> 200 text/html
/services/data-ia            -> 200 text/html      (résolu vers index.html)
/certifications/             -> 404 text/html      (dossier sans index.html, comme nginx)
/page-inexistante/           -> 404 text/html
titre / : <title>Jérôme Marichez — Ingénieur logiciel à Lille</title>
→ après kill : processus éteint, port libéré

$ node scripts/e2e.mjs   (avec une spec temporaire HORS dépôt, pour valider la chaîne)
Export statique absent : construction (`npm run build`)…
✓ Compiled successfully
Export statique servi sur http://127.0.0.1:4173 (GET / → 200) — lancement de Cypress.
  3 passing (293ms)
  ✔ All specs passed!
Serveur statique arrêté.
CODE succès = 0 ; port 4173 : 0 processus ; orphelins : 0

$ make test-e2e   (état actuel du dépôt, sans spec)
Can't run because no spec files were found.
Serveur statique arrêté.
make: *** [test-e2e] Error 1        ← rouge honnête, serveur bien arrêté
```

## Ce qui reste rouge — la spec est écrite par Jérôme MARICHEZ

`tests/e2e/` ne contient toujours que `.gitkeep`. **Tant que la spec de fumée n'est pas
posée, `make test-e2e` échoue** (`Can't run because no spec files were found`) et
`ci-main-e2e` reste rouge. C'est voulu : faire tolérer à Cypress l'absence de spec serait
un contournement. Le harnais, lui, est prouvé fonctionnel.

### Intention de la spec de fumée (à poser par Jérôme MARICHEZ)

- **Niveau** : e2e (parcours navigateur) — fichier attendu : `tests/e2e/fumee.cy.ts`.
- **Comportement vérifié** :
  - la page d'accueil répond et porte le titre du site
    (`Jérôme Marichez — Ingénieur logiciel à Lille`) et un `h1` visible ;
  - une navigation aboutit : depuis l'accueil, le lien vers `/services/ingenierie-web/`
    mène à la page service (`h1` « Ingénierie web ») ;
  - une route est servie **directement** en `trailingSlash` — `/services/data-ia/` est
    résolue via son `index.html`.
- **Cas limites** :
  - `trailingSlash` : `/services/data-ia` (sans barre finale) doit aussi aboutir, le
    serveur résolvant le dossier vers son `index.html` comme nginx ;
  - **404** : une URL inconnue (`/page-inexistante/`) renvoie bien le statut **404** et
    non un 200 trompeur.
- **Jeu de données** : aucun — le contenu servi est l'export statique réellement produit
  par `next build`, aucune fixture n'est nécessaire.

Contenu proposé (à poser tel quel ou à amender — l'implémentation ne changera pas son
intention) :

```ts
describe("fumée — l'export statique est servi et navigable", () => {
  it("sert la page d'accueil avec son titre et son h1", () => {
    cy.visit('/')
    cy.title().should('contain', 'Jérôme Marichez')
    cy.get('h1').should('be.visible')
  })

  it('mène de l’accueil à une page service par le lien de navigation', () => {
    cy.visit('/')
    cy.get('a[href="/services/ingenierie-web/"]').first().click()
    cy.location('pathname').should('eq', '/services/ingenierie-web/')
    cy.contains('h1', 'Ingénierie web').should('be.visible')
  })

  it('résout une route sans barre finale vers son index.html (trailingSlash)', () => {
    cy.request('/services/data-ia').its('status').should('eq', 200)
    cy.visit('/services/data-ia/')
    cy.get('h1').should('be.visible')
  })

  it('renvoie une 404 sur une URL inconnue', () => {
    cy.request({ url: '/page-inexistante/', failOnStatusCode: false })
      .its('status')
      .should('eq', 404)
  })
})
```

Les trois premiers cas (accueil, trailingSlash, 404) ont été exécutés avec succès
contre ce harnais depuis un fichier temporaire **hors du dépôt** : le chemin est validé,
seul le dépôt attend son fichier.

## Aucun garde-fou affaibli

- pas de `continue-on-error: true`, pas d'`allow_failure: true` ;
- pas de `|| true` sur une commande de test ;
- le job `ci-main-e2e` n'est ni désactivé, ni conditionné, ni commenté — seul son
  commentaire `TODO` obsolète a été remplacé par la description du harnais réel ;
- Cypress ne tolère pas l'absence de spec : le job reste rouge tant que la spec manque ;
- aucun hook, aucun script de contrôle, aucune règle du projet n'a été modifié ;
- `scripts/check-max-lines.sh` et Biome passent sans exception ni exclusion ajoutée.

## Documentation

- `docs/testing.md` : nouvelle section « Harnais e2e — l'export statique servi en local »
  (les 5 étapes, `E2E_PORT`, la parité avec `docker/nginx.conf`) ;
- `docs/ci-cd.md` : le job **e2e (main)** décrit le harnais réel ;
- `README.md` : la ligne `make test-e2e` dit ce que la cible fait vraiment.
