### PR TITLE
fix: faire heriter og:image, og:site_name et og:locale a toutes les pages

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -14,6 +14,18 @@ server {
     add_header Cache-Control "public, max-age=31536000, immutable";
   }
 
+  # Les routes de métadonnées d'images sortent de l'export **sans extension**
+  # (`out/opengraph-image` et `out/apple-icon` sont des PNG nus). nginx type les fichiers
+  # d'après leur suffixe : sans ce bloc il les sert en `application/octet-stream`, et un
+  # robot de réseau social refuse une vignette qui ne s'annonce pas comme une image —
+  # la carte de partage repart sans visuel. Le type est donc déclaré à la main, faute de
+  # suffixe que `mime.types` puisse lire.
+  location ~ ^/(opengraph-image|apple-icon)$ {
+    default_type image/png;
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=0, must-revalidate";
+  }
+
   # Le HTML, lui, doit être revalidé — sinon une mise en production reste invisible.
   location / {
     try_files $uri $uri/ =404;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,49 @@ prendre en connaissance de cause, pas un détail de configuration.
 - **Le blog n'est pas un pôle**, et la navigation le dit : il occupe un bloc distinct de
   la liste numérotée de la chaîne, dans l'en-tête comme dans le pied de page.
 
+### Métadonnées : la fusion de Next est **de surface**
+
+C'est le piège le plus coûteux de l'App Router, parce qu'il est silencieux : rien
+n'échoue, ni au build ni au lint. Next fusionne les objets `metadata` des segments d'une
+route **en surface**. Un champ imbriqué — `openGraph`, `robots`, `twitter` — déclaré par
+un segment enfant **remplace intégralement** celui du layout ; il ne le complète pas.
+
+Une page qui n'exportait que son URL de partage :
+
+```ts
+openGraph: { url: page.route }   // ✗ efface og:image, og:site_name et og:locale
+```
+
+perdait donc le visuel et l'identité du site posés par `src/app/layout.tsx`. Partagée sur
+un réseau social, elle sortait en **lien nu** — sans image et sans nom de site (issue
+#60). Le défaut ne se voit pas dans le code source de la page : il ne se constate que
+dans le HTML généré.
+
+Les règles qui en découlent :
+
+- **`src/@shared/seo/open-graph.ts` porte le socle** (`SITE_OPEN_GRAPH` : `type`,
+  `locale`, `siteName`, `images`). C'est la parade recommandée par Next : sortir les
+  champs communs dans une constante et l'étaler dans chaque segment qui surcharge
+  `openGraph`.
+- **Le socle s'étale dans le constructeur commun, jamais page par page.** Les deux
+  fonctions de `@shared/seo/page-metadata` (`buildPageMetadata` et
+  `buildArticleMetadata`) écrivent `{ ...SITE_OPEN_GRAPH, url: … }`, et toutes les pages
+  passent par elles. Une route ajoutée demain hérite sans y penser — c'est la seule
+  raison pour laquelle ces constructeurs existent.
+- **Ce qui est propre à la page vient après le spread** : `url` toujours, `type:
+  'article'` et les dates pour un billet de blog.
+- **Une seule déclaration de l'image.** Alt, dimensions et type MIME vivent dans
+  `open-graph.ts` ; `src/app/opengraph-image.tsx` les importe pour dessiner la vignette.
+  L'image produite et ce que les métadonnées en annoncent ne peuvent donc pas diverger.
+- **`openGraph.images` échappe à `trailingSlash`.** Next n'applique cette règle qu'à
+  `openGraph.url` ; les images sont seulement résolues contre `metadataBase`. Le chemin
+  `/opengraph-image` tombe donc bien sur le fichier produit par l'export, qui n'a ni
+  extension ni barre finale — et que `docker/nginx.conf` doit typer à la main, faute de
+  suffixe à lire.
+- **La vérification se fait sur le HTML généré**, jamais sur le code source :
+  `make build`, puis inspecter les balises `og:` de `out/<route>/index.html`. Une page
+  de référence qui ne surcharge rien (`out/404.html`) sert de témoin.
+
 ### Découpage par domaine
 
 | Domaine | Contenu |

--- a/src/@shared/seo/open-graph.ts
+++ b/src/@shared/seo/open-graph.ts
@@ -1,0 +1,66 @@
+// open-graph.ts — jeromemarichez-fr
+// Le socle Open Graph du site, et la raison pour laquelle chaque page doit le répéter.
+//
+// Next fusionne les métadonnées de segments **en surface** : dès qu'une page exporte un
+// objet `openGraph`, celui-ci **remplace** intégralement celui du layout — il ne le
+// complète pas. Une page qui déclare seulement `openGraph: { url }` perd donc
+// `og:site_name`, `og:locale` et `og:image` : partagée sur un réseau, elle sort en lien
+// nu, sans visuel ni nom de site.
+//
+// Ce module est la parade recommandée par Next lui-même : sortir les champs communs dans
+// une constante et l'étaler dans chaque segment qui surcharge `openGraph`. Les deux
+// constructeurs de `page-metadata.ts` le font, et ce sont eux que toutes les pages
+// appellent — une route ajoutée demain hérite donc du socle sans y penser.
+
+import type { Metadata } from 'next'
+import { SITE_IDENTITY, SITE_PROMESSE } from './site'
+
+/**
+ * Dimensions de la vignette de partage.
+ *
+ * `src/app/opengraph-image.tsx` dessine à ces dimensions et les métadonnées les
+ * annoncent : une seule déclaration, donc aucune dérive possible entre l'image
+ * réellement produite et ce que les réseaux croient recevoir.
+ */
+export const OG_IMAGE_SIZE = { width: 1200, height: 630 }
+
+/** Type MIME de la vignette, imposé par `ImageResponse`. */
+export const OG_IMAGE_TYPE = 'image/png'
+
+/**
+ * Texte alternatif de la vignette. Il dit l'identité et la promesse, parce que c'est
+ * tout ce qu'un lecteur d'écran obtiendra de l'image.
+ */
+export const OG_IMAGE_ALT = `${SITE_IDENTITY.nom}, ${SITE_IDENTITY.titre.toLowerCase()} à ${SITE_IDENTITY.ville}. ${SITE_PROMESSE}`
+
+/**
+ * Adresse servie par `src/app/opengraph-image.tsx`.
+ *
+ * L'export statique écrit l'image à ce chemin exact, sans extension ni barre finale. Le
+ * `trailingSlash` de `next.config.mjs` ne la menace pas : Next n'applique cette règle
+ * qu'à `openGraph.url`, jamais aux images — celles-ci sont seulement résolues contre
+ * `metadataBase`. L'URL annoncée tombe donc bien sur le fichier produit.
+ */
+export const OG_IMAGE_PATH = '/opengraph-image'
+
+/**
+ * Champs Open Graph vrais pour n'importe quelle page du site : l'identité, la langue et
+ * le visuel de partage. Tout le reste — `url` en tête — est propre à la page et vient
+ * s'ajouter par-dessus.
+ *
+ * `type` vaut `website` par défaut ; un article le remplace par `article`.
+ */
+export const SITE_OPEN_GRAPH = {
+  type: 'website',
+  locale: 'fr_FR',
+  siteName: SITE_IDENTITY.nom,
+  images: [
+    {
+      url: OG_IMAGE_PATH,
+      width: OG_IMAGE_SIZE.width,
+      height: OG_IMAGE_SIZE.height,
+      alt: OG_IMAGE_ALT,
+      type: OG_IMAGE_TYPE,
+    },
+  ],
+} satisfies NonNullable<Metadata['openGraph']>

--- a/src/@shared/seo/page-metadata.ts
+++ b/src/@shared/seo/page-metadata.ts
@@ -8,6 +8,7 @@
 
 import type { Metadata } from 'next'
 import type { IPageMeta } from '@/interfaces/IEditorialPage'
+import { SITE_OPEN_GRAPH } from './open-graph'
 import { SITE_IDENTITY } from './site'
 
 /**
@@ -18,6 +19,11 @@ import { SITE_IDENTITY } from './site'
  * (`%s — Jérôme Marichez`), ce qui est la forme voulue pour un partage. Les redéclarer
  * ici perdrait le nom du site.
  *
+ * `SITE_OPEN_GRAPH` est étalé en premier et ce n'est pas une précaution décorative : la
+ * fusion des métadonnées de Next est **de surface**, donc ce bloc `openGraph` écrase
+ * celui du layout au lieu de le compléter. Sans le socle, chaque page perdrait ici son
+ * `og:image`, son `og:site_name` et son `og:locale` (voir `open-graph.ts`).
+ *
  * Les URL sont relatives : `metadataBase` (layout) les résout en absolu, barre finale
  * comprise puisque `trailingSlash` est actif.
  */
@@ -26,7 +32,7 @@ export function buildPageMetadata(page: { meta: IPageMeta; route: string }): Met
     title: page.meta.title,
     description: page.meta.description,
     alternates: { canonical: page.route },
-    openGraph: { url: page.route },
+    openGraph: { ...SITE_OPEN_GRAPH, url: page.route },
   }
 }
 
