### PR TITLE
feature: creer la section blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,11 +270,19 @@ confirmée, sans année connue.
 | `/services/ingenierie-web` | Pôle 1 en détail |
 | `/services/data-ia` | Pôle 2 en détail |
 | `/services/sea-ux` | Pôle 3 en détail |
+| `/blog` | Liste des articles, du plus récent au plus ancien |
+| `/blog/<slug>` | Un article. Une page statique par article, générée au build par `generateStaticParams` |
 | `/parcours` | *(pas encore construite)* Parcours d'ingénieur et de chef de projet, formation |
 | `/contact` | *(reportée)* L'export statique ferme les routes API : un formulaire exigerait un service tiers ou un back séparé. L'accueil et le pied de page portent un `mailto:` direct, cohérent avec la promesse d'interlocuteur unique |
 
 Chaque page de service porte ses propres métadonnées SEO, ses données structurées
 (`schema.org/Service` et `ProfessionalService`) et un appel à contact contextualisé.
+
+Le **blog** n'est pas un quatrième pôle et la navigation le sépare de la chaîne : ce sont
+des notes courtes sur des décisions techniques réelles. Chaque article porte ses propres
+métadonnées, un `schema.org/BlogPosting`, un fil d'Ariane `Accueil → Blog → article` et sa
+**date** — c'est la seule partie du site dont le sitemap publie une date par page. Le
+modèle de l'entité est décrit dans [`docs/data-model.md`](./docs/data-model.md).
 
 ## ✅ Contraintes produit
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,17 +28,44 @@ personne qui fera le travail*. Le jour où un formulaire s'impose, il faudra soi
 service tiers, soit un back séparé, soit renoncer à l'export : c'est un arbitrage à
 prendre en connaissance de cause, pas un détail de configuration.
 
+### Le blog : la seule route dynamique du site
+
+`/blog/[slug]` est le seul segment dynamique, et l'export statique en fixe les règles :
+
+- **`generateStaticParams()` est obligatoire.** Sans lui, `next build` n'a aucune page à
+  écrire pour ce segment et il échoue. La liste est dérivée des articles, jamais tenue à
+  la main : publier un article suffit à créer sa page. `dynamicParams = false` est écrit
+  noir sur blanc, pour qu'un futur passage au rendu serveur n'ouvre pas silencieusement
+  `/blog/<n-importe-quoi>`.
+- **Le sitemap devient composé.** `INDEXABLE_ROUTES` (`@shared/routes`) n'énumère que les
+  routes **fixes** ; les URL d'articles ne sont pas des routes mais des instances d'une
+  seule route, et leur nombre change à chaque publication. `@shared/seo/sitemap-entries`
+  les ajoute avec **une date par article** — et donne à `/blog` la date de son article le
+  plus récent, parce que c'est exactement ce qui la fait changer. C'est le seul module de
+  `@shared/seo` qui lit le contenu de `@vitrine` : un sitemap est par définition
+  l'inventaire du contenu publié, il n'y a pas d'autre source d'où tirer la liste.
+- **Une seule fonction compose une URL d'article** : `toArticleRoute(slug)`. Liste,
+  `canonical`, `og:url`, fil d'Ariane, JSON-LD et sitemap passent tous par elle. Dans un
+  export statique, une URL canonique fausse reste fausse jusqu'au prochain build.
+- **Un seul fil d'Ariane.** `buildBreadcrumbSchema` accepte les niveaux qui suivent
+  l'accueil — celui-ci est un invariant du site, il est posé par la fonction et ne peut
+  pas être oublié par un appelant. La même liste alimente le fil **visible**
+  (`@shared/components/Breadcrumb`) : l'affiché et le déclaré ne peuvent pas diverger.
+- **Le blog n'est pas un pôle**, et la navigation le dit : il occupe un bloc distinct de
+  la liste numérotée de la chaîne, dans l'en-tête comme dans le pied de page.
+
 ### Découpage par domaine
 
 | Domaine | Contenu |
 |---------|---------|
-| `src/@vitrine/` | Sections éditoriales : offres, parcours, preuves, certifications |
+| `src/@vitrine/` | Sections éditoriales : offres, parcours, preuves, certifications, **articles du blog** |
 | `src/@shared/` | Design system, layout, composants transverses, SEO/métadonnées |
 
-Le **contenu éditorial est de la donnée, pas du JSX** : offres, expériences et
-certifications vivent dans des structures typées (`src/interfaces/`, une entité par
-fichier, préfixe `I`) que les composants consomment. Ajouter une certification ou une
-offre ne doit pas demander de toucher au rendu.
+Le **contenu éditorial est de la donnée, pas du JSX** : offres, expériences,
+certifications et articles vivent dans des structures typées (`src/interfaces/`, une
+entité par fichier, préfixe `I`) que les composants consomment. Ajouter une certification,
+une offre ou un article ne doit pas demander de toucher au rendu. Le détail des entités
+est décrit dans [data-model](./data-model.md).
 
 ## Front (Next.js (App Router) + TypeScript)
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,21 +1,111 @@
 # Modèle de données
 
-<!-- TODO : compléter dès que le modèle existe. -->
+Le site n'a **ni base de données, ni API, ni CMS** : tout le contenu est versionné en
+TypeScript dans `src/@vitrine/contenu/`, et sa forme est tenue par des interfaces de
+`src/interfaces/` (une entité par fichier, préfixe `I`). Ce document décrit ces entités.
+
+> **Pas de Zod ici, et c'est volontaire.** Zod est obligatoire sur les **entrées
+> externes** (formulaire, body d'API, webhook, variables d'environnement). Un fichier de
+> contenu compilé avec le site n'en est pas une : le compilateur refuse déjà un champ
+> manquant ou mal typé, et un schéma exécuté au build ne ferait que revérifier ce que
+> TypeScript a garanti. La seule vraie frontière du blog est le `slug` d'URL — il est
+> confronté à la liste close des articles par `generateStaticParams`, donc aucune URL
+> hors de cette liste n'est servie.
 
 ## Entités
 
-| Entité | Rôle | Relations |
-|--------|------|-----------|
-| _TODO_ | | |
+| Entité | Fichier | Rôle | Relations |
+|--------|---------|------|-----------|
+| `IPole` | `src/interfaces/IPole.ts` | Un maillon de la chaîne d'offres | `route` pointe une entrée de `ROUTES` |
+| `IEditorialPage` | `src/interfaces/IEditorialPage.ts` | Une page rédigée (accueil, page de pôle) | contient des `IEditorialSection` |
+| `IEditorialSection` | `src/interfaces/IEditorialSection.ts` | Une section de page | contient des `IEditorialBlock` ; `pole` référence un `PoleId` |
+| `IEditorialBlock` | `src/interfaces/IEditorialBlock.ts` | Un point d'expertise | — |
+| `IProof` | `src/interfaces/IProof.ts` | Une preuve chiffrée | — |
+| `ICertification` | `src/interfaces/ICertification.ts` | Une certification obtenue | `ICertificationLogo` |
+| `IBoundary` | `src/interfaces/IBoundary.ts` | Une limite assumée | — |
+| **`IArticle`** | `src/interfaces/IArticle.ts` | **Un article du blog** | contient des `IArticleSection` |
+| `IArticleSection` | `src/interfaces/IArticleSection.ts` | Une section d'article | — |
+| `IBlogIndex` | `src/interfaces/IBlogIndex.ts` | L'en-tête éditoriale de `/blog` | — |
+| `IBreadcrumbItem` | `src/interfaces/IBreadcrumbItem.ts` | Un niveau de fil d'Ariane | lu par le rendu **et** par le JSON-LD |
 
-## Schéma
+## L'article (`IArticle`)
 
-Décrire ici les tables/collections, clés, contraintes d'intégrité (unicité,
-clés étrangères) — un schéma (Mermaid/drawio) est bienvenu.
+C'est la seule entité **datée** du site, et c'est ce qui la distingue du reste du
+contenu : une page de pôle est vraie ou fausse, un article est vrai **à une date**.
 
-## Règles
+| Champ | Type | Obligatoire | Rôle |
+|-------|------|-------------|------|
+| `slug` | `string` | oui | Identité durable. Dernier segment de l'URL, clé de recherche, ancre du JSON-LD |
+| `titre` | `string` | oui | `<h1>`, `headline` du JSON-LD, dernier niveau du fil d'Ariane |
+| `chapo` | `string` | oui | Résumé. Teaser sur la liste, `description` du JSON-LD |
+| `meta` | `IPageMeta` | oui | `<title>` (60 car. max) et meta description (155 car. max) |
+| `datePublication` | `string` (`AAAA-MM-JJ`) | oui | Date affichée, `datePublished`, **clé de tri** de la liste |
+| `dateRevision` | `string` (`AAAA-MM-JJ`) | non | Révision de fond. `dateModified` et `lastModified` du sitemap |
+| `sections` | `IArticleSection[]` | oui | Corps de l'article : un titre `<h2>` et ses paragraphes |
 
