### PR TITLE
feature: moderniser le rendu visuel dans le cadre des quatre interdits

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -102,14 +102,56 @@ fonte préchargée est un fichier que le navigateur va chercher avant de peindre
 | Corps | **Inter** (variable) | `'ss01' 1, 'cv05' 1` |
 | Annotations et chiffres | **pile monospace système** | Ce registre est intégralement composé en capitales espacées, où le dessin propre à une fonte de labeur ne se distingue pas. `ui-monospace` prend SF Mono sur Apple ; tous les replis ont les chiffres à chasse fixe, seule vraie exigence des preuves |
 
-Échelle fluide en `clamp()`, base 16px : `--t--1` (13px) à `--t-4` (38→64px), plus
-`--t-chiffre` pour le mur de preuves. Mesures : 64ch sur le corps, 34ch sur les `h2`,
-20ch sur le `h1`, 46ch dans un panneau de verre.
+Échelle fluide en `clamp()`, base 16px : `--t--1` (13px) à `--t-4` (40→68px), plus
+`--t-note` (15px) et `--t-chiffre` (40→64px) pour le mur de preuves. Mesures : 64ch sur
+le corps, 30ch sur les `h2`, 18ch sur le `h1`, 46ch dans un panneau de verre.
+
+`--t-note` n'est pas un cran de confort : sept modules écrivaient `0.9375rem` en dur —
+menus, repères de charnière, notes de bas de section. Un demi-cran manquait à l'échelle,
+et chacun le réinventait chez lui.
+
+L'**interlettrage** est un jeton, jamais une valeur locale. Une fonte de titre se
+resserre à mesure qu'elle grandit — à 68 px, l'approche dessinée pour du labeur laisse
+des trous entre les lettres ; les étiquettes font l'inverse, capitales de 13 px qui ont
+besoin d'air.
+
+| Jeton | Valeur | Où |
+|-------|--------|-----|
+| `--suivi-display` | `-0.028em` | `h1` |
+| `--suivi-titre` | `-0.016em` | `h2`, `h3` |
+| `--suivi-etiquette` | `0.09em` | kickers, rangs, tout le registre monospace en capitales |
 
 ### Espaces et formes
 
-Rythme vertical sur base 8 : `--e-1` (8px) à `--e-7` (104px). `--rayon-verre` 18px,
+Rythme vertical sur base 8 : `--e-0` (4px) à `--e-7` (136px). `--rayon-verre` 18px,
 `--rayon-petit` 8px, `--largeur-page` 76rem.
+
+Trois jetons tiennent l'empilement collant, et un seul endroit les déclare :
+
+| Jeton | Rôle |
+|-------|------|
+| `--hauteur-entete` | hauteur nominale de l'en-tête. Volontairement **2 à 3 px sous** la hauteur réelle : la barre de pôle se glisse dessous plutôt que de laisser voir une bande de contenu défiler entre les deux. `SiteHeader` pose le `min-height` correspondant, pour que l'en-tête ne puisse jamais devenir plus court que son jeton |
+| `--hauteur-barre-pole` | hauteur de l'en-tête de pôle collant |
+| `--decalage-ancre` | `scroll-margin-top` de toute section ancrable. Les pages de pôle le redéfinissent localement : deux bandes collantes, donc deux hauteurs à déduire |
+
+### Le fond d'atelier
+
+`.fond-atelier` est un calque peint, séparé du contenu — c'est ce que liquidGL capture,
+et il fait plus de 9 000 px de haut sur l'accueil. **Tout ce qu'on y pose doit être une
+tuile.** Un `repeating-linear-gradient` sans `background-size` est généré une fois aux
+dimensions de son élément, puis capturé tel quel en texture.
+
+| Calque | Tuile | Rôle |
+|--------|-------|------|
+| grain (`--grain`) | 128px | `feTurbulence` en data-URI, alpha moyen **sous 4 %**. Deux tuiles, une par thème : du grain noir sur un fond à 6 % de luminance ne se voit pas, il ne fait qu'assombrir |
+| trame | 32px | deux filets `--trame`, la grille technique |
+| dégradé | plein élément | `radial-gradient`, la lueur d'atelier |
+
+Le grain est volontairement **une tuile de plus, et pas un filtre** : `filter: invert()`
+sur ce calque pour l'adapter au thème sombre forcerait une couche de compositing de la
+hauteur du document. Sous 4 % d'alpha, aucun couple texte/fond documenté ci-dessus ne
+descend sous son seuil AA — et l'audit de contraste n'est de toute façon pas concerné,
+le calque étant un frère du contenu, pas son ancêtre.
 
 ## Mouvement
 
@@ -119,10 +161,12 @@ personnalisé.
 
 | Geste | Où | Détail |
 |-------|-----|--------|
-| **Tracer** | les deux charnières | filet cuivre 2px, `scaleY(0)` → `scaleY(1)`, 700ms. Seul mouvement porteur de sens : la chaîne se trace |
-| **Traverser** | le fil IA | filets cuivre **horizontaux**, `scaleX(0)` → `scaleX(1)`, même durée. Perpendiculaires à ceux des charnières : la chaîne descend, le fil la coupe — la géométrie dit « ceci n'est pas une quatrième offre » |
+| **Poser** | toute section qui entre dans l'écran | `opacity: 0` → `1` et `translateY(24px)` → `none`, `--duree-poser`. Porté par [`Reveal`](../src/@shared/components/Reveal/index.tsx), qui s'appuie sur `useInViewport` — voir « La révélation » ci-dessous |
+| **Tracer** | les deux charnières | filet cuivre 2px, `scaleY(0)` → `scaleY(1)`, `--duree-tracer`. Seul mouvement porteur de sens : la chaîne se trace. Déclenché à l'entrée de la charnière dans l'écran, et non au chargement de la page |
+| **Traverser** | le fil IA | filets cuivre **horizontaux**, `scaleX(0)` → `scaleX(1)`, même durée, même déclenchement. Perpendiculaires à ceux des charnières : la chaîne descend, le fil la coupe — la géométrie dit « ceci n'est pas une quatrième offre » |
 | **Dériver** | la scène des trois dalles | deux fréquences lentes qui ne se referment jamais ensemble, en `transform` seul — assez pour faire lire du volume, jamais assez pour appeler le regard |
-| **Micro-états** | liens et boutons | épaisseur de soulignement, `translateY(-1px)`, 120 à 140ms — aucun déplacement de mise en page |
+| **Aimanter** | les boutons d'action | le bouton suit le pointeur, borné à **6 px** ([`utils/aimant.ts`](../src/utils/aimant.ts)), en `transform` seul. Souris uniquement : au doigt il n'y a pas de survol, l'attraction n'arriverait qu'après l'appui. `MagneticAction` est le **seul** module autorisé à poser un `transform` sur un bouton — deux règles concurrentes se départageraient à l'ordre du paquet CSS |
+| **Micro-états** | liens et boutons | épaisseur de soulignement, `--aimant-appui: -1px` au survol, `--duree-micro` — aucun déplacement de mise en page |
 
 Seuls `transform` et `opacity` sont animés, nulle part ailleurs. Ce sont les deux
 propriétés que le compositeur traite sans repasser par la mise en page ni par le peintre,
@@ -133,7 +177,64 @@ rendue **figée** — les dalles gardent leur pose — et liquidGL **n'est pas a
 tout**, sa boucle de rendu permanente étant une animation même quand aucune lentille ne
 bouge. Le bouton `MotionToggle` offre le même arrêt depuis la page, comme l'exige
 WCAG 2.2.2 : une préférence système n'est pas un mécanisme de mise en pause, elle ne se
