### PR TITLE
ci: verifier les types avec tsc --noEmit sur toute PR vers dev

### DIFF
--- a/.github/workflows/ci-dev-types.yml
+++ b/.github/workflows/ci-dev-types.yml
@@ -1,0 +1,21 @@
+name: ci-dev-types
+# Check rapide (PR -> dev) : vérification des types TypeScript, sans émission.
+# Job dédié et non un step de ci-dev-lint : `tsc` a besoin des dépendances
+# installées (types de Next, React, Jest), là où ci-dev-lint tourne
+# volontairement sans `make install` (Biome via npx seul).
+on:
+  pull_request:
+    branches: [dev]
+jobs:
+  type-check:
+    name: Vérification des types (tsc --noEmit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Installation
+        run: make install
+      - name: Vérification des types
+        run: make type-check

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Interface de commandes unique (local + CI). `make help` liste les cibles.
 
 .DEFAULT_GOAL := help
-.PHONY: help install dev build lint test test-unit test-int test-mutation
+.PHONY: help install dev build lint type-check test test-unit test-int test-mutation
 .PHONY: test-e2e
 .PHONY: test-system
 .PHONY: test-acceptance
@@ -15,6 +15,9 @@ help: ## Liste les commandes disponibles
 lint: ## Biome sur tout le dépôt + limite 300 lignes/fichier
 	npx @biomejs/biome@^2.0.0 check .
 	./scripts/check-max-lines.sh
+
+type-check: ## Vérification des types TypeScript, sans émission de fichiers
+	npx tsc --noEmit
 
 test: test-unit test-int ## Tests unitaires + intégration (rapides)
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ démarrage).
 
 ```bash
 make lint             # Biome + limite 300 lignes/fichier
+make type-check       # types TypeScript (tsc --noEmit), sans émission
 make test             # unitaires + intégration
 make test-unit        # unitaires
 make test-int         # intégration

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -6,13 +6,22 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
 
 | Déclencheur | Workflows | Objectif |
 |-------------|-----------|----------|
-| **PR → `dev`** | `ci-dev-lint`, `ci-dev-tests` | Checks **rapides** : lint (Biome + limite 300 lignes), tests unitaires et intégration. |
+| **PR → `dev`** | `ci-dev-lint`, `ci-dev-types`, `ci-dev-tests` | Checks **rapides** : lint (Biome + limite 300 lignes), vérification des types, tests unitaires et intégration. |
 | **PR → `main`** | `ci-main-e2e`, `ci-main-system`, `ci-main-build` | Checks **complets** avant production : e2e navigateur, tests système, build. |
 
 ## Jobs
 
 - **lint** : `make lint` — Biome sur tout le dépôt + `scripts/check-max-lines.sh`
   (échec si un fichier source dépasse **300 lignes**).
+- **type-check (dev)** : `make type-check` — `tsc --noEmit`, vérification des types
+  **sans émission de fichiers**. Un type faux fait échouer la PR vers `dev`, là où il
+  n'était auparavant détecté qu'au `make build` de `ci-main-build`, au moment de la mise
+  en production. Le job est **séparé de `ci-dev-lint`** parce qu'il exécute `make install`
+  au préalable : `tsc` a besoin des types de Next, React et Jest, quand `ci-dev-lint`
+  tourne volontairement sans installation (Biome via `npx`). Le périmètre est celui de
+  `tsconfig.json` : `cypress.config.ts` et `tests/e2e` restent **exclus** — les types de
+  Cypress y chargent le `expect()` de Chai, qui écrase celui de Jest ; Cypress
+  type-vérifie ses propres specs.
 - **tests (dev)** : unitaires + intégration, front et back.
 - **e2e (main)** : `make test-e2e` — le harnais `scripts/e2e.mjs` construit l'export
   statique si `out/` manque, le sert sur `127.0.0.1:E2E_PORT` (4173 par défaut) avec les

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -128,9 +128,20 @@ chaque route en `<route>/index.html`. `serve-out.mjs` applique exactement les r�
 statique qui ignorerait cette règle ferait échouer les specs pour la mauvaise raison.
 La traversée de répertoire hors de `out/` est refusée.
 
+## Vérification des types
+
+`make type-check` exécute `tsc --noEmit` : le compilateur vérifie tout le dépôt sans
+écrire un seul fichier. Ce n'est pas un niveau de test — c'est le filet qui attrape ce
+qu'aucun test ne voit (unions fermées, `satisfies`, signatures) — mais il tourne au même
+titre qu'eux, dans le job `ci-dev-types` de toute PR vers `dev`, et il **fait échouer la
+PR**. `cypress.config.ts` et `tests/e2e` en sont exclus par `tsconfig.json` : leurs types
+Cypress chargent le `expect()` de Chai, qui écrase celui de Jest et casserait la
+compilation des tests unitaires. Cypress type-vérifie ses specs de son côté.
+
 ## Commandes
 
 ```bash