-- **Pas de binaire en base** : les images/fichiers sont des **références**
-  (URL / chemin d'asset), jamais des BLOB.
-- Migrations versionnées et rejouables.
-- Seed de démonstration au premier démarrage (le cas échéant).
+### Contraintes d'intégrité
+
+Aucune n'est vérifiée à l'exécution — elles le sont par le compilateur, par la
+construction du site, ou elles restent à la charge de l'auteur :
+
+- **`slug` unique et stable.** Deux articles de même slug produiraient deux fois la même
+  page ; changer un slug publié casse les liens entrants et l'historique de position dans
+  les moteurs. Un titre se corrige, un slug ne se corrige pas.
+- **`slug` en kebab-case ASCII**, sans accent ni apostrophe : c'est une URL, elle doit
+  s'écrire, se lire au téléphone et se copier sans encodage.
+- **Dates au format `AAAA-MM-JJ`.** Ce format se compare comme du texte, ce dont le tri
+  chronologique se sert directement. TypeScript ne peut pas le contraindre : c'est une
+  convention, tenue par la relecture.
+- **`dateRevision` ≥ `datePublication`** quand elle existe.
+- **Véracité du contenu** : les règles du [`CLAUDE.md`](../CLAUDE.md) s'appliquent mot
+  pour mot à un article comme au reste du site.
+
+### Règles portées par le service
+
+Elles vivent dans `src/@vitrine/services/find-article.ts`, jamais dans le contenu ni dans
+un composant :
+
+| Règle | Comportement |
+|-------|--------------|
+| `listArticles()` | Classe par `datePublication` décroissante. Le tri porte sur la publication et **non** sur la révision : corriger un vieil article ne doit pas le remettre en tête comme s'il était neuf |
+| `findArticle(slug)` | Rend l'article et jusqu'à `MAX_ARTICLES_LIES` (2) autres. **Lève** sur un slug inconnu : les slugs servis sont énumérés au build, un slug absent est une incohérence de code, pas une URL saisie par un visiteur |
+| `articleRevisionDate(a)` | `dateRevision` si elle existe, `datePublication` sinon. Écrite une fois, pour que le sitemap et le JSON-LD ne puissent pas publier deux dates différentes |
+
+### Ce qui n'est pas dans le modèle, et pourquoi
+
+- **Pas d'auteur.** Le site n'a qu'un auteur, déclaré une fois pour tout le site par le
+  nœud `Person` du layout. Un champ `auteur` par article laisserait croire à une équipe
+  de rédaction.
+- **Pas d'image.** Aucune illustration n'est servie ; déclarer une image dans le JSON-LD
+  ou dans `og:image` sans la servir serait une affirmation fausse de plus.
+- **Pas de rattachement à un pôle, pas de tags, pas de catégories.** Avec trois articles,
+  une taxonomie serait un classement sans classe. Le jour où elle s'impose, le
+  rattachement dérivera de `PoleId` et de `POLE_ORDER` — jamais d'une liste de pôles
+  recopiée dans le blog.
+- **Pas de statut `brouillon`.** Un article non publié n'est pas dans `articles.ts`.
+
+## Où vivent les données
+
+```
+src/@vitrine/contenu/blog/
+├── articles.ts          ← la liste publiée : SOURCE UNIQUE du blog
+├── blog-index.ts        ← l'en-tête éditoriale de /blog
+├── export-statique.ts   ← un fichier par article
+├── test-avant-code.ts
+└── mesurer-avant-arbitrer.ts
+```
+
+`articles.ts` alimente **tout** : la liste, les pages générées au build
+(`generateStaticParams`), le sitemap (`@shared/seo/sitemap-entries`) et les données
+structurées. Retirer un article de ce tableau le fait disparaître partout — il n'y a pas
+de second endroit à mettre à jour.
+
+## Règles générales
+
+- **Pas de binaire en base** : sans objet, il n'y a pas de base. Les rares visuels (logos
+  de certification) sont des **références** vers `public/`, jamais des données.
+- **Migrations** : sans objet. Un changement de forme d'entité est une modification de
+  type, donc une erreur de compilation tant que le contenu ne l'a pas suivie — c'est la
+  contrepartie recherchée d'un contenu typé plutôt que stocké.
+- **Seed de démonstration** : sans objet. Les jeux de données de test vivent dans
+  `tests/fixtures/` (`article.fixture.json` pour le blog).

