### PR TITLE
refactor: preparer le modele des poles sans changer le rendu

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -80,8 +80,9 @@ un composant :
   ou dans `og:image` sans la servir serait une affirmation fausse de plus.
 - **Pas de rattachement à un pôle, pas de tags, pas de catégories.** Avec trois articles,
   une taxonomie serait un classement sans classe. Le jour où elle s'impose, le
-  rattachement dérivera de `PoleId` et de `POLE_ORDER` — jamais d'une liste de pôles
-  recopiée dans le blog.
+  rattachement dérivera de `PoleId` et de l'ordre porté par `POLES_NAV` — jamais d'une
+  liste de pôles recopiée dans le blog. L'ordre est **la position dans `POLES_NAV`**, et
+  nulle part ailleurs : une seconde liste d'ordre finirait par contredire la première.
 - **Pas de statut `brouillon`.** Un article non publié n'est pas dans `articles.ts`.
 
 ## Où vivent les données

--- a/docs/design.md
+++ b/docs/design.md
@@ -144,7 +144,7 @@ Trois contraintes de la bibliothèque sont tenues, et leur parade est explicite 
 |-------------------|--------|
 | Toutes les lentilles doivent partager le **même z-index** | `z-index: 2` posé une seule fois dans `glass-surface.css` ; aucun `z-index` local |
 | Les éléments `fixed` et `sticky` sont **ignorés** | L'en-tête collant utilise un `backdrop-filter` CSS, pas liquidGL |
-| Safari instable au-delà de **50 % du viewport** | Verre désactivé sous 1024px, et plafonné à 3 surfaces par page (`glass-policy.ts`) |
+| Safari instable au-delà de **50 % du viewport** | Verre désactivé sous 1024px, et plafonné par gabarit dans `glass-policy.ts` : `MAX_GLASS_ACCUEIL` (3) et `MAX_GLASS_PAGE_POLE` (3). Le plafond est passé par l'appelant, pas hérité d'une constante unique — une page de pôle compte 4 à 5 chapitres vitrables, et la troncature doit se lire dans le code plutôt que se subir |
 | Le flou coûte cher là où rien ne bouge | Sous 1024px, `backdrop-filter` et `will-change` ne sont pas posés du tout : fond translucide plat |
 | Tout ce qui n'est pas le fond fausse la capture | La scène des dalles porte `data-liquid-ignore` et n'est jamais placée derrière une surface de verre |
 | Capture plein document, coût en carré de `resolution` | `resolution: 0.75` au lieu de 2.0 par défaut. On ne capture pas la page mais un dégradé et une trame de 32px : vue à travers un verre dépoli, sa netteté n'a aucune importance — la mémoire, si |

--- a/src/@shared/routes.ts
+++ b/src/@shared/routes.ts
@@ -14,13 +14,6 @@ export const ROUTES = {
   'sea-ux': '/services/sea-ux',
 } as const satisfies Record<'accueil' | 'blog' | PoleId, string>
 