@@ -42,6 +48,10 @@ export function buildPageMetadata(page: { meta: IPageMeta; route: string }): Met
  * `toArticleRoute(slug)` : c'est la seule façon de composer une URL d'article dans ce
  * dépôt, donc la seule qui garantisse que `canonical` et `og:url` désignent la page
  * réellement servie.
+ *
+ * Le socle est étalé ici aussi, pour la même raison qu'au-dessus : un article n'a aucune
+ * raison de se partager sans visuel ni nom de site. `type` est le seul champ du socle
+ * qu'il contredit — d'où sa place après le spread.
  */
 export function buildArticleMetadata(article: {
   meta: IPageMeta
@@ -54,6 +64,7 @@ export function buildArticleMetadata(article: {
     description: article.meta.description,
     alternates: { canonical: article.route },
     openGraph: {
+      ...SITE_OPEN_GRAPH,
       type: 'article',
       url: article.route,
       publishedTime: article.datePublished,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { SiteFooter } from '@/@shared/components/SiteFooter'
 import { SiteHeader } from '@/@shared/components/SiteHeader'
 import { SkipLink } from '@/@shared/components/SkipLink'
 import { StructuredData } from '@/@shared/components/StructuredData'
+import { SITE_OPEN_GRAPH } from '@/@shared/seo/open-graph'
 import { SITE_IDENTITY, SITE_PROMESSE, SITE_THEME_COLORS, SITE_URL } from '@/@shared/seo/site'
 import { buildPersonSchema, buildProfessionalServiceSchema } from '@/@shared/seo/structured-data'
 import { FONT_VARIABLES } from '@/@shared/typography/fonts'
@@ -23,11 +24,12 @@ export const metadata: Metadata = {
   authors: [{ name: SITE_IDENTITY.nom, url: SITE_URL }],
   // Ni `alternates.canonical` ni `openGraph.url` ici : hérités, ils désignent l'accueil
   // depuis n'importe quelle page. Chaque page pose les siens (@shared/seo/page-metadata).
-  openGraph: {
-    type: 'website',
-    locale: 'fr_FR',
-    siteName: SITE_IDENTITY.nom,
-  },
+  //
+  // Ce socle ne suffit pas à lui seul : Next fusionne les métadonnées de segments en
+  // surface, donc toute page qui exporte un `openGraph` remplace celui-ci en entier.
+  // C'est pourquoi les constructeurs de `page-metadata` l'étalent à leur tour — et
+  // pourquoi il vit dans `open-graph.ts` plutôt qu'écrit à la main ici.
+  openGraph: SITE_OPEN_GRAPH,
   robots: { index: true, follow: true },
 }
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -9,12 +9,16 @@
 // feuille de style, donc sans variable CSS à résoudre. Elles suivent `globals.css`.
 
 import { ImageResponse } from 'next/og'
+import { OG_IMAGE_ALT, OG_IMAGE_SIZE, OG_IMAGE_TYPE } from '@/@shared/seo/open-graph'
 import { SITE_IDENTITY, SITE_PROMESSE } from '@/@shared/seo/site'
 import { POLES_NAV } from '@/@vitrine/contenu/poles-nav'
 
-export const alt = `${SITE_IDENTITY.nom}, ${SITE_IDENTITY.titre.toLowerCase()} à ${SITE_IDENTITY.ville}. ${SITE_PROMESSE}`
-export const size = { width: 1200, height: 630 }
-export const contentType = 'image/png'
+// Alt, dimensions et type MIME viennent de `open-graph.ts`, qui sert aussi à décrire
+// cette image dans les métadonnées de chaque page. Les redéclarer ici les laisserait
+// diverger de ce que les réseaux sociaux croient recevoir.
+export const alt = OG_IMAGE_ALT
+export const size = OG_IMAGE_SIZE
+export const contentType = OG_IMAGE_TYPE
 
 // `output: 'export'` exige que les routes de métadonnées soient déclarées statiques.
 export const dynamic = 'force-static'


### PR DESCRIPTION
Closes #60

## Ce qui changeait

Next fusionne les métadonnées de segments **en surface** : un objet `openGraph` déclaré par une page **remplace intégralement** celui du layout, il ne le complète pas. `page-metadata.ts` posait `openGraph: { url }` — ce qui effaçait `og:image`, `og:site_name` et `og:locale` sur toute page passant par lui.

Rien n'échouait : ni le build, ni le lint, ni les types. Le défaut ne se voyait que dans le HTML généré.

## Ce qui change

La correction est portée par le **constructeur commun**, pas recopiée page par page.

- **`src/@shared/seo/open-graph.ts`** (nouveau) porte le socle `SITE_OPEN_GRAPH` — `type`, `locale`, `siteName`, `images`. C'est la parade que documente Next lui-même : sortir les champs communs dans une constante et l'étaler dans chaque segment qui surcharge `openGraph`.
- **`buildPageMetadata` et `buildArticleMetadata`** étalent le socle avant d'ajouter ce qui leur est propre (`url`, et pour un article `type: 'article'` + les dates). Toutes les pages passent par ces deux fonctions : **une route ajoutée demain hérite sans y penser**. La section blog en bénéficie par le même chemin.
- **`src/app/layout.tsx`** consomme le même socle, pour que l'hérité et le redéclaré ne puissent pas diverger.
- **`src/app/opengraph-image.tsx`** importe alt, dimensions et type MIME du même module : l'image dessinée et ce que les métadonnées en annoncent sont désormais une seule déclaration.

Le chemin `/opengraph-image` est sûr : Next n'applique la règle `trailingSlash` qu'à `openGraph.url`, jamais aux images — celles-ci sont seulement résolues contre `metadataBase` (`next/dist/lib/metadata/resolvers/resolve-url.js`). L'URL annoncée tombe bien sur le PNG produit par l'export.

## Vérification sur le HTML réellement généré

`make build`, puis inspection de `out/`.

**Avant — `out/services/ingenierie-web/index.html`** (ni image, ni identité) :

```
og:title      Ingénierie web — site, SaaS et mobile | Lille — Jérôme Marichez
og:description Site, SaaS et mobile conçus, développés et exploités par une seule personne. […]
og:url        https://jeromemarichez.fr/services/ingenierie-web/
```

**Après — `out/services/ingenierie-web/index.html`** :

```
og:title       Ingénierie web — site, SaaS et mobile | Lille — Jérôme Marichez
og:description Site, SaaS et mobile conçus, développés et exploités par une seule personne. […]
og:url         https://jeromemarichez.fr/services/ingenierie-web/
og:site_name   Jérôme Marichez
og:locale      fr_FR
og:image       https://jeromemarichez.fr/opengraph-image
og:image:type  image/png
og:image:width 1200
og:image:height 630
og:image:alt   Jérôme Marichez, ingénieur logiciel à Lille. Un seul interlocuteur […]
og:type        website
```

**Après — `out/blog/mesurer-avant-d-arbitrer/index.html`** (`og:type` reste `article`) :

```
og:title       Mesurer avant d’arbitrer — Jérôme Marichez
og:url         https://jeromemarichez.fr/blog/mesurer-avant-d-arbitrer/
og:site_name   Jérôme Marichez
og:locale      fr_FR
og:image       https://jeromemarichez.fr/opengraph-image
og:image:type  image/png
og:image:width 1200
og:image:height 630
og:image:alt   Jérôme Marichez, ingénieur logiciel à Lille. […]
og:type        article
```

**Après — `out/index.html`** :

```
og:url         https://jeromemarichez.fr/
og:site_name   Jérôme Marichez
og:locale      fr_FR
og:image       https://jeromemarichez.fr/opengraph-image
og:type        website
```

L'accueil gagne au passage `og:site_name` et `og:locale`, qu'elle perdait elle aussi — l'issue ne les avait relevés que sur les pages de pôle.

**Audit exhaustif** — aucune page générée ne manque un des trois tags :

```
$ grep -rL 'property="og:image"'     --include='*.html' out/   # (vide)
$ grep -rL 'property="og:site_name"' --include='*.html' out/   # (vide)
$ grep -rL 'property="og:locale"'    --include='*.html' out/   # (vide)
$ grep -rl 'property="og:image"' --include='*.html' out/ | wc -l   # 11
$ find out -name '*.html' | wc -l                                  # 11
```

Une seule balise `og:image` par page (pas de doublon avec la convention de fichier), et des `og:url` / `canonical` distincts et corrects sur les 6 routes indexables :

```
out/index.html                              https://jeromemarichez.fr/
out/services/ingenierie-web/index.html      https://jeromemarichez.fr/services/ingenierie-web/
out/services/data-ia/index.html             https://jeromemarichez.fr/services/data-ia/
out/services/sea-ux/index.html              https://jeromemarichez.fr/services/sea-ux/
out/blog/index.html                         https://jeromemarichez.fr/blog/
out/blog/mesurer-avant-d-arbitrer/index.html https://jeromemarichez.fr/blog/mesurer-avant-d-arbitrer/
```

## Second commit — à arbitrer

`out/opengraph-image` et `out/apple-icon` sortent de l'export **sans extension** (ce sont des PNG nus). nginx type les fichiers d'après leur suffixe, et le Dockerfile n'installe que `docker/nginx.conf` dans `conf.d/` : la configuration principale d'origine s'applique, avec son `default_type application/octet-stream`. La vignette était donc servie en octet-stream, et un robot de réseau social refuse une image qui ne s'annonce pas comme telle.

Le défaut préexistait, mais le premier commit en élargit la portée — `og:image` ne concernait que l'accueil et la 404, il concerne maintenant les 11 pages. Corriger le tag sans corriger le service aurait livré une moitié de correction.

**Non vérifié à l'exécution** : ni démon Docker ni nginx disponibles dans l'environnement. Relecture statique uniquement, à confirmer au premier `make docker-up`. Si tu préfères le sortir de cette PR et en faire une issue à part, le commit `d98eac2` s'enlève seul.

## Intention de test proposée (à écrire par Jérôme MARICHEZ)

Je n'ai écrit aucun test — règle du projet. Voici ce que je propose de couvrir.

**Niveau unitaire** — `tests/unitaire/page-metadata.spec.ts` — sur `buildPageMetadata` et `buildArticleMetadata` :

- Comportement attendu : les métadonnées produites portent `openGraph.siteName`, `openGraph.locale` et un `openGraph.images` non vide, **en plus** de `url`.
- Cas limite qui tient la régression : `openGraph.url` vaut la route reçue et **le socle n'est pas perdu** — c'est l'assertion qui rougirait si quelqu'un réécrivait `openGraph: { url }`.
- Cas limite propre à l'article : `type` vaut `article` (le seul champ du socle qu'un billet contredit), et `publishedTime` / `modifiedTime` / `authors` sont présents — tout en gardant `siteName`, `locale` et `images`.
- Jeu de données : `tests/fixtures/article.fixture.json`, déjà versionné.

**Niveau acceptation / UAT** — le plus utile ici, parce que c'est le seul niveau qui constate le vrai défaut. Un test qui, après `make build`, parcourt **tous** les `out/**/*.html` et vérifie que chacun porte `og:image`, `og:site_name` et `og:locale`, et exactement une balise `og:image`. Un test unitaire sur le constructeur n'aurait pas attrapé ce bug : le code source était correct, c'est la fusion du framework qui ne l'était pas. C'est le HTML généré qui fait foi.

## Contrôles

| Contrôle | État |
|---|---|
| `make lint` | vert (seuls les avertissements Biome préexistants, sans rapport) |
| `make type-check` | vert |
| `make build` | vert, 17 routes générées |
| `make test` | vert (2 tests unitaires, aucun test d'intégration) |

Aucun contenu éditorial touché.