--- a/src/@shared/components/Breadcrumb/breadcrumb.module.css
+++ b/src/@shared/components/Breadcrumb/breadcrumb.module.css
@@ -1,0 +1,31 @@
+/* breadcrumb.module.css — fil d'Ariane.
+ * Discret par construction : c'est un repère, pas une navigation principale. */
+
+.ariane {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.06em;
+  color: var(--encre-douce);
+}
+
+.liste {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.niveau {
+  display: flex;
+  align-items: baseline;
+  /* Le dernier niveau peut être un titre d'article entier : il doit pouvoir passer à la
+     ligne sans pousser la page en défilement horizontal. */
+  min-width: 0;
+}
+
+.separateur {
+  padding-inline: 0.5em;
+  color: color-mix(in srgb, var(--encre-douce) 60%, transparent);
+}

--- a/src/@shared/components/Breadcrumb/index.tsx
+++ b/src/@shared/components/Breadcrumb/index.tsx
@@ -1,0 +1,47 @@
+// Breadcrumb/index.tsx — jeromemarichez-fr
+// Le fil d'Ariane visible. Même liste que celle déclarée aux moteurs.
+
+import Link from 'next/link'
+import type { IBreadcrumbItem } from '@/interfaces/IBreadcrumbItem'
+import { ROUTES } from '../../routes'
+import styles from './breadcrumb.module.css'
+
+interface BreadcrumbProps {
+  /** Niveaux qui suivent l'accueil. Le dernier est la page courante. */
+  fil: IBreadcrumbItem[]
+}
+
+/**
+ * Rend le fil d'Ariane à partir de la même liste que `buildBreadcrumbSchema` : le fil
+ * affiché et le fil déclaré ne peuvent pas diverger, puisqu'il n'y en a qu'un.
+ *
+ * Une liste ordonnée, et pas une suite de liens séparés par des barres obliques : la
+ * hiérarchie est une information, elle doit exister pour un lecteur d'écran et pas
+ * seulement à l'œil. Le dernier niveau n'est pas un lien — il désigne la page qu'on lit
+ * déjà, et `aria-current` le dit.
+ */
+export function Breadcrumb({ fil }: BreadcrumbProps) {
+  const dernier = fil.length - 1
+
+  return (
+    <nav aria-label="Fil d'Ariane" className={styles.ariane}>
+      <ol className={styles.liste}>
+        <li className={styles.niveau}>
+          <Link href={ROUTES.accueil}>Accueil</Link>
+        </li>
+        {fil.map((niveau, index) => (
+          <li className={styles.niveau} key={niveau.route}>
+            <span aria-hidden="true" className={styles.separateur}>
+              /
+            </span>
+            {index === dernier ? (
+              <span aria-current="page">{niveau.nom}</span>
+            ) : (
+              <Link href={niveau.route}>{niveau.nom}</Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}

--- a/src/@shared/components/SiteFooter/index.tsx
+++ b/src/@shared/components/SiteFooter/index.tsx
@@ -3,6 +3,7 @@
 
 import Link from 'next/link'
 import { POLES_NAV } from '@/@vitrine/contenu/poles-nav'
+import { ROUTES } from '../../routes'
 import { SITE_IDENTITY } from '../../seo/site'
 import styles from './site-footer.module.css'
 
@@ -36,6 +37,18 @@ export function SiteFooter() {
                 <Link href={pole.route}>{pole.nom}</Link>
               </li>
             ))}
+          </ul>
+        </nav>
+
+        <nav aria-label="Le site" className={styles.navigation}>
+          <p className={styles.titreNav}>Le site</p>
+          <ul className={styles.liens}>
+            <li>
+              <Link href={ROUTES.accueil}>Accueil</Link>
+            </li>
+            <li>
+              <Link href={ROUTES.blog}>Blog</Link>
+            </li>
           </ul>
         </nav>
 

--- a/src/@shared/components/SiteFooter/site-footer.module.css
+++ b/src/@shared/components/SiteFooter/site-footer.module.css
@@ -10,7 +10,9 @@
 
 .contenu {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+  /* L'appel garde le double de la largeur d'une colonne de liens : c'est lui qu'on doit
+     lire d'abord, les trois colonnes de navigation ne sont qu'un repli. */
+  grid-template-columns: minmax(0, 2fr) repeat(3, minmax(0, 1fr));
   gap: var(--e-5);
   max-width: var(--largeur-page);
   margin-inline: auto;
@@ -67,6 +69,14 @@
   padding: var(--e-3) var(--e-4) var(--e-5);
   font-size: var(--t--1);
   color: var(--encre-douce);
+}
+
+/* Palier intermédiaire : à quatre colonnes, les intitulés de pôles se coupent en deux
+   avant 1024px. Deux colonnes valent mieux qu'une colonne de mots tronqués. */
+@media (max-width: 1024px) {
+  .contenu {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 720px) {

--- a/src/@shared/components/SiteHeader/index.tsx
+++ b/src/@shared/components/SiteHeader/index.tsx
@@ -29,20 +29,30 @@ export function SiteHeader() {
           </span>
         </Link>
 
-        <nav aria-label="Les trois pôles" className={styles.navigation}>
-          <ol className={styles.liste}>
-            {POLES_NAV.map((pole) => (
-              <li key={pole.id}>
-                <Link className={styles.lien} href={pole.route}>
-                  <span aria-hidden="true" className={styles.rang}>
-                    {pole.rang}
-                  </span>
-                  {pole.nom}
-                </Link>
-              </li>
-            ))}
-          </ol>
-        </nav>
+        <div className={styles.navigations}>
+          <nav aria-label="Les trois pôles" className={styles.navigation}>
+            <ol className={styles.liste}>
+              {POLES_NAV.map((pole) => (
+                <li key={pole.id}>
+                  <Link className={styles.lien} href={pole.route}>
+                    <span aria-hidden="true" className={styles.rang}>
+                      {pole.rang}
+                    </span>
+                    {pole.nom}
+                  </Link>
+                </li>
+              ))}
+            </ol>
+          </nav>
+
+          {/* Bloc distinct, et pas un quatrième élément de la liste numérotée : le blog
+              n'est pas une offre, et l'ajouter à la chaîne le ferait lire comme telle. */}
+          <nav aria-label="Le blog" className={styles.navigationSecondaire}>
+            <Link className={styles.lien} href={ROUTES.blog}>
+              Blog
+            </Link>
+          </nav>
+        </div>
       </div>
     </header>
   )

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -59,8 +59,24 @@
   color: var(--encre-douce);
 }
 
+.navigations {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--e-1);
+  min-width: 0;
+}
+
 .navigation {
   min-width: 0;
+}
+
+/* Le blog est séparé de la chaîne par un filet vertical : c'est le seul signal qui dit,
+   sans un mot, qu'il n'appartient pas à la liste numérotée d'à côté. */
+.navigationSecondaire {
+  display: flex;
+  padding-left: var(--e-1);
+  border-left: 1px solid color-mix(in srgb, var(--encre) 14%, transparent);
 }
 
 .liste {

--- a/src/@shared/routes.ts
+++ b/src/@shared/routes.ts
@@ -8,10 +8,11 @@ import type { PoleId } from '@/interfaces/types'
 
 export const ROUTES = {
   accueil: '/',
+  blog: '/blog',
   'ingenierie-web': '/services/ingenierie-web',
   'data-ia': '/services/data-ia',
   'sea-ux': '/services/sea-ux',
-} as const satisfies Record<'accueil' | PoleId, string>
+} as const satisfies Record<'accueil' | 'blog' | PoleId, string>
 
 /** Ordre de la chaîne : construire, exploiter et mesurer, arbitrer. */
 export const POLE_ORDER = [
@@ -20,10 +21,30 @@ export const POLE_ORDER = [
   'sea-ux',
 ] as const satisfies readonly PoleId[]
 
-/** Toutes les routes indexables, dans l'ordre de priorité. */
+/**
+ * Toutes les routes **fixes** indexables, dans l'ordre de priorité.
+ *
+ * Les URL d'articles n'y figurent pas : elles ne sont pas des routes du site mais des
+ * instances d'une seule route dynamique, et leur nombre change à chaque publication.
+ * C'est le sitemap qui les ajoute, à partir de la liste des articles
+ * (`@shared/seo/sitemap-entries`).
+ */
 export const INDEXABLE_ROUTES = [
   ROUTES.accueil,
   ROUTES['ingenierie-web'],
   ROUTES['data-ia'],
   ROUTES['sea-ux'],
+  ROUTES.blog,
 ] as const
+
+/**
+ * Route d'un article à partir de son slug.
+ *
+ * Une seule fonction sait comment une URL d'article se compose : liste, métadonnées,
+ * fil d'Ariane, JSON-LD et sitemap passent tous par elle. Sans ça, le préfixe `/blog`
+ * serait recopié à cinq endroits et une page finirait par se déclarer canonique sur une
+ * URL qu'elle n'occupe pas.
+ */
+export function toArticleRoute(slug: string): string {
+  return `${ROUTES.blog}/${slug}`
+}

--- a/src/@shared/seo/page-metadata.ts
+++ b/src/@shared/seo/page-metadata.ts
@@ -8,6 +8,7 @@
 
 import type { Metadata } from 'next'
 import type { IPageMeta } from '@/interfaces/IEditorialPage'
+import { SITE_IDENTITY } from './site'
 
 /**
  * Métadonnées d'une page à partir de son contenu éditorial.
@@ -26,5 +27,38 @@ export function buildPageMetadata(page: { meta: IPageMeta; route: string }): Met
     description: page.meta.description,
     alternates: { canonical: page.route },
     openGraph: { url: page.route },
+  }
+}
+
+/**
+ * Métadonnées d'un article de blog.
+ *
+ * Deux différences avec une page ordinaire, et une seule raison : un article est daté.
+ * `og:type` passe donc à `article` et la date de publication accompagne le partage —
+ * c'est ce qui permet à un agrégateur de classer le billet plutôt que de le traiter
+ * comme une page de site parmi d'autres.
+ *
+ * L'appelant fournit la route, comme pour `buildPageMetadata`, mais il la tient de
+ * `toArticleRoute(slug)` : c'est la seule façon de composer une URL d'article dans ce
+ * dépôt, donc la seule qui garantisse que `canonical` et `og:url` désignent la page
+ * réellement servie.
+ */
+export function buildArticleMetadata(article: {
+  meta: IPageMeta
+  route: string
+  datePublished: string
+  dateModified: string
+}): Metadata {
+  return {
+    title: article.meta.title,
+    description: article.meta.description,
+    alternates: { canonical: article.route },
+    openGraph: {
+      type: 'article',
+      url: article.route,
+      publishedTime: article.datePublished,
+      modifiedTime: article.dateModified,
+      authors: [SITE_IDENTITY.nom],
+    },
   }
 }

--- a/src/@shared/seo/sitemap-entries.ts
+++ b/src/@shared/seo/sitemap-entries.ts
@@ -1,0 +1,44 @@
+// sitemap-entries.ts — jeromemarichez-fr
+// Les entrées du sitemap : les routes fixes du site, plus un article par publication.
+//
+// La logique vit ici et non dans `src/app/sitemap.ts` : `app/` ne fait que du routage
+// (docs/architecture.md), et cette liste-ci se vérifie sans démarrer Next.
+//
+// C'est le seul module de `@shared/seo` qui lit le contenu de `@vitrine`. C'est assumé :
+// un sitemap est par définition l'inventaire du contenu publié, il n'existe aucune autre
+// source d'où tirer la liste des articles.
+
+import type { MetadataRoute } from 'next'
+import { articleRevisionDate, listArticles } from '@/@vitrine/services/find-article'
+import { INDEXABLE_ROUTES, ROUTES, toArticleRoute } from '../routes'
+import { SITE_DERNIERE_REVISION } from './site'
+import { toAbsoluteUrl } from './urls'
+
+/**
+ * Toutes les URL indexables du site, avec leur date de dernière modification.
+ *
+ * Trois dates différentes, et c'est voulu :
+ * - les pages éditoriales portent la révision globale du site, tenue à la main ;
+ * - un article porte **sa** date — c'est tout l'intérêt d'avoir un blog dans un sitemap ;
+ * - la liste `/blog` porte la date de son article le plus récent, parce que c'est
+ *   exactement ce qui la fait changer. Lui laisser la date globale reviendrait à
+ *   annoncer une page modifiée les jours où elle ne l'est pas, et inchangée le jour
+ *   d'une publication — soit le contraire du signal attendu.
+ */
+export function buildSitemapEntries(): MetadataRoute.Sitemap {
+  const articles = listArticles()
+  const premier = articles[0]
+  const dateBlog = premier ? articleRevisionDate(premier) : SITE_DERNIERE_REVISION
+
+  const routesFixes = INDEXABLE_ROUTES.map((route) => ({
+    url: toAbsoluteUrl(route),
+    lastModified: route === ROUTES.blog ? dateBlog : SITE_DERNIERE_REVISION,
+  }))
+
+  const pagesArticles = articles.map((article) => ({
+    url: toAbsoluteUrl(toArticleRoute(article.slug)),
+    lastModified: articleRevisionDate(article),
+  }))
+
+  return [...routesFixes, ...pagesArticles]
+}

--- a/src/@shared/seo/structured-data.ts
+++ b/src/@shared/seo/structured-data.ts
@@ -5,6 +5,7 @@
 // site n'affirme pas déjà. Il est lu par des moteurs, pas par des prospects, ce qui
 // le rend d'autant plus tentant à gonfler — et d'autant plus grave à gonfler.
 
+import type { IBreadcrumbItem } from '@/interfaces/IBreadcrumbItem'
 import { SITE_IDENTITY, SITE_URL, SITE_ZONE } from './site'
 import { toAbsoluteUrl } from './urls'
 
@@ -61,22 +62,99 @@ export function buildServiceSchema(params: {
   }
 }
 
-/** Fil d'Ariane d'une page de pôle. */
-export function buildBreadcrumbSchema(params: {
-  nom: string
-  route: string
-}): Record<string, unknown> {
+/**
+ * Fil d'Ariane d'une page, de deux niveaux ou plus.
+ *
+ * `fil` ne porte que les niveaux **qui suivent** l'accueil : celui-ci n'est pas un choix
+ * éditorial mais un invariant du site, et le rendre facultatif ouvrirait la porte à un
+ * fil amputé de sa racine — que Google refuse d'afficher. Le premier niveau est donc
+ * posé ici, et il ne peut pas être oublié par un appelant.
+ *
+ * La même liste alimente le fil visible (`@shared/components/Breadcrumb`), pour que
+ * l'affiché et le déclaré ne puissent pas diverger.
+ */
+export function buildBreadcrumbSchema(fil: IBreadcrumbItem[]): Record<string, unknown> {
   return {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Accueil', item: toAbsoluteUrl('/') },
-      {
+      ...fil.map((niveau, index) => ({
         '@type': 'ListItem',
-        position: 2,
-        name: params.nom,
-        item: toAbsoluteUrl(params.route),
-      },
+        position: index + 2,
+        name: niveau.nom,
+        item: toAbsoluteUrl(niveau.route),
+      })),
     ],
+  }
+}
+
+/**
+ * Un article du blog.
+ *
+ * `BlogPosting` plutôt qu'`Article` : c'est le sous-type exact, et l'annoncer permet à
+ * un moteur de rattacher l'article au blog qui le contient. Pas de champ `image` — le
+ * site ne sert aucune illustration d'article, et déclarer une image absente serait
+ * précisément le genre de JSON-LD gonflé que ce fichier s'interdit.
+ *
+ * `author` et `publisher` pointent les nœuds déjà publiés par le layout : la personne et
+ * l'activité sont décrites une fois pour tout le site, jamais redéclarées par page.
+ */
+export function buildArticleSchema(params: {
+  titre: string
+  chapo: string
+  route: string
+  datePublished: string
+  dateModified: string
+}): Record<string, unknown> {
+  const url = toAbsoluteUrl(params.route)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    '@id': `${url}#article`,
+    headline: params.titre,
+    description: params.chapo,
+    url,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    inLanguage: 'fr-FR',
+    datePublished: params.datePublished,
+    dateModified: params.dateModified,
+    author: { '@id': `${SITE_URL}/#personne` },
+    publisher: { '@id': `${SITE_URL}/#activite` },
+  }
+}
+
+/**
+ * Le blog lui-même, avec la liste de ses articles.
+ *
+ * Les articles n'y sont référencés que par leur `@id` et leur titre : le détail est
+ * déclaré par chaque page d'article. Recopier ici tout le contenu du billet donnerait
+ * deux descriptions du même objet, qui divergeraient à la première correction.
+ */
+export function buildBlogSchema(params: {
+  nom: string
+  description: string
+  route: string
+  articles: readonly { titre: string; route: string }[]
+}): Record<string, unknown> {
+  const url = toAbsoluteUrl(params.route)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    '@id': `${url}#blog`,
+    name: params.nom,
+    description: params.description,
+    url,
+    inLanguage: 'fr-FR',
+    author: { '@id': `${SITE_URL}/#personne` },
+    publisher: { '@id': `${SITE_URL}/#activite` },
+    blogPost: params.articles.map((article) => ({
+      '@type': 'BlogPosting',
+      '@id': `${toAbsoluteUrl(article.route)}#article`,
+      headline: article.titre,
+      url: toAbsoluteUrl(article.route),
+    })),
   }
 }

--- a/src/@vitrine/components/ArticleCard/article-card.module.css
+++ b/src/@vitrine/components/ArticleCard/article-card.module.css
@@ -1,0 +1,44 @@
+/* article-card.module.css — un article dans une liste.
+ * Pas de panneau ni de bordure : un filet supérieur suffit à séparer, et la liste
+ * reste une suite de textes plutôt qu'une grille de vignettes. */
+
+.carte {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  padding-top: var(--e-3);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+}
+
+.date {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.06em;
+  color: var(--encre-douce);
+}
+
+.titre {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-2);
+  line-height: 1.25;
+}
+
+.lien {
+  color: var(--encre);
+  text-decoration: none;
+}
+
+.lien:hover,
+.lien:focus-visible {
+  color: var(--cuivre);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}

--- a/src/@vitrine/components/ArticleCard/index.tsx
+++ b/src/@vitrine/components/ArticleCard/index.tsx
@@ -1,0 +1,42 @@
+// ArticleCard/index.tsx — jeromemarichez-fr
+// Un article vu depuis une liste : sa date, son titre, son chapô.
+
+import Link from 'next/link'
+import { toArticleRoute } from '@/@shared/routes'
+import type { IArticle } from '@/interfaces/IArticle'
+import { formatDateFr } from '@/utils/format-date'
+import styles from './article-card.module.css'
+
+interface ArticleCardProps {
+  article: IArticle
+  /** Niveau de titre, pour que la hiérarchie du document reste juste selon le contexte. */
+  headingLevel?: 'h2' | 'h3'
+}
+
+/**
+ * Le lien porte le titre, et rien d'autre.
+ *
+ * Rendre la carte entière cliquable aurait demandé de la superposer d'un lien vide ou de
+ * la piloter en JavaScript : dans les deux cas, un lecteur d'écran annonce un lien sans
+ * intitulé ou une zone qu'aucune touche n'atteint. Un titre cliquable dit exactement où
+ * l'on va, au clavier comme à la souris.
+ */
+export function ArticleCard({ article, headingLevel = 'h2' }: ArticleCardProps) {
+  const Heading = headingLevel
+
+  return (
+    <article className={styles.carte}>
+      <p className={styles.date}>
+        <time dateTime={article.datePublication}>{formatDateFr(article.datePublication)}</time>
+      </p>
+
+      <Heading className={styles.titre}>
+        <Link className={styles.lien} href={toArticleRoute(article.slug)}>
+          {article.titre}
+        </Link>
+      </Heading>
+
+      <p className={styles.chapo}>{article.chapo}</p>
+    </article>
+  )
+}

--- a/src/@vitrine/components/PoleHero/index.tsx
+++ b/src/@vitrine/components/PoleHero/index.tsx
@@ -2,6 +2,7 @@
 // Ouverture d'une page de pôle : où l'on est dans la chaîne, et vers où l'on va.
 
 import Link from 'next/link'
+import { Breadcrumb } from '@/@shared/components/Breadcrumb'
 import { ROUTES } from '@/@shared/routes'
 import type { IPole } from '@/interfaces/IPole'
 import styles from './pole-hero.module.css'
@@ -19,11 +20,7 @@ interface PoleHeroProps {
 export function PoleHero({ pole, suivant }: PoleHeroProps) {
   return (
     <section aria-labelledby="pole-titre" className={styles.hero}>
-      <nav aria-label="Fil d'Ariane" className={styles.ariane}>
-        <Link href={ROUTES.accueil}>Accueil</Link>
-        <span aria-hidden="true"> / </span>
-        <span aria-current="page">{pole.nom}</span>
-      </nav>
+      <Breadcrumb fil={[{ nom: pole.nom, route: pole.route }]} />
 
       <p className={styles.rang}>
         <span aria-hidden="true" className={styles.numero}>

--- a/src/@vitrine/components/PoleHero/pole-hero.module.css
+++ b/src/@vitrine/components/PoleHero/pole-hero.module.css
@@ -9,12 +9,8 @@
   padding: var(--e-6) var(--e-4) var(--e-5);
 }
 
-.ariane {
-  font-family: var(--police-mono-pile);
-  font-size: var(--t--1);
-  letter-spacing: 0.06em;
-  color: var(--encre-douce);
-}
+/* Le fil d'Ariane a été extrait dans @shared/components/Breadcrumb : il est désormais
+   partagé avec les pages du blog, et ses styles sont colocalisés avec lui. */
 
 .rang {
   display: flex;

--- a/src/@vitrine/contenu/blog/articles.ts
+++ b/src/@vitrine/contenu/blog/articles.ts
@@ -1,0 +1,20 @@
+// articles.ts — jeromemarichez-fr
+// La liste des articles publiés. Source unique du blog.
+//
+// Tout le blog part d'ici : la liste, les pages d'articles générées au build, le
+// sitemap et les données structurées. Un article retiré de ce tableau disparaît
+// partout — il n'y a pas de second endroit à mettre à jour.
+//
+// L'ORDRE DE CE TABLEAU N'EST PAS L'ORDRE D'AFFICHAGE : le classement par date est une
+// règle métier, elle vit dans `@vitrine/services/find-article`.
+
+import type { IArticle } from '@/interfaces/IArticle'
+import { ARTICLE_EXPORT_STATIQUE } from './export-statique'
+import { ARTICLE_MESURER_AVANT_ARBITRER } from './mesurer-avant-arbitrer'
+import { ARTICLE_TEST_AVANT_CODE } from './test-avant-code'
+
+export const ARTICLES: IArticle[] = [
+  ARTICLE_EXPORT_STATIQUE,
+  ARTICLE_TEST_AVANT_CODE,
+  ARTICLE_MESURER_AVANT_ARBITRER,
+]

--- a/src/@vitrine/contenu/blog/blog-index.ts
+++ b/src/@vitrine/contenu/blog/blog-index.ts
@@ -1,0 +1,25 @@
+// blog-index.ts — jeromemarichez-fr
+// L'en-tête éditoriale de la liste d'articles. Les articles, eux, viennent d'articles.ts.
+
+import { ROUTES } from '@/@shared/routes'
+import type { IBlogIndex } from '@/interfaces/IBlogIndex'
+
+/**
+ * Le libellé « Blog » est repris à l'identique dans la navigation, le fil d'Ariane, le
+ * titre de la page et l'URL. Un nom plus éditorial aurait mieux sonné, mais il aurait
+ * forcé le visiteur à faire le lien lui-même entre quatre formulations du même endroit.
+ */
+export const BLOG_INDEX: IBlogIndex = {
+  route: ROUTES.blog,
+  titre: 'Blog',
+  meta: {
+    title: 'Blog — notes d’ingénierie, de data et de mesure',
+    description:
+      'Notes courtes sur des décisions techniques réelles : ce que j’ai tranché, sur quel ' +
+      'critère, et ce que ça a coûté. Ni veille, ni tutoriel.',
+  },
+  chapo:
+    'Des notes courtes sur des décisions réelles : ce que j’ai tranché, sur quel critère, ' +
+    'et ce que ça a coûté. Pas de veille, pas de tutoriel — ce que je ne pratique pas ' +
+    'moi-même n’a rien à faire ici.',
+}

--- a/src/@vitrine/contenu/blog/export-statique.ts
+++ b/src/@vitrine/contenu/blog/export-statique.ts
@@ -1,0 +1,69 @@
+// export-statique.ts — jeromemarichez-fr
+// Article — pourquoi ce site est un export statique.
+//
+// Véracité (CLAUDE.md) : tout ce qui est affirmé ici est vérifiable dans ce dépôt —
+// `output: 'export'` et `trailingSlash` dans next.config.mjs, l'absence de route API,
+// le mailto du pied de page. Aucun chiffre de performance n'est revendiqué pour ce
+// site : la cible est annoncée comme une cible, pas comme un résultat mesuré.
+
+import type { IArticle } from '@/interfaces/IArticle'
+
+export const ARTICLE_EXPORT_STATIQUE: IArticle = {
+  slug: 'pourquoi-ce-site-est-un-export-statique',
+  titre: 'Pourquoi ce site est un export statique',
+  chapo:
+    'Ce site ne tourne sur aucun serveur applicatif : la commande de build écrit des ' +
+    'fichiers, et un serveur de fichiers les sert. C’est un arbitrage, pas un réglage — ' +
+    'il ferme des portes, et je préfère dire lesquelles.',
+  meta: {
+    title: 'Pourquoi ce site est un export statique',
+    description:
+      'L’arbitrage derrière l’export statique de ce site : ce qu’il ferme (routes API, ' +
+      'ISR, formulaire), ce qu’il ouvre, et quand il ne faut pas le choisir.',
+  },
+  datePublication: '2026-08-21',
+  sections: [
+    {
+      id: 'ce-que-ca-ferme',
+      titre: 'Ce que ça ferme',
+      paragraphes: [
+        'Le build ne produit pas un serveur, il produit un dossier. Conséquence immédiate : ' +
+          'plus de route API, plus de rendu à la requête, plus d’action serveur, plus ' +
+          'd’optimiseur d’images à la volée. Ce ne sont pas des options désactivées quelque ' +
+          'part, ce sont des capacités que le site n’a plus.',
+        'La première victime est le formulaire de contact. Il aurait fallu un service tiers ' +
+          'ou un back séparé pour recevoir un message ; j’ai préféré une adresse en clair, qui ' +
+          'arrive directement chez la personne qui fera le travail. C’est cohérent avec ce que ' +
+          'le site vend, et c’est une capacité en moins à exploiter.',
+      ],
+    },
+    {
+      id: 'ce-que-ca-ouvre',
+      titre: 'Ce que ça ouvre',
+      paragraphes: [
+        'Un site en fichiers plats se déplace : il tient derrière n’importe quel serveur ' +
+          'statique, il n’a ni processus à surveiller ni dépendance à mettre à jour en urgence, ' +
+          'et sa surface d’attaque se réduit à ce qui est servi. La cible de performance et ' +
+          'd’accessibilité que je m’impose ici devient tenable sans acrobatie de cache.',
+        'Il y a une contrepartie de rigueur : chaque page doit déclarer elle-même son adresse ' +
+          'canonique et ses données structurées, parce qu’aucun serveur ne viendra les corriger ' +
+          'après coup. Une URL fausse dans un export statique reste fausse jusqu’au prochain ' +
+          'build.',
+      ],
+    },
+    {
+      id: 'quand-ne-pas-le-choisir',
+      titre: 'Quand ne pas le choisir',
+      paragraphes: [
+        'Dès qu’un contenu dépend de qui regarde, ou qu’il change plusieurs fois par jour, ' +
+          'l’export statique cesse d’être le bon outil : espace client, panier, tableau de bord, ' +
+          'catalogue alimenté par un stock en direct. Le rendre statique quand même se paie en ' +
+          'contournements, et les contournements se paient en incidents.',
+        'La question à trancher n’est donc pas « statique ou dynamique » mais : qu’est-ce qui, ' +
+          'sur ce site, change à quelle fréquence et pour qui ? La réponse décide de la ' +
+          'stratégie de rendu, page par page — et elle peut très bien être différente d’une ' +
+          'page à l’autre du même produit.',
+      ],
+    },
+  ],
+}

--- a/src/@vitrine/contenu/blog/mesurer-avant-arbitrer.ts
+++ b/src/@vitrine/contenu/blog/mesurer-avant-arbitrer.ts
@@ -1,0 +1,71 @@
+// mesurer-avant-arbitrer.ts — jeromemarichez-fr
+// Article — mesurer avant d'arbitrer.
+//
+// Véracité (CLAUDE.md) : régies citées limitées à Google Ads et Bing Ads ; outillage de
+// mesure limité à GTM (web et server-side), Measurement Protocol, GA, Matomo et CMP.
+// Les deux chiffres cités sont repris des preuves du site, avec leur contexte exact :
+// +50 % de panier moyen (Verhoeven Joaillier, A/B testing et heatmaps — pas de GTM sur
+// cette période) et 100 000 € de budget piloté (Truffle Capital, 2017-2019).
+
+import type { IArticle } from '@/interfaces/IArticle'
+
+export const ARTICLE_MESURER_AVANT_ARBITRER: IArticle = {
+  slug: 'mesurer-avant-d-arbitrer',
+  titre: 'Mesurer avant d’arbitrer',
+  chapo:
+    'Couper un budget d’acquisition ou supprimer une étape de tunnel, c’est une décision ' +
+    'de dirigeant. Elle ne vaut que ce que vaut le chiffre sur lequel elle s’appuie — et ' +
+    'ce chiffre se construit dans le code, bien avant le tableau de bord.',
+  meta: {
+    title: 'Mesurer avant d’arbitrer',
+    description:
+      'Une donnée d’acquisition ne vaut que ce que vaut sa collecte : mesure construite ' +
+      'dans le code, consentement conforme, et décisions prises sur un chiffre tenable.',
+  },
+  datePublication: '2026-08-14',
+  sections: [
+    {
+      id: 'la-collecte-avant-le-tableau-de-bord',
+      titre: 'La collecte avant le tableau de bord',
+      paragraphes: [
+        'Un rapport bien présenté ne dit rien de la qualité de ce qu’il agrège. Avant de ' +
+          'regarder une courbe, il faut savoir ce qui est envoyé, depuis où, avec quelle clé ' +
+          'd’identification, et ce qui se perd en route — bloqueurs, navigations abandonnées, ' +
+          'événements dupliqués.',
+        'C’est la raison pour laquelle je pose la mesure dans le code plutôt qu’à côté : ' +
+          'balisage serveur quand la fiabilité l’exige, envoi direct côté serveur pour les ' +
+          'événements qui comptent vraiment, et un plan de marquage écrit avant la première ' +
+          'implémentation. Une mesure ajoutée après coup mesure ce qu’elle peut, pas ce qu’on ' +
+          'voulait savoir.',
+      ],
+    },
+    {
+      id: 'le-consentement',
+      titre: 'Le consentement n’est pas une formalité de fin de projet',
+      paragraphes: [
+        'Le consentement change ce que la donnée contient, donc ce qu’on a le droit d’en ' +
+          'conclure. Un dispositif conforme se conçoit avec la mesure, pas après : quels ' +
+          'événements partent sans consentement, ce qui reste anonyme, ce qui est reconstitué ' +
+          'et ce qui est simplement perdu — et assumé comme tel.',
+        'Traiter le sujet à la fin donne toujours le même résultat : une bannière posée sur ' +
+          'un dispositif qui n’a pas été pensé pour elle, des rapports qui bougent sans qu’on ' +
+          'sache pourquoi, et une conformité qui tient sur une capture d’écran.',
+      ],
+    },
+    {
+      id: 'decider',
+      titre: 'Décider : couper, garder, réallouer',
+      paragraphes: [
+        'Quand la collecte est saine, l’arbitrage devient possible : quelle source ' +
+          'd’acquisition s’arrête le mois prochain, quelle étape de parcours disparaît, quel ' +
+          'segment de clients justifie qu’on dépense davantage pour l’atteindre. Le coût par ' +
+          'clic n’est pas la question ; ce que rapporte un client dans la durée, si.',
+        'Deux repères de mon parcours : un budget publicitaire et de référencement de ' +
+          '100 000 €, piloté et justifié devant des dirigeants ; et une refonte de parcours ' +
+          'd’achat menée à la mesure — tests A/B, cartes de chaleur, taux de rebond — qui a ' +
+          'fait progresser le panier moyen de 50 %. Dans les deux cas, la décision a suivi le ' +
+          'chiffre, et c’est la même personne qui l’a ensuite implémentée.',
+      ],
+    },
+  ],
+}

--- a/src/@vitrine/contenu/blog/test-avant-code.ts
+++ b/src/@vitrine/contenu/blog/test-avant-code.ts
@@ -1,0 +1,79 @@
+// test-avant-code.ts — jeromemarichez-fr
+// Article — le test avant le code, même avec un agent.
+//
+// Véracité (CLAUDE.md) : le développement en IA augmentée piloté par les tests est un
+// différenciateur assumé du site, et l'outillage cité (Jest, Cypress, Stryker, hooks,
+// agents, serveurs MCP) est celui de ce dépôt. La certification citée est ISTQB
+// Foundation — le niveau Avancé n'est pas obtenu et n'est pas mentionné.
+
+import type { IArticle } from '@/interfaces/IArticle'
+
+export const ARTICLE_TEST_AVANT_CODE: IArticle = {
+  slug: 'le-test-avant-le-code-meme-avec-un-agent',
+  titre: 'Le test avant le code, même avec un agent',
+  chapo:
+    'Faire écrire du code par une IA ne change pas la question : qu’est-ce qui prouve que ' +
+    'ce code fait ce qu’on attend ? Ça la rend plus pressante, parce que le volume produit ' +
+    'ne laisse plus le temps de relire ligne à ligne.',
+  meta: {
+    title: 'Le test avant le code, même avec un agent',
+    description:
+      'Développement en IA augmentée piloté par les tests : pourquoi le test s’écrit ' +
+      'avant, ce que les tests de mutation vérifient, et ce que ça change côté client.',
+  },
+  datePublication: '2026-08-18',
+  sections: [
+    {
+      id: 'le-volume-est-le-probleme',
+      titre: 'Le volume est le problème',
+      paragraphes: [
+        'Un agent produit en quelques minutes ce qui prenait une journée. La revue humaine, ' +
+          'elle, n’a pas accéléré. Si rien ne change dans la méthode, on relit de moins en ' +
+          'moins bien un code de plus en plus abondant, et on finit par valider sur ' +
+          'l’apparence : ça compile, ça ressemble à du code correct, donc on passe.',
+        'Le piège n’est pas que l’IA se trompe — un développeur aussi. Le piège est qu’elle se ' +
+          'trompe vite, de façon plausible, et à grande échelle.',
+      ],
+    },
+    {
+      id: 'le-test-en-premier',
+      titre: 'Le test en premier, et il n’est pas écrit par l’agent',
+      paragraphes: [
+        'Le comportement attendu s’écrit avant l’implémentation, avec ses cas limites et son ' +
+          'jeu de données. L’agent code ensuite pour le satisfaire. L’ordre n’est pas un rituel : ' +
+          'un test écrit après coup décrit ce que le code fait, pas ce qu’on voulait qu’il fasse, ' +
+          'et il valide donc aussi les erreurs.',
+        'Sur ce dépôt, la règle est outillée : des hooks refusent qu’un fichier de test soit ' +
+          'posé par l’assistant, refusent qu’une doublure de module remplace un vrai service, et ' +
+          'demandent confirmation dès qu’un fichier source apparaît sans test qui le couvre. ' +
+          'Une règle qu’aucun outil ne fait respecter n’est qu’une intention.',
+      ],
+    },
+    {
+      id: 'ce-qui-verifie-les-tests',
+      titre: 'Et ce qui vérifie les tests',
+      paragraphes: [
+        'Reste une question que la couverture ne répond pas : est-ce que ces tests détectent ' +
+          'quelque chose ? Les tests de mutation modifient volontairement le code — inverser une ' +
+          'condition, supprimer un appel — et regardent si la suite passe encore. Quand elle ' +
+          'passe, le test traversait la ligne sans rien vérifier.',
+        'C’est l’outil qui manque le plus souvent sur une base largement générée : elle est ' +
+          'couverte au sens du pourcentage, et démunie au sens de la détection. Jest et Cypress ' +
+          'disent que le code tourne ; Stryker dit si les tests valent quelque chose.',
+      ],
+    },
+    {
+      id: 'ce-que-vous-tranchez',
+      titre: 'Ce que ça change côté client',
+      paragraphes: [
+        'La bonne question à poser à un prestataire n’est plus « utilisez-vous l’IA ? » — la ' +
+          'réponse est oui presque partout, et elle n’engage à rien. Elle est : qu’est-ce qui ' +
+          'rattrape une erreur produite par cette IA avant qu’elle arrive en production, et qui ' +
+          'en répond ?',
+        'La décision qui vous revient est celle du filet : ce que vous acceptez de faire ' +
+          'produire par une machine, et le niveau de preuve exigé en dessous. Elle se prend ' +
+          'avant le premier fichier, pas au premier incident.',
+      ],
+    },
+  ],
+}

--- a/src/@vitrine/services/find-article.ts
+++ b/src/@vitrine/services/find-article.ts
@@ -1,0 +1,56 @@
+// find-article.ts — jeromemarichez-fr
+// Les règles qui s'appliquent à la liste des articles : ordre, recherche, date qui fait foi.
+//
+// Le contenu (`contenu/blog/articles.ts`) ne porte aucune de ces règles : il déclare des
+// articles dans l'ordre où ils ont été écrits. Tout ce qui relève d'une décision — quel
+// article passe devant, lequel on propose ensuite, quelle date publier — est ici.
+
+import type { IArticle } from '@/interfaces/IArticle'
+import { ARTICLES } from '../contenu/blog/articles'
+
+/**
+ * Nombre d'articles proposés au pied d'un article.
+ *
+ * Deux, et pas la liste entière : au-delà, la fin d'un article devient un sommaire et
+ * cesse d'être une suite de lecture. Le lien vers la liste complète reste à côté.
+ */
+export const MAX_ARTICLES_LIES = 2
+
+/**
+ * Date qui fait foi pour un article : sa révision si elle existe, sa publication sinon.
+ *
+ * Le sitemap et le JSON-LD doivent dire la même date, sans quoi un moteur voit une page
+ * modifiée qui ne se déclare pas modifiée. La règle est donc écrite une fois ici plutôt
+ * que recopiée à chaque appelant.
+ */
+export function articleRevisionDate(article: IArticle): string {
+  return article.dateRevision ?? article.datePublication
+}
+
+/**
+ * Les articles, du plus récent au plus ancien.
+ *
+ * Le tri porte sur la date de **publication**, pas sur la révision : corriger un vieil
+ * article ne doit pas le remettre en tête de liste comme s'il était neuf.
+ */
+export function listArticles(): IArticle[] {
+  return [...ARTICLES].sort((a, b) => b.datePublication.localeCompare(a.datePublication))
+}
+
+/**
+ * Rend l'article demandé et jusqu'à deux autres à lire ensuite.
+ *
+ * Lève sur un slug inconnu, volontairement : les slugs servis sont énumérés au build par
+ * `generateStaticParams`, donc un slug absent ici est une incohérence de code, pas une
+ * URL saisie par un visiteur. La masquer produirait une page vide en production.
+ */
+export function findArticle(slug: string): { article: IArticle; autres: IArticle[] } {
+  const articles = listArticles()
+  const article = articles.find((candidat) => candidat.slug === slug)
+
+  if (!article) throw new Error(`Article inconnu : ${slug}`)
+
+  const autres = articles.filter((candidat) => candidat.slug !== slug).slice(0, MAX_ARTICLES_LIES)
+
+  return { article, autres }
+}

--- a/src/@vitrine/views/ArticleView/article-view.module.css
+++ b/src/@vitrine/views/ArticleView/article-view.module.css
@@ -1,0 +1,100 @@
+/* article-view.module.css — un article.
+ * La seule page du site qui se lit en continu : tout y est réglé sur la longueur de
+ * ligne, y compris les titres. */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-6);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-6) var(--e-4) var(--e-7);
+}
+
+.article {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+}
+
+.entete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+}
+
+.date {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.06em;
+  color: var(--encre-douce);
+}
+
+.titre {
+  margin: 0;
+  max-width: 24ch;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-family: var(--police-titre-pile);
+  font-variation-settings: "opsz" 24;
+  font-size: var(--t-2);
+  line-height: 1.35;
+  color: var(--cuivre);
+}
+
+.corps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+}
+
+.sousTitre {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-2);
+  line-height: 1.25;
+}
+
+.paragraphe {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-0);
+  line-height: 1.65;
+}
+
+.ensuite {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+  padding-top: var(--e-5);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+}
+
+.titreEnsuite {
+  margin: 0;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--encre-douce);
+}
+
+.liste {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.retour {
+  font-size: 0.9375rem;
+}

--- a/src/@vitrine/views/ArticleView/index.tsx
+++ b/src/@vitrine/views/ArticleView/index.tsx
@@ -1,0 +1,86 @@
+// ArticleView/index.tsx — jeromemarichez-fr
+// Un article : son en-tête daté, son corps, et ce qu'on lit ensuite.
+
+import Link from 'next/link'
+import { Breadcrumb } from '@/@shared/components/Breadcrumb'
+import { toArticleRoute } from '@/@shared/routes'
+import type { IArticle } from '@/interfaces/IArticle'
+import type { IBlogIndex } from '@/interfaces/IBlogIndex'
+import { formatDateFr } from '@/utils/format-date'
+import { ArticleCard } from '../../components/ArticleCard'
+import styles from './article-view.module.css'
+
+interface ArticleViewProps {
+  article: IArticle
+  index: IBlogIndex
+  /** Articles proposés en fin de lecture. Choisis par le service, pas par la vue. */
+  autres: IArticle[]
+}
+
+/**
+ * Une seule colonne, mesurée à `--mesure-texte`.
+ *
+ * C'est la seule page du site dont le contenu se lit en continu plutôt qu'en blocs : la
+ * largeur de ligne y devient le premier facteur de lisibilité, avant toute décoration.
+ * Aucun panneau de verre non plus — l'effet sert à distinguer des offres, pas à habiller
+ * un texte suivi.
+ */
+export function ArticleView({ article, index, autres }: ArticleViewProps) {
+  return (
+    <div className={styles.page}>
+      <article className={styles.article}>
+        <header className={styles.entete}>
+          <Breadcrumb
+            fil={[
+              { nom: index.titre, route: index.route },
+              { nom: article.titre, route: toArticleRoute(article.slug) },
+            ]}
+          />
+          <p className={styles.date}>
+            <time dateTime={article.datePublication}>{formatDateFr(article.datePublication)}</time>
+          </p>
+          <h1 className={styles.titre}>{article.titre}</h1>
+          <p className={styles.chapo}>{article.chapo}</p>
+        </header>
+
+        <div className={styles.corps}>
+          {article.sections.map((section) => (
+            <section
+              aria-labelledby={`${section.id}-titre`}
+              className={styles.section}
+              id={section.id}
+              key={section.id}
+            >
+              <h2 className={styles.sousTitre} id={`${section.id}-titre`}>
+                {section.titre}
+              </h2>
+              {section.paragraphes.map((paragraphe) => (
+                <p className={styles.paragraphe} key={paragraphe}>
+                  {paragraphe}
+                </p>
+              ))}
+            </section>
+          ))}
+        </div>
+      </article>
+
+      {autres.length > 0 ? (
+        <aside aria-labelledby="a-lire-ensuite" className={styles.ensuite}>
+          <h2 className={styles.titreEnsuite} id="a-lire-ensuite">
+            À lire ensuite
+          </h2>
+          <ol className={styles.liste}>
+            {autres.map((autre) => (
+              <li key={autre.slug}>
+                <ArticleCard article={autre} headingLevel="h3" />
+              </li>
+            ))}
+          </ol>
+          <p className={styles.retour}>
+            <Link href={index.route}>Tous les articles</Link>
+          </p>
+        </aside>
+      ) : null}
+    </div>
+  )
+}

--- a/src/@vitrine/views/BlogIndexView/blog-index-view.module.css
+++ b/src/@vitrine/views/BlogIndexView/blog-index-view.module.css
@@ -1,0 +1,36 @@
+/* blog-index-view.module.css — la liste des articles. */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-6) var(--e-4) var(--e-7);
+}
+
+.entete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+}
+
+.titre {
+  margin: 0;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+.liste {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}

--- a/src/@vitrine/views/BlogIndexView/index.tsx
+++ b/src/@vitrine/views/BlogIndexView/index.tsx
@@ -1,0 +1,41 @@
+// BlogIndexView/index.tsx — jeromemarichez-fr
+// La liste des articles.
+
+import { Breadcrumb } from '@/@shared/components/Breadcrumb'
+import type { IArticle } from '@/interfaces/IArticle'
+import type { IBlogIndex } from '@/interfaces/IBlogIndex'
+import { ArticleCard } from '../../components/ArticleCard'
+import styles from './blog-index-view.module.css'
+
+interface BlogIndexViewProps {
+  index: IBlogIndex
+  /** Articles déjà classés par le service : la vue n'ordonne rien. */
+  articles: IArticle[]
+}
+
+/**
+ * Une liste, pas une grille.
+ *
+ * Le blog n'a ni vignettes ni catégories, et une mise en page de magazine promettrait
+ * les deux. Une colonne de titres datés dit ce qu'est cet endroit : quelques notes, lues
+ * de la plus récente à la plus ancienne.
+ */
+export function BlogIndexView({ index, articles }: BlogIndexViewProps) {
+  return (
+    <div className={styles.page}>
+      <header className={styles.entete}>
+        <Breadcrumb fil={[{ nom: index.titre, route: index.route }]} />
+        <h1 className={styles.titre}>{index.titre}</h1>
+        <p className={styles.chapo}>{index.chapo}</p>
+      </header>
+
+      <ol className={styles.liste}>
+        {articles.map((article) => (
+          <li key={article.slug}>
+            <ArticleCard article={article} />
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,72 @@
+// src/app/blog/[slug]/page.tsx — jeromemarichez-fr
+// Routage seul : l'article est composé dans src/@vitrine/views/ArticleView.
+
+import type { Metadata } from 'next'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { toArticleRoute } from '@/@shared/routes'
+import { buildArticleMetadata } from '@/@shared/seo/page-metadata'
+import { buildArticleSchema, buildBreadcrumbSchema } from '@/@shared/seo/structured-data'
+import { BLOG_INDEX } from '@/@vitrine/contenu/blog/blog-index'
+import { articleRevisionDate, findArticle, listArticles } from '@/@vitrine/services/find-article'
+import { ArticleView } from '@/@vitrine/views/ArticleView'
+
+interface ArticlePageProps {
+  params: Promise<{ slug: string }>
+}
+
+/**
+ * Obligatoire sous `output: 'export'` : sans cette liste, le build n'a aucune page à
+ * écrire pour ce segment et il échoue. Elle est dérivée des articles, jamais tenue à la
+ * main — un article publié devient une page servie sans autre geste.
+ */
+export function generateStaticParams(): { slug: string }[] {
+  return listArticles().map((article) => ({ slug: article.slug }))
+}
+
+/**
+ * Aucune URL hors de cette liste n'est servie. C'est déjà la conséquence de l'export
+ * statique ; l'écrire noir sur blanc évite qu'un futur passage au rendu serveur ouvre
+ * silencieusement `/blog/<n-importe-quoi>` sur une page générée à la volée.
+ */
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: ArticlePageProps): Promise<Metadata> {
+  const { slug } = await params
+  const { article } = findArticle(slug)
+
+  return buildArticleMetadata({
+    meta: article.meta,
+    route: toArticleRoute(article.slug),
+    datePublished: article.datePublication,
+    dateModified: articleRevisionDate(article),
+  })
+}
+
+export default async function ArticlePage({ params }: ArticlePageProps) {
+  const { slug } = await params
+  const { article, autres } = findArticle(slug)
+  // Une seule dérivation de la route, partagée par le JSON-LD et le fil d'Ariane : c'est
+  // ce qui garantit qu'ils désignent la page réellement servie.
+  const route = toArticleRoute(article.slug)
+
+  return (
+    <>
+      <ArticleView article={article} autres={autres} index={BLOG_INDEX} />
+      <StructuredData
+        schemas={[
+          buildArticleSchema({
+            titre: article.titre,
+            chapo: article.chapo,
+            route,
+            datePublished: article.datePublication,
+            dateModified: articleRevisionDate(article),
+          }),
+          buildBreadcrumbSchema([
+            { nom: BLOG_INDEX.titre, route: BLOG_INDEX.route },
+            { nom: article.titre, route },
+          ]),
+        ]}
+      />
+    </>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,37 @@
+// src/app/blog/page.tsx — jeromemarichez-fr
+// Routage seul : la liste est composée dans src/@vitrine/views/BlogIndexView.
+
+import type { Metadata } from 'next'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { toArticleRoute } from '@/@shared/routes'
+import { buildPageMetadata } from '@/@shared/seo/page-metadata'
+import { buildBlogSchema, buildBreadcrumbSchema } from '@/@shared/seo/structured-data'
+import { BLOG_INDEX } from '@/@vitrine/contenu/blog/blog-index'
+import { listArticles } from '@/@vitrine/services/find-article'
+import { BlogIndexView } from '@/@vitrine/views/BlogIndexView'
+
+export const metadata: Metadata = buildPageMetadata(BLOG_INDEX)
+
+export default function BlogPage() {
+  const articles = listArticles()
+
+  return (
+    <>
+      <BlogIndexView articles={articles} index={BLOG_INDEX} />
+      <StructuredData
+        schemas={[
+          buildBlogSchema({
+            nom: BLOG_INDEX.titre,
+            description: BLOG_INDEX.meta.description,
+            route: BLOG_INDEX.route,
+            articles: articles.map((article) => ({
+              titre: article.titre,
+              route: toArticleRoute(article.slug),
+            })),
+          }),
+          buildBreadcrumbSchema([{ nom: BLOG_INDEX.titre, route: BLOG_INDEX.route }]),
+        ]}
+      />
+    </>
+  )
+}

--- a/src/app/services/data-ia/page.tsx
+++ b/src/app/services/data-ia/page.tsx
@@ -24,7 +24,7 @@ export default function PolePage() {
             description: PAGE_DATA_IA.meta.description,
             route: pole.route,
           }),
-          buildBreadcrumbSchema({ nom: pole.nom, route: pole.route }),
+          buildBreadcrumbSchema([{ nom: pole.nom, route: pole.route }]),
         ]}
       />
     </>

--- a/src/app/services/ingenierie-web/page.tsx
+++ b/src/app/services/ingenierie-web/page.tsx
@@ -24,7 +24,7 @@ export default function PolePage() {
             description: PAGE_INGENIERIE_WEB.meta.description,
             route: pole.route,
           }),
-          buildBreadcrumbSchema({ nom: pole.nom, route: pole.route }),
+          buildBreadcrumbSchema([{ nom: pole.nom, route: pole.route }]),
         ]}
       />
     </>

--- a/src/app/services/sea-ux/page.tsx
+++ b/src/app/services/sea-ux/page.tsx
@@ -24,7 +24,7 @@ export default function PolePage() {
             description: PAGE_SEA_UX.meta.description,
             route: pole.route,
           }),