-/** Ordre de la chaîne : construire, exploiter et mesurer, arbitrer. */
-export const POLE_ORDER = [
-  'ingenierie-web',
-  'data-ia',
-  'sea-ux',
-] as const satisfies readonly PoleId[]
-
 /**
  * Toutes les routes **fixes** indexables, dans l'ordre de priorité.
  *

--- a/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
+++ b/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
@@ -9,7 +9,6 @@
   margin: 0;
   padding: 0;
   list-style: none;
-  counter-reset: maillon;
 }
 
 .maillon {

--- a/src/@vitrine/components/ThreadSection/index.tsx
+++ b/src/@vitrine/components/ThreadSection/index.tsx
@@ -16,7 +16,7 @@ interface ThreadSectionProps {
  * même main : il coupe la chaîne au lieu de s'y insérer. C'est la seule façon de dire
  * visuellement « ceci n'est pas une quatrième offre » sans avoir à l'écrire.
  *
- * Pas de verre ici — `selectGlassSectionIds` ne vitre que les pôles.
+ * Pas de verre ici — `selectGlassSectionIds` ne vitre que les pôles et les chapitres.
  */
 export function ThreadSection({ section }: ThreadSectionProps) {
   const titreId = `${section.id}-titre`

--- a/src/@vitrine/contenu/accueil-data-ia.ts
+++ b/src/@vitrine/contenu/accueil-data-ia.ts
@@ -6,8 +6,12 @@
 // ordre doit se lire d'un seul tenant, sans être rogné pour tenir dans un fichier qui
 // approche la limite de 300 lignes.
 //
-// Version longue : `data-ia-sections.ts`. Les deux disent la même chose dans le même
-// ordre ; l'accueil en donne la version courte, jamais une version différente.
+// Version longue : `data-sections.ts` puis `ia-sections.ts`, recollés par `data-ia.ts`.
+// Les deux disent la même chose dans le même ordre ; l'accueil en donne la version
+// courte, jamais une version différente.
+//
+// `kind: 'pole'` et non `'chapitre'` : cette section-ci EST un pôle, alors que les
+// sections de `/services/data-ia/` sont les chapitres internes d'une seule page.
 
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 

--- a/src/@vitrine/contenu/data-ia.ts
+++ b/src/@vitrine/contenu/data-ia.ts
@@ -1,11 +1,18 @@
 // data-ia.ts — jeromemarichez-fr
-// Pôle 2 — Data & IA. Métadonnées ; les sections vivent dans le fichier voisin.
+// Pôle 2 — Data & IA. Métadonnées, et recollement des chapitres.
 //
 // Le pôle part du métier et finit sur la technique : le titre et la description le
 // disent dès la SERP, sinon la page est ouverte avec la mauvaise attente.
+//
+// Les chapitres vivent dans deux fichiers voisins, `data-sections.ts` et
+// `ia-sections.ts`. La séparation est celle du CONTENU — la donnée d'un côté, les
+// modèles de l'autre — et non celle des pôles : `PoleId` compte toujours `data-ia` comme
+// un seul pôle. L'ordre de concaténation est l'ordre de lecture de la page, et il est le
+// même qu'avant la scission.
 
 import type { IEditorialPage } from '@/interfaces/IEditorialPage'
-import { SECTIONS_DATA_IA } from './data-ia-sections'
+import { SECTIONS_DATA } from './data-sections'
+import { SECTIONS_IA } from './ia-sections'
 
 export const PAGE_DATA_IA: IEditorialPage = {
   route: '/services/data-ia',
@@ -15,5 +22,5 @@ export const PAGE_DATA_IA: IEditorialPage = {
       'Insights métier, profils clients et règles existantes formalisés, stratégie data, ' +
       'gouvernance et RGPD — puis la solution : règle métier, modèle ou LLM.',
   },
-  sections: SECTIONS_DATA_IA,
+  sections: [...SECTIONS_DATA, ...SECTIONS_IA],
 }

--- a/src/@vitrine/contenu/data-sections.ts
+++ b/src/@vitrine/contenu/data-sections.ts
@@ -1,23 +1,30 @@
-// data-ia-sections.ts — jeromemarichez-fr
-// Pôle 2 — Le métier d'abord, la technique en dernier.
+// data-sections.ts — jeromemarichez-fr
+// Les chapitres DATA de la page Data & IA : métier, stratégie data, gouvernance et droit.
 //
-// L'ORDRE EST LE CONTENU : métier → stratégie data → gouvernance et droit → solution.
-// L'inverser reviendrait à vendre un catalogue de technologies à quelqu'un qui cherche
-// une réponse à un problème d'activité. La solution technique répond au problème posé
-// au départ ; elle n'est jamais le point de départ, et elle n'est pas toujours de l'IA.
+// Scindé de l'ancien `data-ia-sections.ts`, qui atteignait 279 lignes pour un plafond dur
+// à 300. Ce n'est qu'un découpage de FICHIERS : `PoleId` est inchangé, la page rend le
+// même contenu dans le même ordre, et `data-ia.ts` recolle les deux tableaux.
+//
+// Le critère de rattachement est le CONTENU, jamais le titre. Vient ici ce qui parle de
+// collecte, de plan de taggage, de gouvernance, de qualité ou de réconciliation
+// d'identités ; ce qui parle de modèles, d'inférence, de fine-tuning, de RAG ou d'agents
+// est dans `ia-sections.ts`.
+//
+// L'ORDRE EST LE CONTENU : métier → stratégie data → gouvernance et droit. On part de
+// l'activité, pas d'un catalogue de technologies — la solution technique répond au
+// problème posé au départ, elle n'en est jamais le point de départ.
 //
 // Faits sourcés dans cv-ai-engineer.md, cv-tracking-specialist.md et
-// cv-ingenieur-fullstack.md. Règles de véracité du CLAUDE.md appliquées : RAG **maison**
-// (aucun framework tiers), méthode arXiv implémentée par Jérôme et non « en
-// collaboration avec » l'Universitat de Barcelona, Prézage et Llama 3 nommables mais
-// corpus, données et chiffres du projet hors ligne, aucun cluster Kubernetes en propre.
+// cv-ingenieur-fullstack.md. Règles de véracité du CLAUDE.md appliquées : méthode arXiv
+// implémentée par Jérôme et non « en collaboration avec » l'Universitat de Barcelona,
+// Llama 3 nommable mais corpus, données et chiffres du projet hors ligne.
 
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 
-export const SECTIONS_DATA_IA: IEditorialSection[] = [
+export const SECTIONS_DATA: IEditorialSection[] = [
   {
     id: 'metier',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'data-ia',
     kicker: 'Le point de départ',
     titre: 'Je commence par votre métier, pas par votre donnée',
@@ -79,7 +86,7 @@ export const SECTIONS_DATA_IA: IEditorialSection[] = [
   },
   {
     id: 'strategie-data',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'data-ia',
     kicker: 'La stratégie data',
     titre: 'Construire la stratégie data, ou s’appuyer sur celle qui existe',
@@ -124,7 +131,7 @@ export const SECTIONS_DATA_IA: IEditorialSection[] = [
   },
   {
     id: 'gouvernance',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'data-ia',
     kicker: 'Gouvernance et droit',
     titre: 'Qui possède quoi, et ce qui a le droit d’être traité',
@@ -163,116 +170,6 @@ export const SECTIONS_DATA_IA: IEditorialSection[] = [
           'd’office et la comparaison se joue entre un modèle open-weight que l’on héberge ' +
           '— Llama 3 par exemple — et une règle explicite. C’est une contrainte de départ, ' +
           'pas une déception à annoncer en fin de projet.',
-      },
-    ],
-  },
-  {
-    id: 'solution',
-    kind: 'pole',
-    pole: 'data-ia',
-    kicker: 'La réponse technique',
-    titre: 'La solution répond au problème — et ce n’est pas toujours de l’IA',
-    chapo:
-      'C’est seulement ici que la technique arrive, et elle est arbitrée contre les trois ' +
-      'étapes précédentes : le problème métier posé au départ, la donnée réellement ' +
-      'disponible, et ce que le droit autorise. Pas contre l’état de l’art.',
-    blocs: [
-      {
-        titre: 'Souvent, une règle métier suffit',
-        texte:
-          'Une règle explicite est moins chère à faire tourner, plus facile à expliquer à ' +
-          'un régulateur et plus simple à corriger qu’un modèle. Quand elle suffit, je le ' +
-          'dis, et je l’intègre dans vos systèmes existants au lieu d’ajouter une brique ' +
-          'de plus. C’est un livrable complet, pas un lot de consolation.',
-        preuve:
-          'Règles anti-fraude définies puis implémentées dans le produit par la même ' +
-          'personne : fraude en baisse, conversion des inscriptions en hausse, latence ' +
-          'réduite. Flux commande, stock et facturation modélisés en BPMN puis intégrés ' +
-          'entre un ERP et un site marchand : survente évitée sur des pièces uniques.',
-        decision:
-          'Ce qui se règle par une règle intégrée à l’existant, et ce qui mérite vraiment ' +
-          'un modèle.',
-      },
-      {
-        titre: 'Un modèle, quand la règle ne tient plus',
-        texte:
-          'Apprentissage supervisé — classification, réseaux de neurones — ou non ' +
-          'supervisé, selon ce que la donnée permet. Exemple livré : un modèle supervisé ' +
-          'anticipant les échecs de dépôt vocal, qui évite d’emprunter une route coûteuse ' +
-          'quand l’échec est probable. La méthode d’extraction des caractéristiques du ' +
-          'signal audio est publiée sur arXiv ; je l’ai implémentée moi-même, adaptée aux ' +
-          'données réelles, validée, puis industrialisée. Entraînement TensorFlow, ' +
-          'inférence en cloud functions.',
-        preuve: 'Routes vocales coûteuses évitées.',
-      },
-      {
-        titre: 'Un LLM, quand le problème est du langage',
-        texte:
-          'Claude sur Vertex AI et par l’API Anthropic, OpenAI, Gemini, Llama : comparés ' +
-          'en continu et arbitrés cas d’usage par cas d’usage sur quatre axes — coût ' +
-          'd’inférence, latence, qualité attendue, confidentialité. Fine-tuning de Llama 3 ' +
-          'sur corpus métier pour l’application mobile Prézage, complété d’un procédé ' +
-          'maison d’augmentation du contexte proche du RAG. RAG documentaire pour le ' +
-          'support de niveau 1 : recherche vectorielle PostgreSQL et API OpenAI, réponses ' +
-          'ancrées sur votre documentation interne et non sur la mémoire du modèle. Aucun ' +
-          'framework tiers — la chaîne est écrite, donc lisible et corrigeable.',
-        preuve: 'Charge de travail des prestataires réduite.',
-        decision: 'Modèle hébergé ou service tiers, et ce que chacun vous coûte par mois.',
-      },
-    ],
-  },
-  {
-    id: 'production',
-    kind: 'pole',
-    pole: 'data-ia',
-    kicker: 'Et ensuite',
-    titre: 'Ce qui est livré tourne, et reste explicable',
-    chapo:
-      'Une solution qui ne survit pas à six mois d’exploitation n’a pas résolu le ' +
-      'problème, elle l’a déplacé. Le déploiement, la surveillance et la conformité font ' +
-      'donc partie du même lot, tenus par la même personne.',
-    blocs: [
-      {
-        titre: 'Déploiement et surveillance',
-        texte:
-          'Déploiement, versioning et monitoring des modèles, CI/CD Docker et GitHub ' +
-          'Actions, Vertex AI, Pub/Sub, Cloud Run, cloud functions, VM Compute Engine ' +
-          'auto-scalées. Pas de cluster Kubernetes administré en propre : je m’en tiens à ' +
-          'ce que je sais exploiter seul, et je le dis avant le devis plutôt qu’après.',
-      },
-      {
-        titre: 'Rendre votre produit appelable',
-        texte:
-          'Conception, développement et documentation de serveurs MCP et de plugins n8n, ' +
-          'Make et Zapier : votre produit devient utilisable par un agent IA ou par un ' +
-          'scénario no-code, chez vous comme chez vos propres clients.',
-        decision: 'Ce que vous ouvrez à l’automatisation, et ce qui reste fermé.',
-      },
-    ],
-  },
-  {
-    id: 'charniere-arbitrage',
-    kind: 'charniere',
-    kicker: 'Charnière vers le pôle 3',
-    titre: 'Un métier compris devient un budget arbitrable',
-    chapo:
-      'Quand les règles sont écrites, les profils identifiés et la donnée gouvernée, on ne ' +
-      'regarde plus un tableau de bord de plus : on tient la matière des décisions ' +
-      'd’acquisition et de parcours. Quel canal financer, quelle étape supprimer, quelle ' +
-      'page rendre autrement. Sans elle, le SEA achète du volume et l’expérience ' +
-      'utilisateur devient une affaire de goût.',
-    blocs: [
-      {
-        titre: 'Rentabilité à long terme',
-        texte:
-          'la mesure de la valeur client dans la durée remplace le coût par clic comme ' +
-          'critère d’arbitrage.',
-      },
-      {
-        titre: 'Et ensuite',
-        texte:
-          'le pôle 3 tranche sur ces chiffres — puis implémente l’arbitrage dans le ' +
-          'produit, sans passer par un tiers.',
       },
     ],
   },

--- a/src/@vitrine/contenu/ia-sections.ts
+++ b/src/@vitrine/contenu/ia-sections.ts
@@ -1,0 +1,137 @@
+// ia-sections.ts — jeromemarichez-fr
+// Les chapitres IA de la page Data & IA : la réponse technique, puis sa mise en
+// production. Le tableau se referme sur la charnière qui clôt la page.
+//
+// Scindé de l'ancien `data-ia-sections.ts`, qui atteignait 279 lignes pour un plafond dur
+// à 300. Ce n'est qu'un découpage de FICHIERS : `PoleId` est inchangé, la page rend le
+// même contenu dans le même ordre, et `data-ia.ts` recolle les deux tableaux.
+//
+// Le critère de rattachement est le CONTENU, jamais le titre. Vient ici ce qui parle de
+// modèles, d'inférence, de fine-tuning, de RAG ou d'agents ; ce qui parle de collecte, de
+// gouvernance, de qualité ou de réconciliation d'identités est dans `data-sections.ts`.
+//
+// `charniere-arbitrage` n'est ni de la data ni de l'IA : c'est la sortie de page vers le
+// pôle suivant. Elle est posée en dernier ici pour que la concaténation
+// `[...SECTIONS_DATA, ...SECTIONS_IA]` rende exactement l'ordre d'avant la scission. Son
+// rattachement définitif est à trancher quand `PoleId` se scindera à son tour.
+//
+// Faits sourcés dans cv-ai-engineer.md et cv-ingenieur-fullstack.md. Règles de véracité
+// du CLAUDE.md appliquées : RAG **maison** (aucun framework tiers), méthode arXiv
+// implémentée par Jérôme et non « en collaboration avec » l'Universitat de Barcelona,
+// Prézage et Llama 3 nommables mais corpus, données et chiffres du projet hors ligne,
+// aucun cluster Kubernetes en propre.
+
+import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+
+export const SECTIONS_IA: IEditorialSection[] = [
+  {
+    id: 'solution',
+    kind: 'chapitre',
+    pole: 'data-ia',
+    kicker: 'La réponse technique',
+    titre: 'La solution répond au problème — et ce n’est pas toujours de l’IA',
+    chapo:
+      'C’est seulement ici que la technique arrive, et elle est arbitrée contre les trois ' +
+      'étapes précédentes : le problème métier posé au départ, la donnée réellement ' +
+      'disponible, et ce que le droit autorise. Pas contre l’état de l’art.',
+    blocs: [
+      {
+        titre: 'Souvent, une règle métier suffit',
+        texte:
+          'Une règle explicite est moins chère à faire tourner, plus facile à expliquer à ' +
+          'un régulateur et plus simple à corriger qu’un modèle. Quand elle suffit, je le ' +
+          'dis, et je l’intègre dans vos systèmes existants au lieu d’ajouter une brique ' +
+          'de plus. C’est un livrable complet, pas un lot de consolation.',
+        preuve:
+          'Règles anti-fraude définies puis implémentées dans le produit par la même ' +
+          'personne : fraude en baisse, conversion des inscriptions en hausse, latence ' +
+          'réduite. Flux commande, stock et facturation modélisés en BPMN puis intégrés ' +
+          'entre un ERP et un site marchand : survente évitée sur des pièces uniques.',
+        decision:
+          'Ce qui se règle par une règle intégrée à l’existant, et ce qui mérite vraiment ' +
+          'un modèle.',
+      },
+      {
+        titre: 'Un modèle, quand la règle ne tient plus',
+        texte:
+          'Apprentissage supervisé — classification, réseaux de neurones — ou non ' +
+          'supervisé, selon ce que la donnée permet. Exemple livré : un modèle supervisé ' +
+          'anticipant les échecs de dépôt vocal, qui évite d’emprunter une route coûteuse ' +
+          'quand l’échec est probable. La méthode d’extraction des caractéristiques du ' +
+          'signal audio est publiée sur arXiv ; je l’ai implémentée moi-même, adaptée aux ' +
+          'données réelles, validée, puis industrialisée. Entraînement TensorFlow, ' +
+          'inférence en cloud functions.',
+        preuve: 'Routes vocales coûteuses évitées.',
+      },
+      {
+        titre: 'Un LLM, quand le problème est du langage',
+        texte:
+          'Claude sur Vertex AI et par l’API Anthropic, OpenAI, Gemini, Llama : comparés ' +
+          'en continu et arbitrés cas d’usage par cas d’usage sur quatre axes — coût ' +
+          'd’inférence, latence, qualité attendue, confidentialité. Fine-tuning de Llama 3 ' +
+          'sur corpus métier pour l’application mobile Prézage, complété d’un procédé ' +
+          'maison d’augmentation du contexte proche du RAG. RAG documentaire pour le ' +
+          'support de niveau 1 : recherche vectorielle PostgreSQL et API OpenAI, réponses ' +
+          'ancrées sur votre documentation interne et non sur la mémoire du modèle. Aucun ' +
+          'framework tiers — la chaîne est écrite, donc lisible et corrigeable.',
+        preuve: 'Charge de travail des prestataires réduite.',
+        decision: 'Modèle hébergé ou service tiers, et ce que chacun vous coûte par mois.',
+      },
+    ],
+  },
+  {
+    id: 'production',
+    kind: 'chapitre',
+    pole: 'data-ia',
+    kicker: 'Et ensuite',
+    titre: 'Ce qui est livré tourne, et reste explicable',
+    chapo:
+      'Une solution qui ne survit pas à six mois d’exploitation n’a pas résolu le ' +
+      'problème, elle l’a déplacé. Le déploiement, la surveillance et la conformité font ' +
+      'donc partie du même lot, tenus par la même personne.',
+    blocs: [
+      {
+        titre: 'Déploiement et surveillance',
+        texte:
+          'Déploiement, versioning et monitoring des modèles, CI/CD Docker et GitHub ' +
+          'Actions, Vertex AI, Pub/Sub, Cloud Run, cloud functions, VM Compute Engine ' +
+          'auto-scalées. Pas de cluster Kubernetes administré en propre : je m’en tiens à ' +
+          'ce que je sais exploiter seul, et je le dis avant le devis plutôt qu’après.',
+      },
+      {
+        titre: 'Rendre votre produit appelable',
+        texte:
+          'Conception, développement et documentation de serveurs MCP et de plugins n8n, ' +
+          'Make et Zapier : votre produit devient utilisable par un agent IA ou par un ' +
+          'scénario no-code, chez vous comme chez vos propres clients.',
+        decision: 'Ce que vous ouvrez à l’automatisation, et ce qui reste fermé.',
+      },
+    ],
+  },
+  {
+    id: 'charniere-arbitrage',
+    kind: 'charniere',
+    kicker: 'Charnière vers le pôle 3',
+    titre: 'Un métier compris devient un budget arbitrable',
+    chapo:
+      'Quand les règles sont écrites, les profils identifiés et la donnée gouvernée, on ne ' +
+      'regarde plus un tableau de bord de plus : on tient la matière des décisions ' +
+      'd’acquisition et de parcours. Quel canal financer, quelle étape supprimer, quelle ' +
+      'page rendre autrement. Sans elle, le SEA achète du volume et l’expérience ' +
+      'utilisateur devient une affaire de goût.',
+    blocs: [
+      {
+        titre: 'Rentabilité à long terme',
+        texte:
+          'la mesure de la valeur client dans la durée remplace le coût par clic comme ' +
+          'critère d’arbitrage.',
+      },
+      {
+        titre: 'Et ensuite',
+        texte:
+          'le pôle 3 tranche sur ces chiffres — puis implémente l’arbitrage dans le ' +
+          'produit, sans passer par un tiers.',
+      },
+    ],
+  },
+]

--- a/src/@vitrine/contenu/ingenierie-web-sections.ts
+++ b/src/@vitrine/contenu/ingenierie-web-sections.ts
@@ -10,7 +10,7 @@ import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
   {
     id: 'natures',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'ingenierie-web',
     kicker: 'Ce que je construis',
     titre: 'Trois natures de produit, une seule façon de les tenir',
@@ -54,7 +54,7 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
   },
   {
     id: 'cadrage',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'ingenierie-web',
     kicker: 'Avant la première ligne',
     titre: 'Le cadrage, tenu par celui qui devra le coder',
@@ -94,7 +94,7 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
   },
   {
     id: 'technique',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'ingenierie-web',
     kicker: 'La construction',
     titre: 'Front, back, architecture et exploitation',
@@ -138,7 +138,7 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
   },
   {
     id: 'qualite',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'ingenierie-web',
     kicker: 'La qualité',
     titre: 'Certifiée et outillée, pas promise',

--- a/src/@vitrine/contenu/sea-ux-sections.ts
+++ b/src/@vitrine/contenu/sea-ux-sections.ts
@@ -15,7 +15,7 @@ import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 export const SECTIONS_SEA_UX: IEditorialSection[] = [
   {
     id: 'cadrage-ux',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'sea-ux',
     kicker: 'Disons-le tout de suite',
     titre: 'Je ne dessine pas vos maquettes',
@@ -51,7 +51,7 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
   },
   {
     id: 'mesure',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'sea-ux',
     kicker: 'La mesure',
     titre: 'Construite dans le code, pas déclarée dans une interface',
@@ -95,7 +95,7 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
   },
   {
     id: 'conformite',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'sea-ux',
     kicker: 'La conformité',
     titre: 'Par construction, pas en rattrapage',
@@ -123,7 +123,7 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
   },
   {
     id: 'pilotage',
-    kind: 'pole',
+    kind: 'chapitre',
     pole: 'sea-ux',
     kicker: 'Le pilotage',
     titre: 'Arbitrer sur la rentabilité réelle, pas sur les métriques des régies',

--- a/src/@vitrine/services/glass-policy.ts
+++ b/src/@vitrine/services/glass-policy.ts
@@ -2,23 +2,48 @@
 // Quelles sections reçoivent le verre réfractant, et combien au maximum.
 
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
+import type { SectionKind } from '@/interfaces/types'
 
 /**
- * Plafond de surfaces vitrées par page.
+ * Les natures de section qui peuvent recevoir le verre.
  *
- * liquidGL tient une trentaine de lentilles, mais chacune lit la même capture plein
- * document : le coût réel est celui de la texture, pas celui du nombre de panneaux. Le
- * plafond est donc là pour une raison de lecture, pas de performance — au-delà de trois
- * panneaux, l'effet cesse d'être un signal et devient un fond.
+ * `pole` sur l'accueil, `chapitre` sur une page de pôle : dans les deux cas une section
+ * de contenu à part entière. Les charnières et les fils restent en texte nu sur le fond
+ * — ce sont des respirations, et les vitrer reviendrait à les faire passer pour une
+ * offre de plus.
  */
-export const MAX_GLASS_PER_PAGE = 3
+const NATURES_VITRABLES: ReadonlySet<SectionKind> = new Set<SectionKind>(['pole', 'chapitre'])
 
 /**
- * Le verre marque les sections qui portent un pôle. Les charnières, elles, restent en
- * texte nu sur le fond : ce sont des respirations, et les vitrer reviendrait à les
- * transformer en quatrième offre.
+ * Plafond de surfaces vitrées sur l'accueil.
+ *
+ * L'accueil porte une section vitrable par pôle vendu. Le plafond y suit donc le nombre
+ * de pôles, et le relever est une décision éditoriale — pas un réglage technique.
  */
-export function selectGlassSectionIds(sections: IEditorialSection[]): Set<string> {
-  const eligibles = sections.filter((section) => section.kind === 'pole')
-  return new Set(eligibles.slice(0, MAX_GLASS_PER_PAGE).map((section) => section.id))
+export const MAX_GLASS_ACCUEIL = 3
+
+/**
+ * Plafond de surfaces vitrées sur une page de pôle.
+ *
+ * Une page de pôle compte aujourd'hui **quatre à cinq** chapitres vitrables : au-delà du
+ * plafond, les derniers sont rendus en texte nu. Ce n'est pas un accident, c'est la
+ * raison d'être du plafond — au-delà de trois panneaux, l'effet cesse d'être un signal
+ * et devient un fond. Mais la troncature n'est plus muette : elle est nommée ici, et
+ * l'appelant choisit son plafond au lieu de le subir.
+ *
+ * Le coût n'est pas la contrainte : liquidGL tient une trentaine de lentilles, et
+ * chacune lit la même capture plein document — le coût réel est celui de la texture, pas
+ * celui du nombre de panneaux. La contrainte est de lecture.
+ */
+export const MAX_GLASS_PAGE_POLE = 3
+
+/**
+ * Les identifiants des sections à vitrer, dans la limite du plafond demandé.
+ *
+ * Le plafond est un paramètre obligatoire : deux gabarits qui n'ont ni le même nombre de
+ * sections ni le même récit n'ont aucune raison de partager une constante implicite.
+ */
+export function selectGlassSectionIds(sections: IEditorialSection[], plafond: number): Set<string> {
+  const eligibles = sections.filter((section) => NATURES_VITRABLES.has(section.kind))
+  return new Set(eligibles.slice(0, plafond).map((section) => section.id))
 }

--- a/src/@vitrine/views/HomeView/index.tsx
+++ b/src/@vitrine/views/HomeView/index.tsx
@@ -13,7 +13,7 @@ import { PAGE_ACCUEIL, THESE_CHAINE } from '../../contenu/accueil'
 import { CERTIFICATIONS } from '../../contenu/certifications'
 import { LIMITES } from '../../contenu/limites'
 import { PREUVES } from '../../contenu/preuves'
-import { selectGlassSectionIds } from '../../services/glass-policy'
+import { MAX_GLASS_ACCUEIL, selectGlassSectionIds } from '../../services/glass-policy'
 import styles from './home-view.module.css'
 
 /**
@@ -22,7 +22,7 @@ import styles from './home-view.module.css'
  * qui distinguent une prise en charge continue d'un catalogue de trois prestations.
  */
 export function HomeView() {
-  const verre = selectGlassSectionIds(PAGE_ACCUEIL.sections)
+  const verre = selectGlassSectionIds(PAGE_ACCUEIL.sections, MAX_GLASS_ACCUEIL)
 
   return (
     <div className={styles.page}>

--- a/src/@vitrine/views/PolePageView/index.tsx
+++ b/src/@vitrine/views/PolePageView/index.tsx
@@ -8,7 +8,7 @@ import { CertificationList } from '../../components/CertificationList'
 import { EditorialSection } from '../../components/EditorialSection'
 import { PoleHero } from '../../components/PoleHero'
 import { selectCertificationsByPole } from '../../contenu/select-certifications'
-import { selectGlassSectionIds } from '../../services/glass-policy'
+import { MAX_GLASS_PAGE_POLE, selectGlassSectionIds } from '../../services/glass-policy'
 import styles from './pole-page-view.module.css'
 
 interface PolePageViewProps {
@@ -26,7 +26,7 @@ interface PolePageViewProps {
  * différentes auraient dit trois prestataires.
  */
 export function PolePageView({ pole, page, suivant }: PolePageViewProps) {
-  const verre = selectGlassSectionIds(page.sections)
+  const verre = selectGlassSectionIds(page.sections, MAX_GLASS_PAGE_POLE)
   const certifications = selectCertificationsByPole(pole.id)
 
   return (

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -10,11 +10,18 @@ export type PoleId = 'ingenierie-web' | 'data-ia' | 'sea-ux'
 export type PoleRank = 1 | 2 | 3
 
 /**
- * Nature d'une section éditoriale.
- * `charniere` désigne les deux sections qui passent la main d'un pôle au suivant :
- * elles portent le récit de continuité et se rendent différemment des autres.
- * `fil` désigne un axe transverse — une méthode qui traverse les trois pôles au lieu
- * de s'intercaler entre deux. Un `fil` ne reçoit jamais le verre : le vitrer en ferait
- * une quatrième offre, alors qu'il décrit la façon de tenir les trois autres.
+ * Nature d'une section éditoriale — elle commande le rendu.
+ *
+ * `pole` et `chapitre` ne sont pas la même chose, et les confondre coûte cher :
+ * - `pole` est une section de l'**accueil** qui porte un pôle entier. Il y en a autant
+ *   que de pôles vendus, et leur nombre bouge quand l'offre bouge.
+ * - `chapitre` est une subdivision **interne** à une page de pôle. Son nombre n'a aucun
+ *   rapport avec le nombre de pôles : c'est le découpage du récit d'une seule page.
+ *
+ * `charniere` désigne les sections qui passent la main d'un pôle au suivant : elles
+ * portent le récit de continuité et se rendent différemment des autres.
+ * `fil` désigne un axe transverse — une méthode qui traverse les pôles au lieu de
+ * s'intercaler entre deux. Un `fil` ne reçoit jamais le verre : le vitrer en ferait une
+ * offre de plus, alors qu'il décrit la façon de tenir les autres.
  */
-export type SectionKind = 'accroche' | 'pole' | 'charniere' | 'fil' | 'preuves' | 'contact'
+export type SectionKind = 'pole' | 'chapitre' | 'charniere' | 'fil' | 'preuves'


### PR DESCRIPTION
Closes #63

Lot **strictement preparatoire** au passage a quatre poles
(`Ingenierie web -> DATA -> ( IA et/ou SEA & UX )`). Aucun texte publie n'est touche,
aucun pole n'est ajoute, `PoleId` est inchange.

**Critere d'acceptation principal : le rendu ne bouge pas.** Il est verifie, pas
suppose — voir la section « Ce qui est verifie ».

---

## 1. Code mort — chaque suppression verifiee par grep AVANT d'etre faite

### `POLE_ORDER` (`src/@shared/routes.ts`)

```
$ grep -rn "POLE_ORDER" . | grep -v "^./.git/"
docs/data-model.md:83:  rattachement derivera de `PoleId` et de `POLE_ORDER` — jamais d'une liste de poles
src/@shared/routes.ts:18:export const POLE_ORDER = [
```

Zero consommateur de code : sa propre declaration, et une mention prospective dans la
doc. Il figeait un ordre lineaire a trois maillons qui serait faux dans le nouveau
modele, alors que l'ordre reel est deja porte par la position dans `POLES_NAV`. La
mention de doc pointe desormais `POLES_NAV`, en disant explicitement que l'ordre n'existe
qu'a un seul endroit.

### `'accroche'` et `'contact'` dans `SectionKind` (`src/interfaces/types.ts`)

```
$ grep -rn "kind:" src/ | sort
... aucune occurrence de kind: 'accroche' ni kind: 'contact'
```

Les seules occurrences de ces deux mots dans le depot sont **autre chose** : une
propriete `accroche: string` sur `IPole`, une classe CSS `.accroche`, une classe CSS
`.contact` et l'ancre `#contact` de l'accueil. Aucune n'est une valeur de `SectionKind`.
Ils faisaient croire a des natures de section qui n'existent pas.

### `counter-reset: maillon` (`chain-diagram.module.css`)

```
$ grep -rn "counter" src/
src/@vitrine/components/ChainDiagram/chain-diagram.module.css:12:  counter-reset: maillon;
```

Seule occurrence : aucun `counter()`, aucun `counter-increment` ne lit ce compteur. La
classe `.maillon` du meme fichier est un nom de classe, sans rapport avec le compteur, et
reste en place.

---

## 2. La confusion `kind: 'pole'`

La meme valeur servait a deux notions qui n'ont ni le meme role ni la meme portee :

| Notion | Occurrences avant | Apres |
|--------|-------------------|-------|
| Une section de **l'accueil** qui EST un pole | 3 — `accueil-sections.ts` x2, `accueil-data-ia.ts` x1 | reste `kind: 'pole'` |
| Un **chapitre interne** d'une page de pole | 13 — `data-ia-sections.ts` x5, `ingenierie-web-sections.ts` x4, `sea-ux-sections.ts` x4 | devient `kind: 'chapitre'` |

*(L'enonce initial situait les 3 sections d'accueil dans `accueil-sections.ts` ; il y en a
2 la-bas et 1 dans `accueil-data-ia.ts`, qui en avait ete extraite. Le total est bien 3.)*

Le nombre des premieres suit l'offre ; celui des seconds ne suit que le decoupage du
recit d'une seule page. A quatre poles, les confondre empeche de raisonner sur « les
sections qui portent un pole » sans attraper les chapitres de chaque page.

### Le plafond de verre n'est plus muet

`glass-policy.ts` filtrait `kind === 'pole'` puis `slice(0, 3)`. Sur `/services/data-ia/`,
qui compte **5** chapitres eligibles, il en tronquait deux **sans que rien ne le dise** —
et la meme constante servait a deux gabarits qui n'ont pas le meme nombre de sections.

Le plafond reste un choix de lecture legitime (au-dela de trois panneaux, le verre cesse
d'etre un signal et devient un fond ; le cout, lui, n'est pas la contrainte — liquidGL
tient une trentaine de lentilles qui lisent toutes la meme capture). Mais il devient un
**parametre obligatoire**, et chaque appelant nomme le sien :

- `MAX_GLASS_ACCUEIL` = 3, passe par `HomeView`
- `MAX_GLASS_PAGE_POLE` = 3, passe par `PolePageView`

L'eligibilite couvre desormais `pole` **et** `chapitre` (`NATURES_VITRABLES`). Les
charnieres, les fils et les preuves restent en texte nu, comme avant.

Les deux plafonds valent 3, comme l'ancienne constante unique : **le rendu ne bouge pas.**

---

## 3. La scission de `data-ia-sections.ts`

279 lignes pour un plafond dur a 300 : toute addition ulterieure faisait echouer
`check-max-lines.sh` au bout de 21 lignes. Scinde en `data-sections.ts` (176 l.) et
`ia-sections.ts` (137 l.), `data-ia.ts` (26 l.) recollant les deux tableaux.

**`PoleId` est inchange** — c'est un decoupage de fichiers, pas de types. `data-ia` reste
un seul pole, et `/services/data-ia/` rend le meme contenu dans le meme ordre.

### Classement bloc par bloc, sur le contenu et non sur le titre

| Chapitre | Vers | La phrase qui a decide |
|----------|------|------------------------|
| `metier` | **data** | « Reprise de l'historique, analyse exploratoire sous Orange Data Mining, ponderation et selection des variables » — de l'exploration de donnee. Le clustering y decrit des profils, il ne livre pas un modele ; le chapitre se referme d'ailleurs sur un document, pas sur une solution technique. |
| `strategie-data` | **data** | « Agregation et reconciliation multi-sources, dedoublonnage des identites selon votre modele metier » — collecte, plan de mesure, qualite, reconciliation d'identites. |
| `gouvernance` | **data** | « RGPD, base legale du traitement, consentement gere par une CMP avec declenchement conditionnel des tags par categorie » — gouvernance et droit de la donnee. Le chapitre cite un modele open-weight, mais pour dire qu'une contrainte de gouvernance **ecarte des solutions** : le sujet reste la donnee. |
| `solution` | **ia** | « Fine-tuning de Llama 3 sur corpus metier [...] RAG documentaire : recherche vectorielle PostgreSQL et API OpenAI » — arbitrage regle / modele / LLM. |
| `production` | **ia** | « Deploiement, versioning et monitoring **des modeles** [...] Vertex AI », et « votre produit devient utilisable par un **agent IA** » — inference et agents. |
| `charniere-arbitrage` | *(ni l'un ni l'autre)* | `kind: 'charniere'`, pas un chapitre : c'est la sortie de page vers le pole suivant. Posee **en dernier dans `ia-sections.ts`** pour que `[...SECTIONS_DATA, ...SECTIONS_IA]` rende exactement l'ordre d'avant la scission. **Son rattachement definitif reste a trancher** — voir plus bas. |

---

## Ce qui est verifie

`make lint`, `make type-check` et `make build` sont verts (le `noImgElement` sur
`CertificationList` est un warning preexistant, sans rapport avec cette PR).

**Le rendu est prouve identique**, pas suppose. L'export statique a ete construit avant
puis apres, et les 11 pages HTML comparees apres neutralisation des deux seules
empreintes qui changent a chaque `next build` sans que le rendu bouge (URL d'assets
hachees `/_next/static/...`, noms de classes CSS Modules, identifiant de build Next) :

```
IDENTIQUE  404.html                                        (verre: 0)
IDENTIQUE  404/index.html                                  (verre: 0)
IDENTIQUE  _not-found/index.html                           (verre: 0)
IDENTIQUE  blog/index.html                                 (verre: 0)
IDENTIQUE  blog/le-test-avant-le-code-meme-avec-un-agent/  (verre: 0)
IDENTIQUE  blog/mesurer-avant-d-arbitrer/index.html        (verre: 0)
IDENTIQUE  blog/pourquoi-ce-site-est-un-export-statique/   (verre: 0)
IDENTIQUE  index.html                                      (verre: 3)
IDENTIQUE  services/data-ia/index.html                     (verre: 3)
IDENTIQUE  services/ingenierie-web/index.html              (verre: 3)
IDENTIQUE  services/sea-ux/index.html                      (verre: 3)

RESULTAT : rendu identique
```

Quatre controles par page : HTML normalise **octet pour octet**, texte visible, nombre de
panneaux de verre, ordre des `id` de sections. **3 panneaux de verre sur l'accueil et sur
chacune des trois pages de pole, avant comme apres.**

Le script de comparaison est un outil de verification jetable, garde hors du depot : il
n'a rien a y faire une fois la PR relue.

---

## Intention de test (a poser par Jerome MARICHEZ)

Aucun test n'est ecrit dans cette PR : les tests sont ecrits par Jerome MARICHEZ. Le
comportement qui merite d'etre verrouille est celui de `glass-policy.ts`, seul endroit du
lot qui porte une regle et non une donnee.

**Niveau : unitaire** — `tests/unitaire/glass-policy.spec.ts`. Fonction pure, sans
frontiere reseau ni persistance : ni integration ni systeme ne se justifient.

**Jeu de donnees** : `tests/fixtures/editorial-section.fixture.json`, un tableau de
sections minimales (`id`, `kind`) couvrant les cinq natures — `pole`, `chapitre`,
`charniere`, `fil`, `preuves`. Je peux le preparer sur demande : un jeu de donnees n'est
pas un test.

**Comportements attendus :**

1. Une section `pole` est vitree ; une section `chapitre` aussi. C'est le coeur de la
   correction : les deux natures sont eligibles, et un test qui ne couvrirait que `pole`
   laisserait repasser le bug.
2. Une `charniere`, un `fil` et une section `preuves` ne sont **jamais** vitres, meme
   quand le plafond n'est pas atteint. L'exclusion tient a la nature, pas a la place
   restante.
3. Le plafond est respecte : avec 5 sections eligibles et un plafond de 3, le resultat en
   contient 3.
4. Ce sont les **premieres** sections eligibles qui sont retenues, dans l'ordre du
   tableau — c'est ce qui garantit que le verre marque le haut de page.
5. Le plafond est bien le parametre, pas une constante : le meme tableau passe avec 2
   puis avec 4 rend 2 puis 4 identifiants. C'est la mutation que Stryker doit tuer si
   quelqu'un rebranche une constante en dur.

**Cas limites :** plafond a 0 (ensemble vide) ; plafond superieur au nombre d'eligibles
(tous les eligibles, sans erreur) ; tableau vide ; tableau ne contenant aucune nature
vitrable.

---

## Ce qui reste a decider par Jerome MARICHEZ

1. **Le rattachement de `charniere-arbitrage`.** Elle n'est ni data ni ia : elle passe la
   main vers SEA & UX. Elle est provisoirement en fin de `ia-sections.ts` pour une raison
   purement mecanique — preserver l'ordre de rendu. Dans le modele cible ou Data est le
   passage oblige et ou IA et SEA & UX sont deux branches **paralleles**, cette charniere
   part logiquement de **Data**, pas d'IA. A trancher quand `PoleId` se scindera.

2. **Les deux plafonds de verre sont maintenant independants** et valent tous les deux 3
   pour ne rien changer au rendu. A quatre poles, l'accueil portera **4** sections
   vitrables : faut-il monter `MAX_GLASS_ACCUEIL` a 4, ou assumer que le quatrieme pole
   soit rendu en texte nu sur l'accueil ? C'est une decision editoriale, pas technique —
   elle n'est pas prise ici.

3. **Le vocabulaire des chapitres reste au modele a trois poles.** Les kickers disent
   encore « Pole 2 · Comprendre », « Charniere vers le pole 3 », et des textes publies
   parlent de « trois maillons ». C'est hors perimetre de ce lot, qui ne touche a aucun
   texte publie — mais c'est le prochain chantier, et il est plus gros que celui-ci.