-change pas depuis le site.
+change pas depuis le site. Tout ce qui est encore en attente se pose alors **sans
+transition** : figer l'animation et voir douze sections glisser en réponse à son propre
+clic serait la contradiction exacte de ce que le bouton promet.
+
+### La révélation
+
+Une révélation au défilement se paie normalement de deux défauts, et [`Reveal`](../src/@shared/components/Reveal/index.tsx)
+n'en accepte aucun :
+
+- **Rien n'est masqué au rendu serveur.** L'état caché n'est armé qu'après montage. Sans
+  JavaScript — ou si l'hydratation échoue — la page reste entièrement lisible. Une
+  révélation qui laisse du contenu à `opacity: 0` n'est pas un effet, c'est une panne, et
+  elle est invisible à celui qui l'écrit.
+- **Ce qui est déjà à l'écran n'est jamais caché puis remontré.** Au montage, seul ce qui
+  est *sous la ligne de flottaison* est armé. C'est le clignotement typique des
+  révélations au défilement, et il frappe d'abord le premier écran.
+
+L'état posé ne déclare **aucun** `transform` — pas même l'identité. Un
+`translate3d(0, 0, 0)` résiduel créerait un contexte d'empilement permanent sur chaque
+section, et l'empilement des lentilles liquidGL se compare dans le contexte racine (voir
+`glass-surface.css`).
+
+**La révélation enveloppe le corps d'une section, jamais la section elle-même**, et cette
+règle paie deux fois :
+
+- une section **vitrée** se retrouve ainsi sous `GlassSurface`, à l'intérieur d'un
+  conteneur qui est déjà un contexte d'empilement : le `transform` transitoire ne peut
+  pas déplacer la lentille dans l'ordre de peinture ;
+- une section **ancrable** ne bouge pas. Un `transform` sur l'élément que vise une ancre
+  décale la cible du `scrollIntoView` de la hauteur de la révélation : la section se pose
+  ensuite 24 px plus haut, et arrive sous l'en-tête. Les cinq sections ancrables de
+  l'accueil gardent donc leur `<section>` — identifiant et `scroll-margin-top` — et la
+  révélation passe à l'intérieur.
+
+Les charnières et le fil font exception : ce sont les seules révélations qui *sont* leur
+section, parce que le filet qui se trace est un `::before` de la section. Aucun lien ne
+pointe vers leur identifiant, et un lien profond arrivant de l'extérieur est exact de
+toute façon — le navigateur défile avant que React ne monte, donc la cible est déjà à
+l'écran et la révélation ne s'arme pas.
+
+## Les bandes collantes
+
+Deux bandes s'empilent en haut d'une page de pôle : l'en-tête du site, puis
+l'**en-tête de pôle** ([`PoleStickyBar`](../src/@vitrine/components/PoleStickyBar/index.tsx)).
+Une page de pôle se lit sur plusieurs écrans ; passé le seuil, plus rien ne disait lequel
+des pôles on lisait, et l'action de contact était restée en bas.
+
+| Contrainte | Parade |
+|------------|--------|
+| liquidGL **ignore** les éléments `sticky` | Ni l'un ni l'autre n'est une lentille. Fond plat, flou CSS au-delà de 1024px seulement — même recette pour les deux |
+| Sans flou, la translucidité laisse passer un **fantôme de texte** | En dessous de 1024px, la bande est **opaque**. La transparence du site est celle du verre, et le verre floute ; là où le flou n'est pas payé, la bande est pleine |
+| L'en-tête est bien plus haut sous 720px (il passe en colonne) | La barre de pôle y reste **dans le flux**. Deux bandes collantes sur un téléphone prendraient la place de ce qu'elles annoncent |
+| Une ancre ne doit pas se poser sous les bandes | `--decalage-ancre`, redéfini localement sur la page de pôle |
+
+La barre consomme **`--accent`**, la teinte du pôle courant, posée par `data-pole` sur la
+page (mécanisme de l'issue #44). Aucun composant ne connaît la couleur d'un pôle : il ne
+connaît que `--accent`. Tant que les teintes ne sont pas définies, le repli est le
+cuivre — la barre est correcte avant elles, et juste après.
 
 ## Le verre liquidGL
 

--- a/src/@shared/components/MagneticAction/index.tsx
+++ b/src/@shared/components/MagneticAction/index.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+// MagneticAction/index.tsx — jeromemarichez-fr
+// Le bouton d'action qui se laisse attirer par le pointeur.
+
+import { type PointerEvent, type ReactNode, useCallback, useEffect, useRef } from 'react'
+import { calculerDecalageAimant } from '@/utils/aimant'
+import { useMotionPaused } from '../../hooks/use-motion-paused'
+import styles from './magnetic-action.module.css'
+
+interface MagneticActionProps {
+  href: string
+  children: ReactNode
+  /** Classes d'apparence de l'appelant. Elles ne doivent jamais poser de `transform`. */
+  className?: string
+}
+
+/**
+ * Un lien d'action qui suit le pointeur de quelques pixels, et rien d'autre.
+ *
+ * Trois garde-fous, chacun pour une raison distincte :
+ *
+ * - **`transform` seul.** Aucune propriété de mise en page n'est touchée : la cible de
+ *   clic ne se déplace pas, rien ne se recalcule, et le geste tient 60 images par
+ *   seconde. Le décalage est borné à `PORTEE_AIMANT`, il ne peut pas déborder du bouton.
+ * - **Souris uniquement.** Au doigt, il n'y a pas de survol : l'attraction n'arriverait
+ *   qu'après l'appui, comme un bouton qui recule quand on le presse.
+ * - **Coupé avec le reste du mouvement.** `useMotionPaused` couvre la préférence
+ *   système et le `MotionToggle` de la page. Le décalage déjà posé est relâché à
+ *   l'instant où l'un des deux bascule, sans quoi le bouton resterait figé de travers.
+ *
+ * Le décalage passe par deux variables CSS écrites directement sur le nœud, jamais par
+ * l'état React : une position de pointeur change à chaque image, et re-rendre un arbre
+ * React à 60 Hz pour déplacer un bouton de six pixels coûterait plus que l'effet.
+ */
+export function MagneticAction({ href, children, className }: MagneticActionProps) {
+  const ref = useRef<HTMLAnchorElement>(null)
+  const fige = useMotionPaused()
+
+  const relacher = useCallback(() => {
+    const node = ref.current
+    if (!node) return
+    node.style.removeProperty('--aimant-x')
+    node.style.removeProperty('--aimant-y')
+  }, [])
+
+  useEffect(() => {
+    if (fige) relacher()
+  }, [fige, relacher])
+
+  const suivre = (evenement: PointerEvent<HTMLAnchorElement>) => {
+    const node = ref.current
+    if (!node || fige || evenement.pointerType !== 'mouse') return
+
+    const [x, y] = calculerDecalageAimant(
+      node.getBoundingClientRect(),
+      evenement.clientX,
+      evenement.clientY,
+    )
+    node.style.setProperty('--aimant-x', `${x}px`)
+    node.style.setProperty('--aimant-y', `${y}px`)
+  }
+
+  return (
+    <a
+      className={className ? `${styles.aimant} ${className}` : styles.aimant}
+      href={href}
+      onPointerCancel={relacher}
+      onPointerLeave={relacher}
+      onPointerMove={suivre}
+      ref={ref}
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/@shared/components/MagneticAction/magnetic-action.module.css
+++ b/src/@shared/components/MagneticAction/magnetic-action.module.css
@@ -1,0 +1,35 @@
+/* magnetic-action.module.css — l'attraction d'un bouton d'action.
+ *
+ * Cette classe est la SEULE à poser un `transform` sur un bouton d'action : les classes
+ * d'apparence des appelants ne portent que la couleur, le rembourrage et l'ombre. Deux
+ * règles qui déclarent `transform` sur le même élément se départageraient à l'ordre du
+ * paquet CSS, ce qui n'est pas une règle. */
+
+.aimant {
+  /* `--aimant-appui` reste dans la même déclaration : le survol soulève d'un pixel,
+     l'attraction décale de six, et les deux doivent composer sans s'écraser. */
+  transform: translate3d(
+    var(--aimant-x, 0px),
+    calc(var(--aimant-y, 0px) + var(--aimant-appui, 0px)),
+    0
+  );
+  transition: transform var(--duree-micro) var(--courbe-poser);
+}
+
+.aimant:hover {
+  --aimant-appui: -1px;
+}
+
+/* L'appui repose le bouton : c'est le retour tactile, et il doit être plus prompt que
+   l'attraction, sinon le clic paraît mou. */
+.aimant:active {
+  --aimant-appui: 0px;
+  transition-duration: var(--duree-appui);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aimant {
+    transform: none;
+    transition: none;
+  }
+}

--- a/src/@shared/components/MotionToggle/motion-toggle.module.css
+++ b/src/@shared/components/MotionToggle/motion-toggle.module.css
@@ -16,8 +16,8 @@
   letter-spacing: 0.04em;
   cursor: pointer;
   transition:
-    color 140ms ease-out,
-    border-color 140ms ease-out;
+    color var(--duree-micro) ease-out,
+    border-color var(--duree-micro) ease-out;
 }
 
 .bouton:hover {

--- a/src/@shared/components/Reveal/index.tsx
+++ b/src/@shared/components/Reveal/index.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+// Reveal/index.tsx — jeromemarichez-fr
+// La révélation à l'entrée de section : ce qui arrive se pose, il n'apparaît pas.
+
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { MARGE_TRACE, useInViewport } from '../../hooks/use-in-viewport'
+import { useMotionPaused } from '../../hooks/use-motion-paused'
+import styles from './reveal.module.css'
+
+interface RevealProps {
+  children: ReactNode
+  /** Balise rendue. La révélation prend la place de la section plutôt que de l'envelopper. */
+  as?: 'div' | 'section'
+  /** Classes de mise en page de l'appelant. Elles ne doivent jamais poser de `transform`. */
+  className?: string
+  id?: string
+  /** Repris tel quel en `aria-labelledby` quand la balise rendue est la section. */
+  ariaLabelledBy?: string
+}
+
+/**
+ * Porte le seul geste de révélation du site, et il n'y en a pas deux implémentations :
+ * `useInViewport` est le hook prévu pour ça, il ne fait que dire « c'est entré ».
+ *
+ * **Rien n'est masqué au rendu serveur.** L'état caché n'est armé qu'après montage, et
+ * seulement pour ce qui est encore *sous la ligne de flottaison* à cet instant. Deux
+ * défauts tombent d'un coup :
+ *
+ * - sans JavaScript, ou si l'hydratation échoue, la page reste entièrement lisible —
+ *   une révélation qui laisse du contenu à `opacity: 0` est une panne, pas un effet ;
+ * - ce qui est déjà à l'écran quand le JavaScript arrive n'est jamais caché *puis*
+ *   remontré. C'est le clignotement typique des révélations au défilement, et il est
+ *   d'autant plus visible qu'il frappe le premier écran.
+ *
+ * Le mouvement se coupe des deux côtés : `useMotionPaused` couvre la préférence système
+ * **et** le `MotionToggle` de la page (WCAG 2.2.2), et le module CSS repose la même
+ * garde sous `prefers-reduced-motion` — un état caché ne doit jamais dépendre du seul
+ * JavaScript pour se lever.
+ */
+export function Reveal({ children, as = 'div', className, id, ariaLabelledBy }: RevealProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const vu = useInViewport(ref, MARGE_TRACE)
+  const fige = useMotionPaused()
+  const [arme, setArme] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+    if (node.getBoundingClientRect().top > window.innerHeight) setArme(true)
+  }, [])
+
+  const Tag = as
+  const classes = className ? `${styles.revelation} ${className}` : styles.revelation
+
+  return (
+    <Tag
+      aria-labelledby={ariaLabelledBy}
+      className={classes}
+      data-revele={arme && !fige && !vu ? 'attente' : 'pose'}
+      id={id}
+      ref={ref}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/src/@shared/components/Reveal/index.tsx
+++ b/src/@shared/components/Reveal/index.tsx
@@ -10,7 +10,10 @@ import styles from './reveal.module.css'
 
 interface RevealProps {
   children: ReactNode
-  /** Balise rendue. La révélation prend la place de la section plutôt que de l'envelopper. */
+  /**
+   * Balise rendue. `section` est réservé aux charnières et au fil, dont le filet qui se
+   * trace est un `::before` de la section : eux seuls *sont* leur révélation.
+   */
   as?: 'div' | 'section'
   /** Classes de mise en page de l'appelant. Elles ne doivent jamais poser de `transform`. */
   className?: string
@@ -37,6 +40,13 @@ interface RevealProps {
  * **et** le `MotionToggle` de la page (WCAG 2.2.2), et le module CSS repose la même
  * garde sous `prefers-reduced-motion` — un état caché ne doit jamais dépendre du seul
  * JavaScript pour se lever.
+ *
+ * **On enveloppe le corps d'une section, pas la section.** Une section ancrée qui porte
+ * un `transform` décale la cible d'un `scrollIntoView` de la hauteur de la révélation :
+ * elle se pose ensuite 24 px plus haut et arrive sous l'en-tête. Et une section vitrée
+ * doit garder son `transform` à l'INTÉRIEUR de `GlassSurface`, sous un conteneur qui est
+ * déjà un contexte d'empilement — sinon la lentille liquidGL change d'ordre de peinture.
+ * Voir `docs/design.md`, section « La révélation ».
  */
 export function Reveal({ children, as = 'div', className, id, ariaLabelledBy }: RevealProps) {
   const ref = useRef<HTMLDivElement>(null)
@@ -57,6 +67,11 @@ export function Reveal({ children, as = 'div', className, id, ariaLabelledBy }: 
     <Tag
       aria-labelledby={ariaLabelledBy}
       className={classes}
+      // Posé UNIQUEMENT quand le mouvement est coupé — même convention que
+      // `SlabScene`. Il coupe la transition, sans quoi une personne qui vient de figer
+      // l'animation verrait, en réponse à son clic, toutes les sections encore en
+      // attente se poser en glissant.
+      data-fige={fige ? 'true' : undefined}
       data-revele={arme && !fige && !vu ? 'attente' : 'pose'}
       id={id}
       ref={ref}

--- a/src/@shared/components/Reveal/reveal.module.css
+++ b/src/@shared/components/Reveal/reveal.module.css
@@ -20,6 +20,10 @@
   transform: translate3d(0, var(--e-4), 0);
 }
 
+.revelation[data-fige="true"] {
+  transition: none;
+}
+
 /* Deuxième garde, indépendante du JavaScript : même si l'état « attente » était armé,
    il ne masquerait rien sous mouvement réduit. */
 @media (prefers-reduced-motion: reduce) {

--- a/src/@shared/components/Reveal/reveal.module.css
+++ b/src/@shared/components/Reveal/reveal.module.css
@@ -1,0 +1,34 @@
+/* reveal.module.css — la section se pose.
+ *
+ * `transform` et `opacity`, rien d'autre : ce sont les deux propriétés que le
+ * compositeur traite sans repasser par la mise en page ni par le peintre.
+ *
+ * L'état posé ne déclare AUCUN `transform`. Ce n'est pas une économie : un
+ * `translate3d(0, 0, 0)` laissé en place créerait un contexte d'empilement permanent
+ * sur chaque section, et l'empilement des lentilles liquidGL se compare dans le
+ * contexte racine (voir `glass-surface.css`). L'interpolation vers `none` est celle de
+ * la matrice identité — l'animation est la même, le contexte disparaît à l'arrivée. */
+
+.revelation {
+  transition:
+    opacity var(--duree-poser) var(--courbe-poser),
+    transform var(--duree-tracer) var(--courbe-tracer);
+}
+
+.revelation[data-revele="attente"] {
+  opacity: 0;
+  transform: translate3d(0, var(--e-4), 0);
+}
+
+/* Deuxième garde, indépendante du JavaScript : même si l'état « attente » était armé,
+   il ne masquerait rien sous mouvement réduit. */
+@media (prefers-reduced-motion: reduce) {
+  .revelation {
+    transition: none;
+  }
+
+  .revelation[data-revele="attente"] {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/src/@shared/components/SiteFooter/site-footer.module.css
+++ b/src/@shared/components/SiteFooter/site-footer.module.css
@@ -35,7 +35,7 @@
 
 .contact {
   font-family: var(--police-mono-pile);
-  font-size: 1.0625rem;
+  font-size: var(--t-0);
   width: fit-content;
 }
 
@@ -49,7 +49,7 @@
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--encre-douce);
 }
 
@@ -60,7 +60,7 @@
   margin: 0;
   padding: 0;
   list-style: none;
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
 }
 
 .mentions {

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -11,10 +11,12 @@
      cas d'école du jank au défilement : un en-tête `sticky` pleine largeur qui porte un
      `backdrop-filter` force le navigateur à reflouter la bande à chaque image, sur les
      appareils qui en ont le moins les moyens.
-     92% et non 88% : sans flou pour brouiller ce qui passe dessous, il faut un peu plus
-     de matière pour que le texte des sections ne reste pas lisible à travers l'en-tête.
-     La transparence ne doit jamais coûter la lisibilité du nom. */
-  background: color-mix(in srgb, var(--fond) 92%, transparent);
+     OPAQUE, et non translucide. Sans flou, il n'y a rien pour brouiller ce qui passe
+     dessous : un titre à fort contraste — tous les `h2` en thème sombre — reste
+     lisible à travers l'en-tête, et le défilement donne deux textes superposés. Ce
+     n'est pas de la transparence, c'est un fantôme. La transparence du site est celle
+     du verre, et le verre floute ; là où le flou n'est pas payé, la bande est pleine. */
+  background: var(--fond);
 }
 
 @media (min-width: 1024px) {

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -27,11 +27,17 @@
   }
 }
 
+/* Le plancher de hauteur n'est pas décoratif : `--hauteur-entete` est ce à quoi la
+   barre de pôle s'accroche. Si l'en-tête devenait plus court que son jeton, une bande
+   de contenu défilerait entre les deux — c'est le seul défaut visible de cet
+   empilement, et cette ligne l'empêche. Le jeton reste volontairement un poil sous la
+   hauteur réelle : la barre se glisse dessous plutôt que d'y laisser un jour. */
 .contenu {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--e-4);
+  min-height: var(--hauteur-entete);
   max-width: var(--largeur-page);
   margin-inline: auto;
   padding: var(--e-2) var(--e-4);
@@ -48,7 +54,7 @@
   font-family: var(--police-titre-pile);
   font-variation-settings: "opsz" 18;
   font-weight: 600;
-  font-size: 1.0625rem;
+  font-size: var(--t-0);
   line-height: 1.2;
 }
 
@@ -95,8 +101,8 @@
   border-radius: var(--rayon-petit);
   color: var(--encre);
   text-decoration: none;
-  font-size: 0.9375rem;
-  transition: background-color 140ms ease-out;
+  font-size: var(--t-note);
+  transition: background-color var(--duree-micro) ease-out;
 }
 
 .lien:hover {
@@ -120,7 +126,7 @@
   }
 
   .lien {
-    font-size: 0.875rem;
+    font-size: var(--t--1);
     padding-inline: var(--e-1);
   }
 }

--- a/src/@vitrine/components/BoundaryList/boundary-list.module.css
+++ b/src/@vitrine/components/BoundaryList/boundary-list.module.css
@@ -28,7 +28,7 @@
 
 .alaPlace {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
   line-height: 1.55;
   color: var(--encre-douce);
 }

--- a/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
+++ b/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
@@ -42,7 +42,7 @@
   font-weight: 500;
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--cuivre);
 }
 