-          buildBreadcrumbSchema({ nom: pole.nom, route: pole.route }),
+          buildBreadcrumbSchema([{ nom: pole.nom, route: pole.route }]),
         ]}
       />
     </>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,10 +1,8 @@
 // sitemap.ts — jeromemarichez-fr
-// Sitemap généré à partir de la liste des routes, jamais tenu à la main.
+// Sitemap généré à partir des routes et des articles, jamais tenu à la main.
 
 import type { MetadataRoute } from 'next'
-import { INDEXABLE_ROUTES } from '@/@shared/routes'
-import { SITE_DERNIERE_REVISION } from '@/@shared/seo/site'
-import { toAbsoluteUrl } from '@/@shared/seo/urls'
+import { buildSitemapEntries } from '@/@shared/seo/sitemap-entries'
 
 // `output: 'export'` exige que les routes de métadonnées soient déclarées statiques.
 export const dynamic = 'force-static'
@@ -13,10 +11,10 @@ export const dynamic = 'force-static'
  * Seul `lastModified` est renseigné. Google ignore `changeFrequency` et `priority`
  * depuis 2023 : les garder reviendrait à publier des champs que personne ne lit, en
  * laissant croire qu'ils pilotent le passage du robot.
+ *
+ * La composition des entrées — quelles URL, avec quelle date — vit dans
+ * `@shared/seo/sitemap-entries`, où elle se vérifie sans démarrer Next.
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  return INDEXABLE_ROUTES.map((route) => ({
-    url: toAbsoluteUrl(route),
-    lastModified: SITE_DERNIERE_REVISION,
-  }))
+  return buildSitemapEntries()
 }