+make type-check       # types TypeScript (tsc --noEmit), sans émission de fichiers
 make test             # unitaires + intégration
 make test-unit        # unitaires (Jest)
 make test-int         # intégration (Jest)

--- a/src/@shared/routes.ts
+++ b/src/@shared/routes.ts
@@ -18,6 +18,7 @@ export const POLE_ORDER = [
   'ingenierie-web',
   'data-ia',
   'sea-ux',
+  'pole-inexistant',
 ] as const satisfies readonly PoleId[]
 
 /** Toutes les routes indexables, dans l'ordre de priorité. */

--- a/src/@shared/routes.ts
+++ b/src/@shared/routes.ts
@@ -18,7 +18,6 @@ export const POLE_ORDER = [
   'ingenierie-web',
   'data-ia',
   'sea-ux',
-  'pole-inexistant',
 ] as const satisfies readonly PoleId[]
 
 /** Toutes les routes indexables, dans l'ordre de priorité. */


### PR DESCRIPTION
Closes #53

## Le probleme

Sur une PR vers `dev`, la CI se limitait a `ci-dev-lint` (Biome + limite 300 lignes) et
`ci-dev-tests` (Jest). **Ni `tsc --noEmit`, ni `next build`.** Une erreur de type
traversait donc `dev` sans etre vue et n'apparaissait qu'au `make build` de
`ci-main-build` — au moment de la mise en production, quand elle coute le plus cher.

C'est bloquant maintenant : la restructuration du modele des poles touche des types
fermes (union `PoleId`, `satisfies Record<'accueil' | PoleId, string>` de `ROUTES`,
union `PoleRank = 1 | 2 | 3`). Ce sont exactement les erreurs que seul `tsc` voit.

## Ce qui est ajoute

- **`make type-check`** — `npx tsc --noEmit`, verification des types **sans emission
  d'aucun fichier**.
- **`.github/workflows/ci-dev-types.yml`** — job dedie `ci-dev-types`, declenche sur toute
  PR vers `dev`, qui execute `make install` puis `make type-check`.
- `docs/ci-cd.md`, `docs/testing.md`, `README.md` decrivent le nouveau check.

### Pourquoi un job dedie et non un step de `ci-dev-lint`

`ci-dev-lint` tourne **sans `make install`** : Biome est appele via `npx` et
`check-max-lines.sh` est un script shell. `tsc`, lui, a besoin des dependances installees
— il lit les types de Next (via `next-env.d.ts`), React et Jest. Ajouter le step dans
`ci-dev-lint` aurait impose une installation complete a un job volontairement rapide. Le
job dedie garde `ci-dev-lint` court et rend la cause d'un echec lisible au premier coup
d'oeil.

Note : `tsconfig.json` inclut `.next/types/**/*.ts`, mais c'est un glob — l'absence de
build ne gene pas. Verifie : `tsc` passe sur un arbre sans `.next/`.