@@ -68,7 +68,7 @@
   gap: var(--e-2);
   max-width: 40rem;
   padding-left: clamp(0rem, 4vw, 3.5rem);
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
   color: var(--encre-douce);
 }
 

--- a/src/@vitrine/components/EditorialSection/editorial-section.module.css
+++ b/src/@vitrine/components/EditorialSection/editorial-section.module.css
@@ -4,7 +4,16 @@
   display: flex;
   flex-direction: column;
   gap: var(--e-5);
-  scroll-margin-top: 6rem;
+  scroll-margin-top: var(--decalage-ancre);
+}
+
+/* Le corps porte le rythme interne de la section. Il est aussi l'élément que `Reveal`
+   révèle : aucun `transform` ne doit être écrit ici, c'est le module de la révélation
+   qui en est propriétaire. */
+.corps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
 }
 
 .entete {
@@ -18,7 +27,7 @@
   font-weight: 500;
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--cuivre);
 }
 

--- a/src/@vitrine/components/EditorialSection/index.tsx
+++ b/src/@vitrine/components/EditorialSection/index.tsx
@@ -2,6 +2,7 @@
 // Une section de contenu, rendue selon sa nature.
 
 import { GlassSurface } from '@/@shared/components/GlassSurface'
+import { Reveal } from '@/@shared/components/Reveal'
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 import { ExpertiseBlock } from '../ExpertiseBlock'
 import { HingeNote } from '../HingeNote'
@@ -33,8 +34,12 @@ export function EditorialSection({ section, glass = false }: EditorialSectionPro
 
   const titreId = `${section.id}-titre`
 
+  // La révélation enveloppe le CORPS, jamais la section. Quand la section est vitrée,
+  // elle se retrouve ainsi à l'intérieur de `GlassSurface`, sous un conteneur qui est
+  // déjà un contexte d'empilement : son `transform` transitoire ne peut pas déplacer la
+  // lentille liquidGL dans l'ordre de peinture. L'inverse casserait le verre.
   const corps = (
-    <>
+    <Reveal className={styles.corps}>
       <header className={styles.entete}>
         <p className={styles.kicker}>{section.kicker}</p>
         <h2 className={styles.titre} id={titreId}>
@@ -50,7 +55,7 @@ export function EditorialSection({ section, glass = false }: EditorialSectionPro
           ))}
         </div>
       ) : null}
-    </>
+    </Reveal>
   )
 
   return (

--- a/src/@vitrine/components/ExpertiseBlock/expertise-block.module.css
+++ b/src/@vitrine/components/ExpertiseBlock/expertise-block.module.css
@@ -24,11 +24,11 @@
 .decision {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--e-0);
   max-width: 46ch;
   padding-left: var(--e-2);
   border-left: 2px solid var(--cuivre-vif);
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
 }
 
 .decision {
@@ -41,6 +41,6 @@
   font-weight: 500;
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--encre-douce);
 }

--- a/src/@vitrine/components/HingeSection/hinge-section.module.css
+++ b/src/@vitrine/components/HingeSection/hinge-section.module.css
@@ -32,6 +32,10 @@
   transform: scaleY(0);
 }
 
+.charniere[data-fige="true"]::before {
+  transition: none;
+}
+
 .kicker {
   font-family: var(--police-mono-pile);
   font-weight: 500;

--- a/src/@vitrine/components/HingeSection/hinge-section.module.css
+++ b/src/@vitrine/components/HingeSection/hinge-section.module.css
@@ -10,9 +10,13 @@
   max-width: 60ch;
   margin-left: clamp(0rem, 6vw, 5rem);
   padding: var(--e-5) 0 var(--e-5) var(--e-4);
-  scroll-margin-top: 6rem;
+  scroll-margin-top: var(--decalage-ancre);
 }
 
+/* Le filet ne s'anime plus au chargement : `Reveal` pose `data-revele`, et le tracé
+   part quand la charnière entre réellement dans l'écran. Une transition plutôt qu'une
+   `animation` — l'état de départ n'existe que si la révélation a été armée, ce qui
+   n'arrive jamais sans JavaScript ni sous mouvement réduit. */
 .charniere::before {
   content: "";
   position: absolute;
@@ -21,7 +25,11 @@
   width: 2px;
   background: var(--cuivre-vif);
   transform-origin: top;
-  animation: tracer var(--duree-tracer) var(--courbe-tracer) both;
+  transition: transform var(--duree-tracer) var(--courbe-tracer);
+}
+
+.charniere[data-revele="attente"]::before {
+  transform: scaleY(0);
 }
 
 .kicker {
@@ -29,7 +37,7 @@
   font-weight: 500;
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--cuivre);
 }
 
@@ -57,14 +65,14 @@
   flex-wrap: wrap;
   align-items: baseline;
   gap: 0.6em;
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
 }
 
 .repereTitre {
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--encre);
 }
 
@@ -72,17 +80,13 @@
   color: var(--encre-douce);
 }
 
-@keyframes tracer {
-  from {
-    transform: scaleY(0);
-  }
-  to {
-    transform: scaleY(1);
-  }
-}
-
+/* Seconde garde, indépendante du JavaScript : le filet est entier, sans transition. */
 @media (prefers-reduced-motion: reduce) {
   .charniere::before {
-    animation: none;
+    transition: none;
+  }
+
+  .charniere[data-revele="attente"]::before {
+    transform: none;
   }
 }

--- a/src/@vitrine/components/HingeSection/index.tsx
+++ b/src/@vitrine/components/HingeSection/index.tsx
@@ -1,6 +1,7 @@
 // HingeSection/index.tsx — jeromemarichez-fr
 // Une charnière : le moment où un pôle passe la main au suivant.
 
+import { Reveal } from '@/@shared/components/Reveal'
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 import styles from './hinge-section.module.css'
 