--- a/src/interfaces/IArticle.ts
+++ b/src/interfaces/IArticle.ts
@@ -1,0 +1,40 @@
+// IArticle.ts — jeromemarichez-fr
+// Un article du blog : le seul contenu du site dont la date compte.
+//
+// Le contenu est versionné en TypeScript, comme le reste du site (docs/architecture.md).
+// Ce n'est donc **pas** une entrée externe et il n'est pas validé par Zod : la seule
+// frontière que le blog franchit est le `slug` d'URL, et il est confronté à cette liste
+// close au build par `generateStaticParams`, pas à un schéma.
+
+import type { IArticleSection } from './IArticleSection'
+import type { IPageMeta } from './IEditorialPage'
+
+/**
+ * Un article publié.
+ *
+ * `slug` est l'identité durable de l'article : il fait l'URL, la clé de recherche et
+ * l'ancre du JSON-LD. Le changer casse les liens entrants et l'historique de position
+ * dans les moteurs — un titre se corrige, un slug ne se corrige pas.
+ */
+export interface IArticle {
+  /** Identifiant kebab-case, dernier segment de l'URL (`/blog/<slug>/`). Immuable. */
+  slug: string
+  /** Titre affiché, `<h1>` de la page. */
+  titre: string
+  /** Chapô, 2 à 3 phrases. Sert aussi de résumé sur la liste et dans le JSON-LD. */
+  chapo: string
+  /** Métadonnées SEO propres à l'article. */
+  meta: IPageMeta
+  /** Date de première publication, au format `AAAA-MM-JJ`. */
+  datePublication: string
+  /**
+   * Date de dernière révision de fond, au format `AAAA-MM-JJ`.
+   *
+   * Absente tant que l'article n'a pas été retouché : sans ce champ, le `lastModified`
+   * du sitemap resterait figé sur la publication et deviendrait faux à la première
+   * correction. Une révision de forme (coquille) ne la déplace pas.
+   */
+  dateRevision?: string
+  /** Corps de l'article, découpé en sections titrées. */
+  sections: IArticleSection[]
+}