## Perimetre inchange

`cypress.config.ts` et `tests/e2e` restent **exclus** par `tsconfig.json`, comme
aujourd'hui : leurs types Cypress chargent le `expect()` de Chai, qui ecrase celui de Jest
et casserait la compilation des tests unitaires. Le commentaire qui l'explique est
conserve tel quel. Cypress type-verifie ses propres specs.

`tsconfig.json` **n'est pas modifie** : `strict` reste a `true`,
`noUncheckedIndexedAccess` et `noImplicitOverride` restent actifs, `exclude` n'est pas
elargi.

## La preuve : rouge, puis vert

Le critere d'acceptation demande la demonstration en deux etats. Elle est faite sur cette
branche, commit par commit.

### Etat rouge

Commit `bf52874` — un identifiant de pole inexistant ajoute dans `POLE_ORDER`, qui
casse le `satisfies readonly PoleId[]` :

```
src/@shared/routes.ts(21,3): error TS2322: Type '"pole-inexistant"' is not assignable to type 'PoleId'.
```

- `ci-dev-types` : **ECHEC** -> https://github.com/Jerome-Marichez/jeromemarichez2026/actions/runs/32530354570/job/96920984187
- `ci-dev-lint` : succes -> https://github.com/Jerome-Marichez/jeromemarichez2026/actions/runs/32530354446/job/96920983853
- `ci-dev-tests` : succes -> https://github.com/Jerome-Marichez/jeromemarichez2026/actions/runs/32530354437/job/96920983799

**Les deux checks preexistants restent verts sur cette erreur.** C'est precisement le trou
decrit par l'issue #53, et la demonstration qu'un nouveau controle etait necessaire.

### Etat vert

Commit `130334a` — l'erreur est retiree, rien d'autre ne change.

- `ci-dev-types` : **succes** -> https://github.com/Jerome-Marichez/jeromemarichez2026/actions/runs/32530662712/job/96921859595
- `ci-dev-lint` : succes -> https://github.com/Jerome-Marichez/jeromemarichez2026/actions/runs/32530662696/job/96921859453
- `ci-dev-tests` : succes -> https://github.com/Jerome-Marichez/jeromemarichez2026/actions/runs/32530662769/job/96921859706

## Erreurs de type preexistantes

**Aucune.** `tsc --noEmit` passe sur `dev` (commit `383cb0c`) sans une seule erreur, sur
les 113 fichiers du perimetre. Rien n'a donc eu besoin d'etre corrige ni masque : le check
est ajoute sur un depot deja sain, et il le gardera tel.

## Regle 8 — aucun controle affaibli

Ce ticket **ajoute** un controle, il n'en retire aucun. Ni `continue-on-error`, ni
`|| true`, ni `if: false`. Aucun job existant n'est modifie, mis en condition ou supprime
— `ci-dev-lint.yml` et `ci-dev-tests.yml` sont intacts. Aucun seuil, aucun test, aucune
assertion touchee.

## Tests

**Aucun fichier de test n'est ajoute**, et l'issue n'en appelle pas : le check *est* la
verification, et sa preuve est la demonstration rouge/vert ci-dessus. Un test unitaire qui
verifierait le contenu du `Makefile` ou du YAML testerait sa propre copie du fichier, pas
le comportement.

Une intention de test reste envisageable si Jerome MARICHEZ la juge utile, mais elle
releverait plutot de l'acceptation : *le depot expose une cible `type-check` qui sort en
code non nul quand un fichier de `src/` porte une erreur de type* — niveau acceptation
(`tests/acceptance/`), jeu de donnees = un fichier `.ts` temporaire volontairement mal
type, hors de `src/`. Elle n'est pas posee ici : elle demanderait un `tsc` complet a
chaque execution, pour un gain faible face a la preuve deja faite en CI.