@@ -18,12 +19,18 @@ interface HingeSectionProps {
  * l'argument n'est tenable que parce que c'est la même personne aux trois postes.
  *
  * Les repères sont rendus en liste : ce sont des faits d'exploitation, pas du décor.
+ *
+ * La section EST la révélation, elle n'est pas enveloppée dedans : le filet qui se
+ * trace est un `::before` de `.charniere`, et il doit partir au moment où la charnière
+ * entre à l'écran. Jusqu'ici l'animation démarrait au chargement de la page, donc pour
+ * les deux charnières à la fois, largement hors de vue — un tracé achevé avant d'être
+ * regardé ne raconte rien.
  */
 export function HingeSection({ section }: HingeSectionProps) {
   const titreId = `${section.id}-titre`
 
   return (
-    <section aria-labelledby={titreId} className={styles.charniere} id={section.id}>
+    <Reveal ariaLabelledBy={titreId} as="section" className={styles.charniere} id={section.id}>
       <p className={styles.kicker}>{section.kicker}</p>
       <h2 className={styles.titre} id={titreId}>
         {section.titre}
@@ -40,6 +47,6 @@ export function HingeSection({ section }: HingeSectionProps) {
           ))}
         </ul>
       ) : null}
-    </section>
+    </Reveal>
   )
 }

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -9,7 +9,11 @@
   gap: var(--e-6);
   max-width: var(--largeur-page);
   margin-inline: auto;
-  padding: var(--e-7) var(--e-4) var(--e-6);
+  /* Pas `--e-7` en tête : le cran du haut de l'échelle est devenu l'écart ENTRE deux
+     sections, et il est trop large ici. Le seuil doit tenir le titre, le chapô et le
+     bouton d'action sur le premier écran d'un portable — un titre plus ample ne vaut
+     rien s'il pousse l'action en dessous. */
+  padding: var(--e-5) var(--e-4) var(--e-6);
 }
 
 .discours {

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -22,7 +22,7 @@
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--encre-douce);
 }
 
@@ -57,6 +57,9 @@
   gap: var(--e-4);
 }
 
+/* Apparence seule : le `transform` appartient à `MagneticAction`, qui est le seul à en
+   poser un sur un bouton d'action. Deux règles concurrentes se départageraient à
+   l'ordre du paquet CSS, ce qui n'est pas une règle. */
 .actionPrincipale {
   display: inline-block;
   padding: var(--e-2) var(--e-4);
@@ -65,19 +68,11 @@
   color: var(--fond);
   text-decoration: none;
   font-weight: 500;
-  transition:
-    transform 140ms ease-out,
-    box-shadow 140ms ease-out;
+  transition: box-shadow var(--duree-micro) ease-out;
 }
 
 .actionPrincipale:hover {
-  transform: translateY(-1px);
   box-shadow: 0 6px 18px color-mix(in srgb, var(--cuivre) 30%, transparent);
-}
-
-.actionPrincipale:active {
-  transform: translateY(0);
-  transition-duration: 80ms;
 }
 
 .actionSecondaire {
@@ -97,14 +92,14 @@
 .jeton {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--e-0);
   max-width: 16ch;
 }
 
 .chiffre {
   font-family: var(--police-mono-pile);
   font-weight: 500;
-  font-size: 1.5rem;
+  font-size: var(--t-2);
   font-variant-numeric: tabular-nums;
   line-height: 1;
   color: var(--cuivre);

--- a/src/@vitrine/components/HomeHero/index.tsx
+++ b/src/@vitrine/components/HomeHero/index.tsx
@@ -3,6 +3,7 @@
 
 import Link from 'next/link'
 import { ChainCanvas } from '@/@shared/components/ChainCanvas'
+import { MagneticAction } from '@/@shared/components/MagneticAction'
 import { MotionToggle } from '@/@shared/components/MotionToggle'
 import { SITE_IDENTITY } from '@/@shared/seo/site'
 import { HERO_ACCUEIL } from '../../contenu/accueil'
@@ -31,9 +32,12 @@ export function HomeHero() {
         <p className={styles.methode}>{HERO_ACCUEIL.methode}</p>
 
         <p className={styles.actions}>
-          <a className={styles.actionPrincipale} href={`mailto:${SITE_IDENTITY.email}`}>
+          <MagneticAction
+            className={styles.actionPrincipale}
+            href={`mailto:${SITE_IDENTITY.email}`}
+          >
             Décrire mon besoin
-          </a>
+          </MagneticAction>
           <Link className={styles.actionSecondaire} href="#chaine">
             Voir la chaîne
           </Link>

--- a/src/@vitrine/components/PoleHero/pole-hero.module.css
+++ b/src/@vitrine/components/PoleHero/pole-hero.module.css
@@ -31,7 +31,7 @@
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--encre-douce);
 }
 
@@ -60,7 +60,7 @@
   padding-top: var(--e-3);
   border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
   max-width: var(--mesure-texte);
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
   color: var(--encre-douce);
 }
 

--- a/src/@vitrine/components/PoleStickyBar/index.tsx
+++ b/src/@vitrine/components/PoleStickyBar/index.tsx
@@ -1,0 +1,44 @@
+// PoleStickyBar/index.tsx — jeromemarichez-fr
+// L'en-tête de pôle collant : où l'on est, et la seule action de la page.
+
+import { MagneticAction } from '@/@shared/components/MagneticAction'
+import { SITE_IDENTITY } from '@/@shared/seo/site'
+import type { IPole } from '@/interfaces/IPole'
+import styles from './pole-sticky-bar.module.css'
+
+interface PoleStickyBarProps {
+  pole: IPole
+}
+
+/**
+ * Une page de pôle se lit sur plusieurs écrans : passé le seuil, plus rien ne dit
+ * lequel des pôles on est en train de lire, et l'action de contact est restée en bas.
+ * Cette barre répond aux deux, sans rien ajouter au discours.
+ *
+ * Elle prend `--accent`, la teinte du pôle courant, posée par `data-pole` sur la page
+ * (mécanisme de l'issue #44). Tant que les teintes ne sont pas définies, le repli est
+ * le cuivre : la barre est correcte avant elles, et juste après.
+ *
+ * Ce n'est **pas** une lentille de verre : liquidGL ignore délibérément les éléments
+ * `sticky`, une lentille y resterait figée sur la capture initiale. Le fond suit donc
+ * exactement la recette de `SiteHeader` — translucide plat partout, flou au-delà du
+ * seuil de 1024px seulement.
+ */
+export function PoleStickyBar({ pole }: PoleStickyBarProps) {
+  return (
+    <div className={styles.barre}>
+      <div className={styles.contenu}>
+        <p className={styles.repere}>
+          <span aria-hidden="true" className={styles.rang}>
+            {pole.rang}
+          </span>
+          <span className={styles.nom}>{pole.nom}</span>
+        </p>
+
+        <MagneticAction className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
+          Décrire mon besoin
+        </MagneticAction>
+      </div>
+    </div>
+  )
+}

--- a/src/@vitrine/components/PoleStickyBar/pole-sticky-bar.module.css
+++ b/src/@vitrine/components/PoleStickyBar/pole-sticky-bar.module.css
@@ -11,7 +11,9 @@
   position: static;
   z-index: 40;
   border-bottom: 1px solid color-mix(in srgb, var(--teinte-pole) 34%, transparent);
-  background: color-mix(in srgb, var(--fond) 92%, transparent);
+  /* Opaque tant que le flou n'est pas là, pour la même raison que `SiteHeader` : sans
+     flou, la translucidité ne fait que laisser passer un fantôme de texte. */
+  background: var(--fond);
 }
 
 /* Sous 720px, l'en-tête du site passe en colonne et occupe déjà une part sérieuse de

--- a/src/@vitrine/components/PoleStickyBar/pole-sticky-bar.module.css
+++ b/src/@vitrine/components/PoleStickyBar/pole-sticky-bar.module.css
@@ -1,0 +1,84 @@
+/* pole-sticky-bar.module.css — l'en-tête de pôle collant.
+ *
+ * Pas de liquidGL : la bibliothèque ignore les éléments `sticky`. Le fond est du CSS
+ * pur, et il change de nature au seuil de 1024px, exactement comme `SiteHeader`. */
+
+.barre {
+  /* Repli tant que les teintes de pôle de l'issue #44 ne sont pas posées. Un seul
+     endroit le déclare ; le reste du module ne connaît que `--teinte-pole`. */
+  --teinte-pole: var(--accent, var(--cuivre));
+
+  position: static;
+  z-index: 40;
+  border-bottom: 1px solid color-mix(in srgb, var(--teinte-pole) 34%, transparent);
+  background: color-mix(in srgb, var(--fond) 92%, transparent);
+}
+
+/* Sous 720px, l'en-tête du site passe en colonne et occupe déjà une part sérieuse de
+   l'écran : une seconde bande collante y prendrait la place de ce qu'elle annonce. La
+   barre reste donc dans le flux, utile au passage, jamais encombrante. */
+@media (min-width: 721px) {
+  .barre {
+    position: sticky;
+    /* Sous l'en-tête (z-index 50), et volontairement 2 à 3 px trop haut : la barre se
+       glisse dessous plutôt que de laisser voir une bande de contenu entre les deux. */
+    top: var(--hauteur-entete);
+  }
+}
+
+@media (min-width: 1024px) {
+  @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+    .barre {
+      background: color-mix(in srgb, var(--fond) 82%, transparent);
+      backdrop-filter: blur(14px) saturate(1.1);
+      -webkit-backdrop-filter: blur(14px) saturate(1.1);
+    }
+  }
+}
+
+.contenu {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--e-2);
+  min-height: var(--hauteur-barre-pole);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-1) var(--e-4);
+}
+
+.repere {
+  display: flex;
+  align-items: baseline;
+  gap: var(--e-2);
+  min-width: 0;
+}
+
+.rang {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  font-variant-numeric: tabular-nums;
+  color: var(--teinte-pole);
+}
+
+.nom {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: var(--suivi-etiquette);
+  color: var(--encre);
+}
+
+/* Aucun `transform` ici : il appartient à `MagneticAction`, qui est le seul à le poser
+   sur un bouton d'action. */
+.action {
+  flex: none;
+  padding: var(--e-1) var(--e-3);
+  border-radius: var(--rayon-petit);
+  background: var(--teinte-pole);
+  color: var(--fond);
+  font-size: var(--t-note);
+  font-weight: 500;
+  text-decoration: none;
+}

--- a/src/@vitrine/components/ProofWall/proof-wall.module.css
+++ b/src/@vitrine/components/ProofWall/proof-wall.module.css
@@ -27,12 +27,12 @@
 }
 
 .libelle {
-  font-size: 1.0625rem;
+  font-size: var(--t-0);
   color: var(--encre);
 }
 
 .contexte {
-  font-size: 0.875rem;
+  font-size: var(--t--1);
   line-height: 1.5;
   color: var(--encre-douce);
 }

--- a/src/@vitrine/components/ThreadSection/index.tsx
+++ b/src/@vitrine/components/ThreadSection/index.tsx
@@ -1,6 +1,7 @@
 // ThreadSection/index.tsx — jeromemarichez-fr
 // Le fil : une méthode qui traverse les trois pôles.
 
+import { Reveal } from '@/@shared/components/Reveal'
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 import styles from './thread-section.module.css'
 
@@ -22,7 +23,7 @@ export function ThreadSection({ section }: ThreadSectionProps) {
   const titreId = `${section.id}-titre`
 
   return (
-    <section aria-labelledby={titreId} className={styles.fil} id={section.id}>
+    <Reveal ariaLabelledBy={titreId} as="section" className={styles.fil} id={section.id}>
       <header className={styles.entete}>
         <p className={styles.kicker}>{section.kicker}</p>
         <h2 className={styles.titre} id={titreId}>
@@ -51,6 +52,6 @@ export function ThreadSection({ section }: ThreadSectionProps) {
           </li>
         ))}
       </ol>