--- a/src/interfaces/IArticleSection.ts
+++ b/src/interfaces/IArticleSection.ts
@@ -1,0 +1,20 @@
+// IArticleSection.ts — jeromemarichez-fr
+// Une section d'article : un titre et ses paragraphes.
+
+/**
+ * Section du corps d'un article.
+ *
+ * Volontairement pauvre : un titre, des paragraphes. Un article du site n'est pas un
+ * gabarit de page — lui donner des blocs, des encarts et des niveaux de titre libres
+ * reviendrait à réinventer un éditeur, et à ouvrir la porte à des articles qui ne se
+ * ressemblent plus. Le jour où un article demande davantage, c'est le modèle qu'on
+ * élargit, pas le rendu qu'on contourne.
+ */
+export interface IArticleSection {
+  /** Identifiant kebab-case, sert d'ancre (`#id`) et de cible aux liens profonds. */
+  id: string
+  /** Titre de la section, rendu en `<h2>`. */
+  titre: string
+  /** Paragraphes de la section. Texte fini, publiable tel quel. */
+  paragraphes: string[]
+}

--- a/src/interfaces/IBlogIndex.ts
+++ b/src/interfaces/IBlogIndex.ts
@@ -1,0 +1,21 @@
+// IBlogIndex.ts — jeromemarichez-fr
+// L'en-tête éditoriale de la liste d'articles.
+
+import type { IPageMeta } from './IEditorialPage'
+
+/**
+ * La page de liste du blog, hors articles.
+ *
+ * Elle n'est pas un `IEditorialPage` : celui-ci porte des sections rédigées, alors que
+ * la liste ne porte qu'une accroche et se remplit toute seule à partir des articles.
+ * Les confondre aurait obligé à inventer des sections vides pour satisfaire le type.
+ */
+export interface IBlogIndex {
+  /** Route servie par la liste. */
+  route: string
+  meta: IPageMeta
+  /** Titre affiché, `<h1>`. Sert aussi de libellé au fil d'Ariane des articles. */
+  titre: string
+  /** Chapô, 2 à 3 phrases : ce qu'on trouve ici, et ce qu'on n'y trouve pas. */
+  chapo: string
+}