-    </section>
+    </Reveal>
   )
 }

--- a/src/@vitrine/components/ThreadSection/thread-section.module.css
+++ b/src/@vitrine/components/ThreadSection/thread-section.module.css
@@ -29,6 +29,11 @@
   transform: scaleX(0);
 }
 
+.fil[data-fige="true"]::before,
+.fil[data-fige="true"]::after {
+  transition: none;
+}
+
 .fil::before {
   top: 0;
 }

--- a/src/@vitrine/components/ThreadSection/thread-section.module.css
+++ b/src/@vitrine/components/ThreadSection/thread-section.module.css
@@ -8,9 +8,11 @@
   flex-direction: column;
   gap: var(--e-5);
   padding: var(--e-6) 0 var(--e-5);
-  scroll-margin-top: 6rem;
+  scroll-margin-top: var(--decalage-ancre);
 }
 
+/* Comme la charnière : le tracé part à l'entrée du fil dans l'écran, pas au chargement
+   de la page. `Reveal` pose `data-revele` sur la section elle-même. */
 .fil::before,
 .fil::after {
   content: "";
@@ -19,7 +21,12 @@
   height: 2px;
   background: var(--cuivre-vif);
   transform-origin: left;
-  animation: tracer-fil var(--duree-tracer) var(--courbe-tracer) both;
+  transition: transform var(--duree-tracer) var(--courbe-tracer);
+}
+
+.fil[data-revele="attente"]::before,
+.fil[data-revele="attente"]::after {
+  transform: scaleX(0);
 }
 
 .fil::before {
@@ -42,7 +49,7 @@
   font-weight: 500;
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--cuivre);
 }
 
@@ -93,7 +100,7 @@
 
 .etapeTexte {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
   line-height: 1.55;
   color: var(--encre-douce);
 }
@@ -119,22 +126,18 @@
 .decisionLabel {
   font-family: var(--police-mono-pile);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--cuivre);
-}
-
-@keyframes tracer-fil {
-  from {
-    transform: scaleX(0);
-  }
-  to {
-    transform: scaleX(1);
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .fil::before,
   .fil::after {
-    animation: none;
+    transition: none;
+  }
+
+  .fil[data-revele="attente"]::before,
+  .fil[data-revele="attente"]::after {
+    transform: none;
   }
 }

--- a/src/@vitrine/views/ArticleView/article-view.module.css
+++ b/src/@vitrine/views/ArticleView/article-view.module.css
@@ -82,7 +82,7 @@
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--encre-douce);
 }
 
@@ -96,5 +96,5 @@
 }
 
 .retour {
-  font-size: 0.9375rem;
+  font-size: var(--t-note);
 }

--- a/src/@vitrine/views/HomeView/home-view.module.css
+++ b/src/@vitrine/views/HomeView/home-view.module.css
@@ -17,7 +17,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--e-4);
-  scroll-margin-top: 6rem;
+  scroll-margin-top: var(--decalage-ancre);
 }
 
 .kicker {
@@ -25,7 +25,7 @@
   font-weight: 500;
   font-size: var(--t--1);
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: var(--suivi-etiquette);
   color: var(--cuivre);
 }
 
@@ -53,9 +53,10 @@
   border: 1px solid var(--verre-arete);
   border-radius: var(--rayon-verre);
   background: color-mix(in srgb, var(--fond-creux) 60%, transparent);
-  scroll-margin-top: 6rem;
+  scroll-margin-top: var(--decalage-ancre);
 }
 
+/* Apparence seule : le `transform` appartient à `MagneticAction`. */
 .action {
   display: inline-block;
   padding: var(--e-2) var(--e-4);
@@ -64,17 +65,9 @@
   color: var(--fond);
   font-family: var(--police-mono-pile);
   text-decoration: none;
-  transition:
-    transform 140ms ease-out,
-    box-shadow 140ms ease-out;
+  transition: box-shadow var(--duree-micro) ease-out;
 }
 
 .action:hover {
-  transform: translateY(-1px);
   box-shadow: 0 6px 18px color-mix(in srgb, var(--cuivre) 30%, transparent);
-}
-
-.action:active {
-  transform: translateY(0);
-  transition-duration: 80ms;
 }

--- a/src/@vitrine/views/HomeView/home-view.module.css
+++ b/src/@vitrine/views/HomeView/home-view.module.css
@@ -13,11 +13,18 @@
   padding: 0 var(--e-4) var(--e-7);
 }
 
+/* La section ancrable ne porte que son identité : identifiant, marge d'ancre, et le
+   décor pour `.contact`. Elle ne se déplace JAMAIS — c'est `.corpsBloc` que `Reveal`
+   révèle. Un `transform` sur l'élément ancré décalerait la cible d'un `scrollIntoView`
+   de la hauteur de la révélation, et la section arriverait sous l'en-tête. */
 .bloc {
+  scroll-margin-top: var(--decalage-ancre);
+}
+
+.corpsBloc {
   display: flex;
   flex-direction: column;
   gap: var(--e-4);
-  scroll-margin-top: var(--decalage-ancre);
 }
 
 .kicker {
@@ -45,15 +52,18 @@
 }
 
 .contact {
-  display: flex;
-  flex-direction: column;
-  gap: var(--e-3);
-  align-items: flex-start;
   padding: var(--e-5);
   border: 1px solid var(--verre-arete);
   border-radius: var(--rayon-verre);
   background: color-mix(in srgb, var(--fond-creux) 60%, transparent);
   scroll-margin-top: var(--decalage-ancre);
+}
+
+.corpsContact {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+  align-items: flex-start;
 }
 
 /* Apparence seule : le `transform` appartient à `MagneticAction`. */