--- a/src/interfaces/IBreadcrumbItem.ts
+++ b/src/interfaces/IBreadcrumbItem.ts
@@ -1,0 +1,16 @@
+// IBreadcrumbItem.ts — jeromemarichez-fr
+// Un niveau de fil d'Ariane, vu à la fois par le rendu et par le JSON-LD.
+
+/**
+ * Un niveau du fil d'Ariane.
+ *
+ * La même structure alimente le fil visible et le `BreadcrumbList` de schema.org. C'est
+ * le point : un fil affiché qui ne dit pas la même chose que celui déclaré aux moteurs
+ * est une incohérence que Google sanctionne, et elle ne se voit pas à l'œil nu.
+ */
+export interface IBreadcrumbItem {
+  /** Libellé affiché, repris tel quel dans le JSON-LD. */
+  nom: string
+  /** Route interne du niveau. */
+  route: string
+}

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -1,0 +1,23 @@
+// format-date.ts — jeromemarichez-fr
+// Une date `AAAA-MM-JJ` rendue lisible en français.
+
+/**
+ * Formateur construit une seule fois : `Intl.DateTimeFormat` est coûteux à instancier
+ * et la liste d'articles l'appellerait à chaque ligne.
+ *
+ * `timeZone: 'UTC'` n'est pas un détail. Une chaîne `AAAA-MM-JJ` est interprétée comme
+ * minuit UTC ; la formater dans un fuseau situé à l'ouest de Greenwich afficherait la
+ * veille. Un article publié le 1er du mois passerait au mois précédent selon la machine
+ * qui construit le site.
+ */
+const FORMAT_FR = new Intl.DateTimeFormat('fr-FR', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'UTC',
+})
+
+/** Rend `2026-08-21` sous la forme `21 août 2026`. */
+export function formatDateFr(dateIso: string): string {
+  return FORMAT_FR.format(new Date(`${dateIso}T00:00:00Z`))
+}

--- a/tests/fixtures/article.fixture.json
+++ b/tests/fixtures/article.fixture.json
@@ -1,0 +1,93 @@
+{
+  "_lisezmoi": "Jeu de données d'articles (jeromemarichez-fr) — PAS un mock. Les vrais services (find-article, buildSitemapEntries, buildArticleSchema, formatDateFr) tournent sur ces articles réalistes ; aucune doublure de module n'est utilisée. Voir docs/testing.md et docs/data-model.md.",
+  "_cas": {
+    "articles": "Trois articles dans un ordre de déclaration volontairement différent de l'ordre chronologique : le plus récent est déclaré en deuxième position. Un tri absent ou inversé se voit immédiatement.",
+    "articleRevise": "Porte une dateRevision postérieure à sa publication — c'est la date que le sitemap et dateModified doivent publier, alors que le tri de la liste doit continuer à s'appuyer sur datePublication.",
+    "articleSeul": "Liste réduite à un article : findArticle doit rendre un tableau 'autres' vide, et la page ne propose alors aucune suite de lecture.",
+    "slugInconnu": "Slug absent de la liste : findArticle doit lever, jamais rendre undefined."
+  },
+  "articles": [
+    {
+      "slug": "premier-article",
+      "titre": "Premier article",
+      "chapo": "Le plus ancien des trois. Il ferme la liste quel que soit l'ordre de déclaration.",
+      "meta": {
+        "title": "Premier article",
+        "description": "Article de jeu de données, publié le 3 mars 2026."
+      },
+      "datePublication": "2026-03-03",
+      "sections": [
+        {
+          "id": "une-section",
+          "titre": "Une section",
+          "paragraphes": ["Un premier paragraphe.", "Un second paragraphe."]
+        }
+      ]
+    },
+    {
+      "slug": "article-le-plus-recent",
+      "titre": "Article le plus récent",
+      "chapo": "Publié en dernier, déclaré en deuxième : c'est lui qui doit ouvrir la liste.",
+      "meta": {
+        "title": "Article le plus récent",
+        "description": "Article de jeu de données, publié le 1er septembre 2026."
+      },
+      "datePublication": "2026-09-01",
+      "sections": [
+        {
+          "id": "une-section",
+          "titre": "Une section",
+          "paragraphes": ["Un paragraphe."]
+        },
+        {
+          "id": "une-autre-section",
+          "titre": "Une autre section",
+          "paragraphes": ["Un paragraphe.", "Un autre paragraphe."]
+        }
+      ]
+    },
+    {
+      "slug": "article-revise",
+      "titre": "Article révisé",
+      "chapo": "Publié entre les deux autres, révisé après. Le tri ne doit pas le remonter.",
+      "meta": {
+        "title": "Article révisé",
+        "description": "Article de jeu de données, publié le 12 juin 2026 et révisé le 20 août 2026."
+      },
+      "datePublication": "2026-06-12",
+      "dateRevision": "2026-08-20",
+      "sections": [
+        {
+          "id": "une-section",
+          "titre": "Une section",
+          "paragraphes": ["Un paragraphe."]
+        }
+      ]
+    }
+  ],
+  "articleSeul": [
+    {
+      "slug": "seul-article",
+      "titre": "Seul article",
+      "chapo": "Unique article de la liste : rien à proposer ensuite.",
+      "meta": {
+        "title": "Seul article",
+        "description": "Article de jeu de données, seul de sa liste."
+      },
+      "datePublication": "2026-01-15",
+      "sections": [
+        {
+          "id": "une-section",
+          "titre": "Une section",
+          "paragraphes": ["Un paragraphe."]
+        }
+      ]
+    }
+  ],
+  "slugInconnu": "article-qui-n-existe-pas",
+  "datesAFormater": [
+    { "iso": "2026-08-21", "attendu": "21 août 2026" },
+    { "iso": "2026-01-01", "attendu": "1 janvier 2026" },
+    { "iso": "2026-12-31", "attendu": "31 décembre 2026" }
+  ]
+}


### PR DESCRIPTION
Closes #46

Le site n'avait aucune section blog : ni route, ni contenu, ni composant, ni ligne dans l'arborescence du `README.md`. Cette PR crée `/blog` (liste) et `/blog/<slug>` (article).

## Routes produites

`make build` écrit bien chaque page dans `out/` :

```
out/blog/index.html
out/blog/pourquoi-ce-site-est-un-export-statique/index.html
out/blog/le-test-avant-le-code-meme-avec-un-agent/index.html
out/blog/mesurer-avant-d-arbitrer/index.html
```

Et le sitemap les référence, avec **une date par article** :

| URL | `lastmod` |
|-----|-----------|
| `/blog/` | `2026-08-21` (date de l'article le plus récent) |
| `/blog/pourquoi-ce-site-est-un-export-statique/` | `2026-08-21` |
| `/blog/le-test-avant-le-code-meme-avec-un-agent/` | `2026-08-18` |
| `/blog/mesurer-avant-d-arbitrer/` | `2026-08-14` |

Vérifié dans le HTML généré : `canonical` et `og:url` pointent la route réelle de chaque article, `og:type` passe à `article` avec `article:published_time`, le `BlogPosting` et le `BreadcrumbList` à trois niveaux (`Accueil → Blog → article`) sont bien émis, et le fil d'Ariane visible dit exactement la même chose.

## Arbitrages d'architecture

**`ROUTES` élargi au minimum.** `blog: '/blog'` est ajouté et l'union de clés du `satisfies` devient `Record<'accueil' | 'blog' | PoleId, string>`. Pas de type `RouteId` intermédiaire, pas de retouche de `POLE_ORDER` ni de `src/interfaces/types.ts` : ces fichiers évoluent par ailleurs, et cette PR ne prend que ce que l'issue exige. L'entrée `blog` est volontairement placée **avant** les pôles pour éloigner la modification de la zone où d'autres entrées viendront.

**`INDEXABLE_ROUTES` reste littérale.** Une URL d'article n'est pas une route du site mais une instance d'une seule route dynamique, et leur nombre change à chaque publication. La liste garde donc les routes **fixes** (elle gagne `/blog`), et c'est le sitemap qui compose : `@shared/seo/sitemap-entries` ajoute un article par publication avec sa date. Trois dates différentes, et c'est voulu — révision globale du site pour les pages éditoriales, date propre pour un article, date du dernier article pour `/blog`, parce que c'est exactement ce qui fait changer la liste.

**Fil d'Ariane généralisé, pas dupliqué.** `buildBreadcrumbSchema` prend désormais les niveaux **qui suivent** l'accueil ; celui-ci est un invariant du site, il est posé par la fonction et un appelant ne peut plus l'oublier. Le fil visible est extrait dans `@shared/components/Breadcrumb` et consomme la même liste que le JSON-LD : un fil affiché qui ne dit pas la même chose que celui déclaré aux moteurs est une incohérence qui ne se voit pas à l'œil nu. `PoleHero` le consomme à son tour, et le fil devient une `<ol>` — la hiérarchie est une information, elle doit exister pour un lecteur d'écran.

**Une seule fonction compose une URL d'article** (`toArticleRoute`). Liste, `canonical`, `og:url`, fil d'Ariane, JSON-LD et sitemap passent par elle. Dans un export statique, une URL canonique fausse reste fausse jusqu'au prochain build.

**Le blog n'est pas un quatrième pôle**, et la navigation le dit : bloc distinct dans l'en-tête (séparé de la liste numérotée par un filet), colonne « Le site » dans le pied de page. La liste des pôles n'est pas touchée.

**Pas de Zod sur le contenu.** Un fichier de contenu compilé avec le site n'est pas une entrée externe. La seule frontière est le `slug` d'URL, confronté à la liste close des articles par `generateStaticParams` — `dynamicParams = false` est écrit explicitement.

## Contenu

Trois **coquilles rédactionnelles courtes**, sur des sujets qui relèvent réellement du site. Les règles de véracité du `CLAUDE.md` ont été appliquées mot pour mot : régies limitées à Google Ads et Bing Ads, outillage de mesure limité à GTM / Measurement Protocol / GA / Matomo / CMP, ISTQB Foundation seule, aucun chiffre de performance revendiqué pour ce site, les deux chiffres cités repris des preuves existantes avec leur contexte exact. **Le contenu réel relève de Jérôme MARICHEZ.**

## Intention de test

**Aucun fichier de test n'a été écrit** (règle du projet). Le jeu de données est prêt : `tests/fixtures/article.fixture.json` — trois articles dont l'ordre de déclaration diffère volontairement de l'ordre chronologique, un article révisé, une liste à un seul article, un slug inconnu, et des dates à formater.

Candidats, tous **unitaires** sauf mention contraire :

| Cible | Comportement attendu | Cas limites |
|-------|---------------------|-------------|
| `listArticles()` | Classe par `datePublication` **décroissante** | L'article révisé (publication ancienne, révision récente) ne doit **pas** remonter en tête |
| `findArticle(slug)` | Rend l'article demandé et jusqu'à 2 autres, l'article courant exclu | Slug inconnu → **lève** ; liste à un seul article → `autres` vide |
| `articleRevisionDate(a)` | `dateRevision` si présente, `datePublication` sinon | Les deux branches |
| `generateStaticParams()` | Rend un `{ slug }` par article publié, sans doublon | Couvre bien **tous** les articles de la liste |
| `buildSitemapEntries()` | Contient les routes fixes, `/blog`, et un article par publication avec sa date | `/blog` porte la date du plus récent ; l'article révisé publie sa **révision** ; toutes les URL ont la barre finale |
| `buildArticleSchema()` | `@type: BlogPosting`, `@id`/`url`/`mainEntityOfPage` sur la route réelle, `datePublished` et `dateModified` | Aucun champ `image` inventé |
| `buildBreadcrumbSchema()` | `Accueil` en position 1 posé par la fonction, puis les niveaux fournis en 2, 3… | **Trois niveaux** ; un seul niveau (page de pôle) reste correct ; liste vide |
| `formatDateFr()` | `2026-08-21` → `21 août 2026` | Le 1er et le 31 du mois ne doivent pas glisser d'un jour selon le fuseau de la machine |
| `Breadcrumb` (RTL) | Le dernier niveau n'est **pas** un lien et porte `aria-current="page"` | Un seul niveau ; trois niveaux |

Un e2e Cypress `visiter un article depuis la liste` serait pertinent (parcours accueil → blog → article → retour à la liste) : à proposer à Jérôme MARICHEZ plutôt qu'à décider ici.

## Points laissés à Jérôme MARICHEZ

1. **Le contenu des trois articles** — ce sont des coquilles.
2. **La version dans `package.json`** n'est pas bumpée : cette PR vise `dev`, et le bump se fait dans la PR `dev → main` (c'est la pratique des PR précédentes).
3. **Défaut préexistant repéré, hors périmètre de cette issue** : les métadonnées d'une page étant *shallow-merged*, l'objet `openGraph` d'une page **remplace** celui du layout. Conséquence, vérifiable sur `main` : les pages de pôle (et maintenant celles du blog) n'ont **ni `og:site_name`, ni `og:locale`, ni `og:image`** — seule l'accueil, qui partage le segment de `opengraph-image.tsx`, en hérite. Partager un article ou une page de pôle donne donc une carte sans visuel. Cela mérite sa propre issue ; le corriger ici aurait modifié le SEO de trois pages existantes sans rapport avec le blog.