--- a/src/@vitrine/views/HomeView/index.tsx
+++ b/src/@vitrine/views/HomeView/index.tsx
@@ -31,64 +31,69 @@ export function HomeView() {
       <HomeHero />
 
       <div className={styles.corps}>
-        <Reveal ariaLabelledBy="chaine-titre" as="section" className={styles.bloc} id="chaine">
-          <p className={styles.kicker}>La thèse</p>
-          <h2 id="chaine-titre">{THESE_CHAINE.titre}</h2>
-          <p className={styles.chapo}>{THESE_CHAINE.chapo}</p>
-          <ChainDiagram />
-          <p className={styles.appui}>{THESE_CHAINE.appui}</p>
-        </Reveal>
+        <section aria-labelledby="chaine-titre" className={styles.bloc} id="chaine">
+          <Reveal className={styles.corpsBloc}>
+            <p className={styles.kicker}>La thèse</p>
+            <h2 id="chaine-titre">{THESE_CHAINE.titre}</h2>
+            <p className={styles.chapo}>{THESE_CHAINE.chapo}</p>
+            <ChainDiagram />
+            <p className={styles.appui}>{THESE_CHAINE.appui}</p>
+          </Reveal>
+        </section>
 
         {PAGE_ACCUEIL.sections.map((section) => (
           <EditorialSection glass={verre.has(section.id)} key={section.id} section={section} />
         ))}
 
-        <Reveal ariaLabelledBy="preuves-titre" as="section" className={styles.bloc} id="preuves">
-          <p className={styles.kicker}>Vérifiable</p>
-          <h2 id="preuves-titre">Ce qui est mesuré, pas ce qui est promis</h2>
-          <p className={styles.chapo}>
-            Chaque chiffre porte son contexte : où, quand, et sur quel produit. Sans cela, un
-            chiffre n'est qu'une affirmation de plus.
-          </p>
-          <ProofWall preuves={PREUVES} />
-        </Reveal>
+        <section aria-labelledby="preuves-titre" className={styles.bloc} id="preuves">
+          <Reveal className={styles.corpsBloc}>
+            <p className={styles.kicker}>Vérifiable</p>
+            <h2 id="preuves-titre">Ce qui est mesuré, pas ce qui est promis</h2>
+            <p className={styles.chapo}>
+              Chaque chiffre porte son contexte : où, quand, et sur quel produit. Sans cela, un
+              chiffre n'est qu'une affirmation de plus.
+            </p>
+            <ProofWall preuves={PREUVES} />
+          </Reveal>
+        </section>
 
-        <Reveal ariaLabelledBy="limites-titre" as="section" className={styles.bloc} id="limites">
-          <p className={styles.kicker}>Les limites</p>
-          <h2 id="limites-titre">Ce que je ne fais pas</h2>
-          <p className={styles.chapo}>
-            Un prestataire qui sait tout faire ne sait rien faire. Voici ce que je laisse à
-            d'autres, et ce que je fais à la place — c'est le bloc qui rend le reste croyable.
-          </p>
-          <BoundaryList limites={LIMITES} />
-        </Reveal>
+        <section aria-labelledby="limites-titre" className={styles.bloc} id="limites">
+          <Reveal className={styles.corpsBloc}>
+            <p className={styles.kicker}>Les limites</p>
+            <h2 id="limites-titre">Ce que je ne fais pas</h2>
+            <p className={styles.chapo}>
+              Un prestataire qui sait tout faire ne sait rien faire. Voici ce que je laisse à
+              d'autres, et ce que je fais à la place — c'est le bloc qui rend le reste croyable.
+            </p>
+            <BoundaryList limites={LIMITES} />
+          </Reveal>
+        </section>
 
-        <Reveal
-          ariaLabelledBy="certifications-titre"
-          as="section"
-          className={styles.bloc}
-          id="certifications"
-        >
-          <p className={styles.kicker}>Certifications</p>
-          <h2 id="certifications-titre">Ce qui a été évalué par quelqu'un d'autre que moi</h2>
-          <p className={styles.chapo}>
-            Aucun justificatif n'est publié en ligne à ce jour : ils sont communiqués sur demande.
-            Un lien mort sur un site qui vend de la rigueur coûterait plus cher que l'absence de
-            lien.
-          </p>
-          <CertificationList certifications={CERTIFICATIONS} />
-        </Reveal>
+        <section aria-labelledby="certifications-titre" className={styles.bloc} id="certifications">
+          <Reveal className={styles.corpsBloc}>
+            <p className={styles.kicker}>Certifications</p>
+            <h2 id="certifications-titre">Ce qui a été évalué par quelqu'un d'autre que moi</h2>
+            <p className={styles.chapo}>
+              Aucun justificatif n'est publié en ligne à ce jour : ils sont communiqués sur demande.
+              Un lien mort sur un site qui vend de la rigueur coûterait plus cher que l'absence de
+              lien.
+            </p>
+            <CertificationList certifications={CERTIFICATIONS} />
+          </Reveal>
+        </section>
 
-        <Reveal ariaLabelledBy="contact-titre" as="section" className={styles.contact} id="contact">
-          <h2 id="contact-titre">Décrivez-moi votre situation</h2>
-          <p className={styles.chapo}>
-            Vous écrivez à la personne qui fera le travail. Je vous dis ce que j'en ferais — et si
-            ce n'est pas pour moi, je vous le dis aussi.
-          </p>
-          <MagneticAction className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
-            {SITE_IDENTITY.email}
-          </MagneticAction>
-        </Reveal>
+        <section aria-labelledby="contact-titre" className={styles.contact} id="contact">
+          <Reveal className={styles.corpsContact}>
+            <h2 id="contact-titre">Décrivez-moi votre situation</h2>
+            <p className={styles.chapo}>
+              Vous écrivez à la personne qui fera le travail. Je vous dis ce que j'en ferais — et si
+              ce n'est pas pour moi, je vous le dis aussi.
+            </p>
+            <MagneticAction className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
+              {SITE_IDENTITY.email}
+            </MagneticAction>
+          </Reveal>
+        </section>
       </div>
 
       <LiquidGlassRuntime />

--- a/src/@vitrine/views/HomeView/index.tsx
+++ b/src/@vitrine/views/HomeView/index.tsx
@@ -2,6 +2,8 @@
 // La page d'accueil : la chaîne complète, d'un bout à l'autre.
 
 import { LiquidGlassRuntime } from '@/@shared/components/LiquidGlassRuntime'
+import { MagneticAction } from '@/@shared/components/MagneticAction'
+import { Reveal } from '@/@shared/components/Reveal'
 import { SITE_IDENTITY } from '@/@shared/seo/site'
 import { BoundaryList } from '../../components/BoundaryList'
 import { CertificationList } from '../../components/CertificationList'
@@ -29,19 +31,19 @@ export function HomeView() {
       <HomeHero />
 
       <div className={styles.corps}>
-        <section aria-labelledby="chaine-titre" className={styles.bloc} id="chaine">
+        <Reveal ariaLabelledBy="chaine-titre" as="section" className={styles.bloc} id="chaine">
           <p className={styles.kicker}>La thèse</p>
           <h2 id="chaine-titre">{THESE_CHAINE.titre}</h2>
           <p className={styles.chapo}>{THESE_CHAINE.chapo}</p>
           <ChainDiagram />
           <p className={styles.appui}>{THESE_CHAINE.appui}</p>
-        </section>
+        </Reveal>
 
         {PAGE_ACCUEIL.sections.map((section) => (
           <EditorialSection glass={verre.has(section.id)} key={section.id} section={section} />
         ))}
 
-        <section aria-labelledby="preuves-titre" className={styles.bloc} id="preuves">
+        <Reveal ariaLabelledBy="preuves-titre" as="section" className={styles.bloc} id="preuves">
           <p className={styles.kicker}>Vérifiable</p>
           <h2 id="preuves-titre">Ce qui est mesuré, pas ce qui est promis</h2>
           <p className={styles.chapo}>
@@ -49,9 +51,9 @@ export function HomeView() {
             chiffre n'est qu'une affirmation de plus.
           </p>
           <ProofWall preuves={PREUVES} />
-        </section>
+        </Reveal>
 
-        <section aria-labelledby="limites-titre" className={styles.bloc} id="limites">
+        <Reveal ariaLabelledBy="limites-titre" as="section" className={styles.bloc} id="limites">
           <p className={styles.kicker}>Les limites</p>
           <h2 id="limites-titre">Ce que je ne fais pas</h2>
           <p className={styles.chapo}>
@@ -59,9 +61,14 @@ export function HomeView() {
             d'autres, et ce que je fais à la place — c'est le bloc qui rend le reste croyable.
           </p>
           <BoundaryList limites={LIMITES} />
-        </section>
+        </Reveal>
 
-        <section aria-labelledby="certifications-titre" className={styles.bloc} id="certifications">
+        <Reveal
+          ariaLabelledBy="certifications-titre"
+          as="section"
+          className={styles.bloc}
+          id="certifications"
+        >
           <p className={styles.kicker}>Certifications</p>
           <h2 id="certifications-titre">Ce qui a été évalué par quelqu'un d'autre que moi</h2>
           <p className={styles.chapo}>
@@ -70,18 +77,18 @@ export function HomeView() {
             lien.
           </p>
           <CertificationList certifications={CERTIFICATIONS} />
-        </section>
+        </Reveal>
 
-        <section aria-labelledby="contact-titre" className={styles.contact} id="contact">
+        <Reveal ariaLabelledBy="contact-titre" as="section" className={styles.contact} id="contact">
           <h2 id="contact-titre">Décrivez-moi votre situation</h2>
           <p className={styles.chapo}>
             Vous écrivez à la personne qui fera le travail. Je vous dis ce que j'en ferais — et si
             ce n'est pas pour moi, je vous le dis aussi.
           </p>
-          <a className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
+          <MagneticAction className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
             {SITE_IDENTITY.email}
-          </a>
-        </section>
+          </MagneticAction>
+        </Reveal>
       </div>
 
       <LiquidGlassRuntime />

--- a/src/@vitrine/views/PolePageView/index.tsx
+++ b/src/@vitrine/views/PolePageView/index.tsx
@@ -2,11 +2,13 @@
 // Gabarit commun aux trois pages de pôle.
 
 import { LiquidGlassRuntime } from '@/@shared/components/LiquidGlassRuntime'
+import { Reveal } from '@/@shared/components/Reveal'
 import type { IEditorialPage } from '@/interfaces/IEditorialPage'
 import type { IPole } from '@/interfaces/IPole'
 import { CertificationList } from '../../components/CertificationList'
 import { EditorialSection } from '../../components/EditorialSection'
 import { PoleHero } from '../../components/PoleHero'
+import { PoleStickyBar } from '../../components/PoleStickyBar'
 import { selectCertificationsByPole } from '../../contenu/select-certifications'
 import { MAX_GLASS_PAGE_POLE, selectGlassSectionIds } from '../../services/glass-policy'
 import styles from './pole-page-view.module.css'
@@ -30,8 +32,12 @@ export function PolePageView({ pole, page, suivant }: PolePageViewProps) {
   const certifications = selectCertificationsByPole(pole.id)
 
   return (
-    <div className={styles.page}>
+    // `data-pole` est le porteur de la teinte : le bloc CSS qui mappe `--accent` sur
+    // l'identifiant du pôle s'y accroche, et tout ce qui est dessous en hérite. Aucun
+    // composant ne connaît la couleur d'un pôle, il ne connaît que `--accent`.
+    <div className={styles.page} data-pole={pole.id}>
       <PoleHero pole={pole} suivant={suivant} />
+      <PoleStickyBar pole={pole} />
 
       <div className={styles.corps}>
         {page.sections.map((section) => (
@@ -39,14 +45,18 @@ export function PolePageView({ pole, page, suivant }: PolePageViewProps) {
         ))}
 
         {certifications.length > 0 ? (
-          <section aria-labelledby="certifications-titre" className={styles.certifications}>
+          <Reveal
+            ariaLabelledBy="certifications-titre"
+            as="section"
+            className={styles.certifications}
+          >
             <h2 id="certifications-titre">Ce qui est certifié sur ce pôle</h2>
             <p className={styles.chapo}>
               Une certification ne remplace pas une réalisation. Elle dit seulement que la méthode a
               été évaluée par quelqu'un d'autre que moi.
             </p>
             <CertificationList certifications={certifications} />
-          </section>
+          </Reveal>
         ) : null}
       </div>
 

--- a/src/@vitrine/views/PolePageView/pole-page-view.module.css
+++ b/src/@vitrine/views/PolePageView/pole-page-view.module.css
@@ -2,8 +2,15 @@
  * Identique pour les trois, volontairement : trois mises en page différentes
  * diraient trois prestataires. */
 
+/* `position: relative` sans `z-index` : la page ne crée AUCUN contexte d'empilement,
+   sinon les lentilles liquidGL qu'elle contient ne se compareraient plus aux canvas
+   posés sur `body`. Voir `glass-surface.css`. La barre de pôle, elle, porte son propre
+   z-index et ne contient pas de verre. */
 .page {
   position: relative;
+  /* Deux bandes collantes sur une page de pôle, donc deux hauteurs à déduire pour
+     qu'une ancre ne se pose pas sous elles. */
+  --decalage-ancre: calc(var(--hauteur-entete) + var(--hauteur-barre-pole) + var(--e-3));
 }
 
 .corps {
@@ -12,7 +19,7 @@
   gap: var(--e-7);
   max-width: var(--largeur-page);
   margin-inline: auto;
-  padding: 0 var(--e-4) var(--e-7);
+  padding: var(--e-6) var(--e-4) var(--e-7);
 }
 
 .certifications {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -60,7 +60,7 @@
   --t-1: clamp(1.25rem, 1.16rem + 0.44vw, 1.5rem);
   --t-2: clamp(1.4375rem, 1.29rem + 0.72vw, 1.8125rem);
   --t-3: clamp(1.9375rem, 1.6rem + 1.75vw, 2.875rem);
-  --t-4: clamp(2.5rem, 1.72rem + 3.9vw, 4.5rem);
+  --t-4: clamp(2.5rem, 1.78rem + 3.6vw, 4.25rem);
   --t-chiffre: clamp(2.5rem, 1.85rem + 3.1vw, 4rem);
 
   /* — Interlettrage — */
@@ -212,7 +212,9 @@ h3 {
 
 h1 {
   font-size: var(--t-4);
-  line-height: 1.02;
+  /* 1.05 et non 1.02 : à 72 px, une jambe de « j » et l'ascendante de la ligne suivante
+     se touchent sous 1.05 dans Fraunces. Le gain d'un centième ne vaut pas ça. */
+  line-height: 1.05;
   letter-spacing: var(--suivi-display);
   /* 20ch était calé sur une échelle plus petite. À 72 px, la mesure se referme d'un
      cran : c'est le nombre de signes par ligne qui fait la tenue d'un titre, pas sa

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,18 @@
   --fond-degrade-haut: #f7f5f0;
   --fond-degrade-bas: #ede9e0;
 
+  /* Grain de papier : une TUILE de 128 px, comme la trame en est une de 32 px. Le
+     `feTurbulence` n'est rasterisé qu'une fois, sur 128×128 px, puis répété — même
+     raisonnement que pour la trame, et pour la même raison : `.fond-atelier` est le
+     calque que liquidGL capture, et il fait plus de 9 000 px de haut sur l'accueil.
+     Deux tuiles distinctes plutôt qu'une seule inversée par un filtre : `filter` sur un
+     calque plein document forcerait une couche de compositing de la hauteur du
+     document. Ici, rien n'est promis au compositeur.
+     L'alpha moyen est volontairement sous 4 % : au-delà, le grain cesse d'être une
+     texture et devient un voile qui déplace les contrastes documentés. */
+  --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.07 0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23g)'/%3E%3C/svg%3E");
+  --grain-tuile: 128px;
+
   /* — Typographie — */
   --police-titre-pile: var(--police-titre), Georgia, "Times New Roman", serif;
   --police-texte-pile: var(--police-texte), system-ui, -apple-system, sans-serif;
@@ -40,21 +52,35 @@
     "DejaVu Sans Mono", "Liberation Mono", Menlo, Consolas, monospace;
 
   --t--1: 0.8125rem;
+  /* Demi-cran sous le corps. Il porte tout ce qui accompagne sans être lu en continu :
+     menus, repères de charnière, notes de bas de section. Sans lui, ces sept endroits
+     réécrivaient `0.9375rem` en dur — la source unique n'en était plus une. */
+  --t-note: 0.9375rem;
   --t-0: clamp(1rem, 0.955rem + 0.22vw, 1.125rem);
-  --t-1: clamp(1.1875rem, 1.11rem + 0.38vw, 1.4375rem);
-  --t-2: clamp(1.375rem, 1.24rem + 0.68vw, 1.75rem);
-  --t-3: clamp(1.75rem, 1.5rem + 1.25vw, 2.4375rem);
-  --t-4: clamp(2.375rem, 1.8rem + 2.9vw, 4rem);
-  --t-chiffre: clamp(2.25rem, 1.7rem + 2.6vw, 3.5rem);
+  --t-1: clamp(1.25rem, 1.16rem + 0.44vw, 1.5rem);
+  --t-2: clamp(1.4375rem, 1.29rem + 0.72vw, 1.8125rem);
+  --t-3: clamp(1.9375rem, 1.6rem + 1.75vw, 2.875rem);
+  --t-4: clamp(2.5rem, 1.72rem + 3.9vw, 4.5rem);
+  --t-chiffre: clamp(2.5rem, 1.85rem + 3.1vw, 4rem);
+
+  /* — Interlettrage — */
+  /* Une fonte de titre gagne en tenue quand elle se resserre à mesure qu'elle grandit :
+     à 72 px, l'approche dessinée pour du labeur laisse des trous entre les lettres. Les
+     étiquettes font l'inverse — capitales de 13 px, elles ont besoin d'air pour rester
+     lisibles. Trois valeurs, jamais réécrites dans un module. */
+  --suivi-display: -0.028em;
+  --suivi-titre: -0.016em;
+  --suivi-etiquette: 0.09em;
 
   /* — Rythme vertical, base 8 — */
+  --e-0: 0.25rem;
   --e-1: 0.5rem;
   --e-2: 0.75rem;
   --e-3: 1rem;
   --e-4: 1.5rem;
-  --e-5: 2.5rem;
-  --e-6: 4rem;
-  --e-7: 6.5rem;
+  --e-5: 3rem;
+  --e-6: 5rem;
+  --e-7: 8.5rem;
 
   /* — Formes — */
   --rayon-verre: 18px;
@@ -62,7 +88,20 @@
   --largeur-page: 76rem;
   --mesure-texte: 64ch;
 
+  /* — Repères d'empilement collant — */
+  /* Hauteur nominale de l'en-tête, en un seul endroit : la barre de pôle s'y accroche,
+     et les ancres s'en déduisent. Volontairement 2 à 3 px SOUS la hauteur réelle — la
+     barre passe alors sous l'en-tête plutôt que de laisser voir une bande de contenu
+     entre les deux, qui serait le seul défaut visible des deux. */
+  --hauteur-entete: 4rem;
+  --hauteur-barre-pole: 3.25rem;
+  --decalage-ancre: calc(var(--hauteur-entete) + var(--e-4));
+
   /* — Mouvement — */
+  /* Trois durées, trois échelles : le micro-état répond à la main, la pose accompagne
+     l'arrivée d'une section, le tracé raconte. Aucun module ne réécrit de durée. */
+  --duree-appui: 80ms;
+  --duree-micro: 140ms;
   --duree-poser: 420ms;
   --duree-tracer: 700ms;
   --courbe-poser: cubic-bezier(0.2, 0.6, 0.2, 1);
@@ -84,6 +123,9 @@
     --verre-lueur: rgba(255, 255, 255, 0.14);
     --fond-degrade-haut: #14181d;
     --fond-degrade-bas: #0b0e11;
+    /* Même tuile, speckles clairs : du grain noir sur un fond à 6 % de luminance ne
+       se voit pas, il ne fait qu'assombrir encore. */
+    --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23g)'/%3E%3C/svg%3E");
   }
 }
 
@@ -136,7 +178,11 @@ body {
    mesure : un `repeating-linear-gradient` sans `background-size` est généré une fois aux
    dimensions de son élément, soit ici plus de 9 000 px de haut sur l'accueil, puis
    capturé tel quel en texture par liquidGL. Avec `background-size: 32px 32px`, le
-   navigateur ne rasterise qu'un carré de 32 px et le répète. */
+   navigateur ne rasterise qu'un carré de 32 px et le répète.
+
+   Le grain suit la MÊME règle et ne l'annule pas : c'est une quatrième tuile, de
+   128 px, posée au-dessus de la trame et sous le dégradé. Rien n'est rasterisé à la
+   hauteur du document. */
 .fond-atelier {
   position: absolute;
   inset: 0;
@@ -144,11 +190,12 @@ body {
   pointer-events: none;
   background-color: var(--fond-degrade-bas);
   background-image:
-    linear-gradient(to right, var(--trame) 0 1px, transparent 1px),
+    var(--grain), linear-gradient(to right, var(--trame) 0 1px, transparent 1px),
     linear-gradient(to bottom, var(--trame) 0 1px, transparent 1px),
     radial-gradient(1200px 900px at 22% 8%, var(--fond-degrade-haut), var(--fond-degrade-bas));
-  background-repeat: repeat, repeat, no-repeat;
+  background-repeat: repeat, repeat, repeat, no-repeat;
   background-size:
+    var(--grain-tuile) var(--grain-tuile),
     32px 32px,
     32px 32px,
     100% 100%;
@@ -165,20 +212,25 @@ h3 {
 
 h1 {
   font-size: var(--t-4);
-  line-height: 1.06;
-  letter-spacing: -0.015em;
-  max-width: 20ch;
+  line-height: 1.02;
+  letter-spacing: var(--suivi-display);
+  /* 20ch était calé sur une échelle plus petite. À 72 px, la mesure se referme d'un
+     cran : c'est le nombre de signes par ligne qui fait la tenue d'un titre, pas sa
+     largeur en pixels. */
+  max-width: 18ch;
 }
 
 h2 {
   font-size: var(--t-3);
-  line-height: 1.14;
-  max-width: 34ch;
+  line-height: 1.08;
+  letter-spacing: var(--suivi-titre);
+  max-width: 30ch;
 }
 
 h3 {
   font-size: var(--t-2);
-  line-height: 1.25;
+  line-height: 1.2;
+  letter-spacing: var(--suivi-titre);
 }
 
 p {
@@ -189,7 +241,7 @@ a {
   color: var(--cuivre);
   text-decoration-thickness: 1px;
   text-underline-offset: 0.18em;
-  transition: text-decoration-thickness 120ms ease-out;
+  transition: text-decoration-thickness var(--duree-micro) ease-out;
 }
 
 a:hover {

--- a/src/utils/aimant.ts
+++ b/src/utils/aimant.ts
@@ -1,0 +1,45 @@
+// aimant.ts — jeromemarichez-fr
+// Le décalage d'un bouton attiré par le pointeur. Fonction pure, sans DOM.
+
+/**
+ * Amplitude maximale du décalage, en pixels.
+ *
+ * Six pixels, et pas davantage : au-delà, le bouton quitte visiblement sa place et le
+ * geste devient un jouet. En deçà, il ne se remarque pas. C'est aussi la borne qui
+ * garantit que rien ne dépasse de la zone de clic — l'attraction reste un `transform`,
+ * la cible au pointeur ne bouge pas.
+ */
+export const PORTEE_AIMANT = 6
+
+function borner(valeur: number): number {
+  return Math.max(-1, Math.min(1, valeur))
+}
+
+/**
+ * Rend le décalage `[x, y]` à appliquer au bouton pour qu'il suive le pointeur.
+ *
+ * La position du pointeur est ramenée à `[-1, 1]` dans chaque axe du cadre, puis
+ * multipliée par la portée. Un pointeur au centre ne décale rien ; un pointeur au bord
+ * décale de la portée entière ; au-delà du cadre, le décalage est borné plutôt que de
+ * croître — sans quoi un mouvement rapide traversant le bouton l'enverrait au loin.
+ *
+ * Un cadre de largeur ou de hauteur nulle rend `0` sur l'axe concerné : l'élément n'est
+ * pas encore mis en page, il n'y a pas de centre à viser.
+ *
+ * @param cadre position et dimensions de l'élément, telles que les rend un `DOMRect`.
+ *   Le type est réduit aux quatre champs utiles pour que la fonction se teste sans DOM.
+ */
+export function calculerDecalageAimant(
+  cadre: { left: number; top: number; width: number; height: number },
+  pointeurX: number,
+  pointeurY: number,
+  portee: number = PORTEE_AIMANT,
+): readonly [number, number] {
+  const demiLargeur = cadre.width / 2
+  const demiHauteur = cadre.height / 2
+
+  const x = demiLargeur > 0 ? borner((pointeurX - (cadre.left + demiLargeur)) / demiLargeur) : 0
+  const y = demiHauteur > 0 ? borner((pointeurY - (cadre.top + demiHauteur)) / demiHauteur) : 0
+
+  return [x * portee, y * portee]
+}


### PR DESCRIPTION
Closes #50

## Ce qui change

Modernisation du rendu, **dans** le cadre de `docs/design.md`. Cinq gestes, plus ce que
la mesure et le rendu réel ont fait sortir.

### 1. Typographie et rythme

L'échelle `--t-*` monte d'un cran (`--t-4` : 64 → 68 px au maximum, `--t-3` : 39 → 46 px)
et gagne **`--t-note`** (15 px), le demi-cran qui manquait : sept modules réécrivaient
`0.9375rem` en dur, la source unique n'en était donc pas une. Trois jetons
d'**interlettrage** (`--suivi-display`, `--suivi-titre`, `--suivi-etiquette`) remplacent
les valeurs éparpillées. Le rythme `--e-5` à `--e-7` s'élargit (40/64/104 → 48/80/136 px),
toujours sur la base 8, et `--e-0` (4 px) reprend les deux `gap: 2px` en dur.

**Aucune taille, aucune durée, aucun interlettrage n'est plus écrit en dur dans un
module** — les sept `0.9375rem`, les deux `1.0625rem`, les deux `0.875rem`, le `1.5rem`,
les dix `letter-spacing: 0.09em` et les sept `120ms`/`140ms`/`80ms` passent par un jeton.

### 2. La révélation à l'entrée de section

`use-in-viewport.ts` avait été écrit puis **jamais importé**. Il porte maintenant
[`Reveal`](../blob/feature/modernisation-visuelle/src/@shared/components/Reveal/index.tsx),
et il n'y a pas de second hook.

Deux défauts habituels de ce geste sont évités par construction :

- **rien n'est masqué au rendu serveur.** L'état caché n'est armé qu'après montage. Sans
  JavaScript, la page reste entièrement lisible — vérifié : les 13 révélations sortent du
  build en `data-revele="pose"` ;
- **ce qui est déjà à l'écran n'est jamais caché puis remontré.** Seul ce qui est *sous la
  ligne de flottaison* au montage est armé. C'est le clignotement typique de ces
  révélations, et il frappe d'abord le premier écran.

Les filets « tracer » des charnières et du fil s'animaient **au chargement de la page**,
donc tous ensemble, largement hors de vue. Ils partent désormais quand la section entre
dans l'écran — ce qui était l'intention d'origine du hook, `MARGE_TRACE` comprise.

### 3. En-tête de pôle collant

Nouveau `PoleStickyBar` : rang, nom du pôle, et l'action de contact. Il consomme
**`--accent`**, posé par `data-pole` sur la page — le mécanisme de l'issue **#44**.

> **Point d'attention :** #44 n'est pas fusionnée, donc `--accent` n'existe pas encore.
> La barre consomme `var(--accent, var(--cuivre))` : elle est correcte aujourd'hui en
> cuivre, et prendra la teinte du pôle **sans une ligne de plus** dès que #44 arrive.
> `data-pole` est déjà posé sur la page pour l'accrocher.

Trois jetons nouveaux tiennent l'empilement : `--hauteur-entete` (volontairement 2 à 4 px
sous la hauteur réelle, pour que la barre se glisse dessous plutôt que de laisser voir
une bande de contenu entre les deux), `--hauteur-barre-pole`, `--decalage-ancre`. Sous
720 px, la barre reste **dans le flux** : l'en-tête y passe en colonne et occupe déjà
160 px, une seconde bande collante prendrait la place de ce qu'elle annonce.

### 4. Grain sur `.fond-atelier`

**Le choix de perf en place n'est pas annulé.** La trame reste une tuile de 32 px ; le
grain en est une **de 128 px**, `feTurbulence` en data-URI, alpha moyen **sous 4 %**. Rien
n'est rastérisé à la hauteur du document — c'est exactement le point du commentaire
existant, et il est étendu, pas contourné. Deux tuiles, une par thème, plutôt qu'un
`filter: invert()` qui forcerait une couche de compositing de la hauteur du document.

### 5. Survol magnétique

`MagneticAction` + `utils/aimant.ts` (fonction pure, testable sans DOM). `transform`
seul, borné à **6 px**, **souris uniquement** (au doigt il n'y a pas de survol :
l'attraction n'arriverait qu'après l'appui), coupé par le `MotionToggle` **et** par
`prefers-reduced-motion`, des deux côtés — le JavaScript n'écrit rien et le CSS repose la
garde. Le décalage passe par deux variables CSS écrites sur le nœud : re-rendre un arbre
React à 60 Hz pour bouger un bouton de six pixels coûterait plus que l'effet.

### Ce que la mesure et le rendu ont fait sortir

- **Le seuil poussait son bouton d'action sous la ligne de flottaison.** `--e-7` est
  devenu l'écart *entre* deux sections ; l'employer aussi en tête du seuil coûtait 136 px
  avant le titre. Et un titre de 78 signes prend une cinquième ligne au-delà de
  4.25 rem — l'ampleur se serait payée en action invisible.
- **Une section ancrée ne doit pas porter de `transform`.** `scrollIntoView` vise la boîte
  **après** transform : la cible arrivait 24 px trop haut, donc sous l'en-tête. Les cinq
  sections ancrables de l'accueil gardent désormais leur `<section>` — identifiant et
  `scroll-margin-top` — et la révélation passe à l'intérieur, comme elle le fait déjà
  dans `EditorialSection`. Mesuré : la cible se pose à 88 px, l'en-tête s'arrête à 68 px.
- **Une bande collante translucide sans flou ne fait que laisser passer un fantôme de
  texte.** Visible sur tout titre à fort contraste en thème sombre, sur tous les écrans
  sous 1024 px où le flou n'est délibérément pas payé. Sous le seuil, l'en-tête et la
  barre de pôle sont maintenant **opaques** ; au-dessus, le flou fait le travail et la
  translucidité reste.
- **La révélation ne transitionne plus quand le mouvement est figé** (`data-fige`, même
  convention que `SlabScene`). Répondre à un clic sur « Figer l'animation » par douze
  sections qui glissent serait la contradiction exacte de ce que le bouton promet.

## Les quatre interdits : aucun n'est introduit

| Interdit de `docs/design.md` | État dans cette PR |
|------------------------------|--------------------|
| Défilement détourné (Lenis, Locomotive) | **Aucun.** Zéro dépendance ajoutée, `package.json` inchangé. Le défilement reste celui du navigateur |
| Parallaxe | **Aucune.** Rien n'est lié à la position de défilement : `IntersectionObserver` dit « c'est entré », une fois, et n'en repart pas |
| Curseur personnalisé | **Aucun.** L'aimant déplace le **bouton**, jamais le curseur, qui reste celui du système |
| Compteur qui s'incrémente | **Aucun.** Les chiffres du mur de preuves et les rangs sont du texte statique rendu au serveur |

Et la règle « seuls `transform` et `opacity` sont animés » est tenue partout : la
révélation, les tracés et l'aimant n'animent rien d'autre. `CLS = 0` sur toutes les pages
mesurées le confirme.

## Vérifié

`make lint`, `make type-check`, `make build` et `make test` verts.

**Lighthouse** (mobile, Chrome 12.8.2, export statique servi **avec compression**, comme
le ferait un serveur de production) :

| Page | Perf | A11y | Bonnes pratiques | SEO |
|------|------|------|------------------|-----|
| Accueil | **96** | **100** | **100** | **100** |
| `/services/data-ia/` | **96** | **100** | **100** | **100** |
| `/services/ingenierie-web/` | **96** | **100** | **100** | **100** |
| `/blog/` | **97–98** | **100** | **100** | **100** |

FCP 1,1 s · LCP 2,8 s · TBT ≤ 30 ms · **CLS 0**. Coût de la PR : **+1,5 ko de JS et
+0,8 ko de CSS gzip**.

> **À décider par Jérôme MARICHEZ — un point sérieux, hors périmètre de cette issue.**
> Servi **sans compression**, l'export tombe à **80 en performance**, et `dev` y est
> exactement au même score : ce n'est pas une régression de cette PR, c'est la couche de
> service. `docker/nginx.conf` **n'active pas `gzip`**, et l'image nginx officielle le
> laisse commenté par défaut — la production sert donc probablement ~470 ko de JavaScript
> non compressé. Une ligne `gzip on;` vaut 16 points de Lighthouse. Cela mérite sa propre
> issue (proche de #25) ; je ne l'ai pas prise ici pour ne pas mélanger les sujets.

**Accessibilité (RGAA / WCAG AA)** — Lighthouse a11y à 100 sur les quatre pages, plus les
vérifications que Lighthouse ne fait pas :

- **Mouvement réduit** : sous `prefers-reduced-motion: reduce`, les 13 révélations restent
  `pose`, `opacity: 1`, `transform: none`, y compris très bas dans la page ; l'aimant
  n'écrit aucune variable et calcule `transform: none`. Mesuré au CDP dans les deux cas.
- **WCAG 2.2.2** : un clic sur `MotionToggle` relâche immédiatement toutes les sections en
  attente, **sans transition**.
- **Sans JavaScript** : les 13 révélations sortent du build en `data-revele="pose"`.
  Aucune ligne de contenu ne dépend du JavaScript pour être visible.
- **Contraste** : la barre de pôle porte `--fond` sur `--accent` — 6.02:1 en clair,
  6.96:1 en sombre. Aucun jeton n'est modifié ; le grain à moins de 4 % ne touche aucun
  couple documenté (le calque est un frère du contenu, pas son ancêtre).
- **Focus visible** : l'`outline` global est à 3 px de décalage, donc posé sur le fond de
  la bande et non sur le bouton — il reste visible sur un bouton de la même teinte.

## Intention de test (à poser par Jérôme MARICHEZ)

Je n'écris aucun test. Voici ce que je proposerais, dans l'ordre de valeur.

**Unitaire — `tests/unitaire/aimant.spec.ts`** (`src/utils/aimant.ts`, fonction pure, sans
DOM)

> *Intention* : `calculerDecalageAimant` rend un décalage borné, proportionnel à la
> position du pointeur dans le cadre.
>
> - pointeur au centre → `[0, 0]` ;
> - pointeur au coin bas-droit → `[+PORTEE, +PORTEE]`, au coin haut-gauche →
>   `[-PORTEE, -PORTEE]` ;
> - **cas limite** : pointeur **au-delà** du cadre (un mouvement rapide qui le traverse)
>   → toujours borné à `PORTEE`, jamais au-delà. C'est l'assertion qui compte : sans
>   elle, le bouton part au loin ;
> - **cas limite** : cadre de largeur ou de hauteur **nulle** (élément pas encore mis en
>   page) → `0` sur l'axe concerné, aucune division par zéro ;
> - `portee` passée explicitement est respectée.
>
> *Jeu de données* : cadres littéraux dans le test — quatre nombres, aucun DOM, aucune
> fixture ne se justifie.

**Unitaire — `tests/unitaire/reveal.spec.tsx`** (Jest + RTL)

> *Intention* : `Reveal` ne masque jamais rien qu'il ne puisse démasquer.
>
> - au rendu, l'élément porte `data-revele="pose"` — c'est l'état du rendu serveur, celui
>   qui garantit qu'une page sans JavaScript reste lisible ;
> - un élément dont le haut est **au-dessus** de `window.innerHeight` au montage n'est
>   **jamais** armé : il reste `pose` même si l'observateur ne l'a pas encore signalé ;
> - un élément **sous** la ligne de flottaison passe à `attente`, puis à `pose` quand
>   l'`IntersectionObserver` le signale ;
> - **cas limite** : `IntersectionObserver` absent de l'environnement → `pose` d'emblée,
>   jamais de contenu bloqué à `opacity: 0` ;
> - `as="section"` + `ariaLabelledBy` rendent bien `<section aria-labelledby="…">`.
>
> *Jeu de données* : aucun. `getBoundingClientRect` et `IntersectionObserver` sont des
> **frontières du navigateur** au sens de `docs/testing.md` — elles se pilotent, ce ne
> sont pas des doublures de module.

**e2e — `tests/e2e/revelation.cy.ts`** (Cypress ; à arbitrer, l'issue #51 signale que le
job e2e n'est pas encore opérationnel)

> *Intention* : le parcours réel tient les deux garanties.
>
> - au chargement de l'accueil, aucun texte du premier écran n'est à `opacity: 0` ;
> - en défilant jusqu'à `#preuves`, la section devient visible ;
> - un clic sur « Voir la chaîne » pose `#chaine` **sous** l'en-tête, pas derrière — le
>   défaut d'ancre corrigé dans cette PR, et le seul que seul un e2e rattrape ;
> - `cy.visit('/', { onBeforeLoad: … prefers-reduced-motion })` → tout est visible
>   immédiatement, aucune section en attente.

## Reste à décider par Jérôme MARICHEZ

1. **La compression en production** (voir l'encadré ci-dessus) : 16 points de Lighthouse
   pour une ligne de nginx. À ouvrir en issue.
2. **Le bouton « Décrire mon besoin » dans la barre de pôle** : l'issue demandait la
   teinte et le collant, pas une action. Je l'ai mis parce qu'une bande qui ne fait que
   répéter le `h1` est de la décoration sur un site qui la refuse — mais c'est un ajout
   de ma part, à retirer d'un mot si tu préfères.
3. **L'en-tête sous 720 px fait 160 px de haut et il est collant** : 18 % de l'écran d'un
   téléphone, en permanence. Antérieur à cette PR et hors périmètre, mais c'est le plus
   gros défaut d'ergonomie mobile qui reste.
4. **Dépendance à #44** : la teinte par pôle. Cette PR est câblée pour la recevoir.
