### PR TITLE
feat: une teinte par pole, jetons de verre et d'elevation

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -15,7 +15,14 @@ Conformité **WCAG 2.1 AA** sur les parcours principaux.
 - HTML **sémantique** d'abord (`nav`, `main`, `button`…) ; ARIA seulement en complément.
 - **Navigation clavier** complète : focus visible, ordre logique, pas de piège de focus.
 - **Formulaires** : chaque champ a un `label` associé ; erreurs annoncées (`aria-live`).
-- **Contrastes** : ratio ≥ 4.5:1 pour le texte courant.
+- **Contrastes** : ratio ≥ 4.5:1 pour le texte courant. Les **seize valeurs** de la
+  palette des pôles (`--accent` et `--accent-vif`, quatre pôles, deux thèmes) sont
+  mesurées et tabulées dans [`design.md`](./design.md) :
+  `--accent-vif` est **non-texte uniquement**, il est entre 3.5:1 et 3.9:1 en thème clair.
+- **La couleur n'est jamais le seul porteur d'information** (WCAG 1.4.1). La teinte de
+  pôle double une information déjà écrite — le nom du pôle, sa place, son temps. La
+  limite connue de cette palette sous vision dichromate est documentée dans `design.md`,
+  chiffres à l'appui, plutôt que passée sous silence.
 - **Images** : `alt` pertinent (ou vide si décorative).
 
 ## Checklist par composant

--- a/docs/design.md
+++ b/docs/design.md
@@ -3,8 +3,8 @@
 Direction retenue : **« L'Établi »**. Le site est un plan de travail vu à travers des
 panneaux de verre — on voit littéralement au travers parce qu'il n'y a rien à cacher,
 ni chaîne de prestataires ni couche commerciale. Les quatre pôles ne sont pas quatre
-offres côte à côte : ce sont des plaques alignées dans le même axe, tenues par un
-liseré de cuivre.
+offres côte à côte : ce sont des plaques alignées dans le même axe, chacune tenue par
+le liseré de sa propre teinte.
 
 > **Décor à reprendre.** La scène SVG du seuil (`ChainCanvas` / `SlabScene`) dessine
 > encore **trois** dalles en file, héritées du modèle à trois pôles linéaires. Elle est
@@ -76,9 +76,9 @@ ci-dessous sont ceux des couples texte/fond effectivement utilisés.
 | `--fond-creux` | `#E7E2D7` | bandes de section en retrait | — |
 | `--encre` | `#14171A` | texte courant et titres | 15.67:1 |
 | `--encre-douce` | `#4A5157` | texte secondaire, chapôs | 7.02:1 |
-| `--cuivre` | `#8F4520` | liens, accents de texte, focus | 6.02:1 |
+| `--cuivre` | `#8F4520` | teinte de marque, et teinte du pôle « ingénierie web » | 6.02:1 |
 | `--cuivre-vif` | `#B4623A` | **non-texte uniquement** : filets, arêtes | 3.85:1 |
-| `--signal` | `#1F5F52` | disponibilité, ligne « ce que vous tranchez » | 6.49:1 |
+| `--signal` | `#1F5F52` | **la décision, et rien d'autre** — voir plus bas | 6.49:1 |
 
 ### Couleurs — thème sombre
 
@@ -91,9 +91,144 @@ ci-dessous sont ceux des couples texte/fond effectivement utilisés.
 | `--cuivre-vif` | `#F0A468` | 9.21:1 |
 | `--signal` | `#5FD1AE` | 10.12:1 |
 
-> `--cuivre-vif` en thème clair est à **3.85:1** : il passe le seuil AA des éléments
-> non textuels (3:1) mais **pas** celui du texte (4.5:1). Il ne doit jamais porter de
-> texte en thème clair.
+### Une teinte par pôle
+
+La couleur porte une **information** : le pôle qu'on est en train de lire. Le mécanisme
+tient en trois lignes, dans [`poles.css`](../src/app/poles.css) :
+
+1. une page ou une section de pôle pose `data-pole="<id>"` ;
+2. un bloc CSS mappe `--accent` et `--accent-vif` sur la teinte de ce pôle ;
+3. **aucun composant ne connaît la couleur d'un pôle** — les dix-huit modules CSS du
+   site ne consomment que `--accent` et `--accent-vif`.
+
+Hors de tout `data-pole` — accueil, blog, en-tête, pied de page — `--accent` vaut le
+cuivre : la teinte de marque, qui est aussi celle du socle.
+
+Trois endroits posent `data-pole` : la page de pôle
+([`PolePageView`](../src/@vitrine/views/PolePageView/index.tsx)), chaque maillon du
+schéma de la chaîne ([`ChainDiagram`](../src/@vitrine/components/ChainDiagram/index.tsx)),
+et chaque entrée du menu ([`SiteHeader`](../src/@shared/components/SiteHeader/index.tsx)) —
+l'en-tête devient ainsi la légende de la palette.
+
+#### Le choix des teintes
+
+Les quatre teintes sont posées en **OKLCH**, sur une seule clarté et une seule chroma par
+variante : **seule la teinte change**. C'est ce qui interdit de lire une progression là où
+il n'y en a pas — en particulier entre l'IA et le SEA & UX, qui sont deux branches
+**parallèles** de la donnée et non deux étapes successives (`CLAUDE.md`). Deux couleurs
+d'éclat différent auraient affirmé dans le pixel un ordre que le modèle nie.
+
+| Pôle | Place | Teinte OKLCH | Lecture |
+|------|-------|--------------|---------|
+| Ingénierie web | socle, temps 1 | h ≈ 45 — cuivre | inchangée : c'est la couleur de la maison |
+| Data | passage, temps 2 | h = 215 — bleu d'encre | le tronc refroidit en passant du construire au mesurer |
+| IA | suite, temps 3 | h = 300 — violet | à **+85°** du bleu de la donnée |
+| SEA & UX | suite, temps 3 | h = 130 — vert | à **−85°** du bleu de la donnée |
+
+Les deux suites sont **équidistantes** de la teinte de leur parent, à clarté et chroma
+strictement égales : la branche ne progresse pas, elle se dédouble.
+
+#### Contraste — les 16 valeurs, mesurées
+
+Luminance relative WCAG 2.x, calculée sur les valeurs sRGB effectives. **Aucune n'est
+arrondie ni estimée.**
+
+| Pôle | `--accent` clair | `--accent-vif` clair | `--accent` sombre | `--accent-vif` sombre |
+|------|------------------|----------------------|-------------------|-----------------------|
+| Ingénierie web | `#8F4520` — **6.02:1** | `#B4623A` — **3.85:1** | `#E08B4C` — **7.18:1** | `#F0A468` — **9.21:1** |
+| Data | `#00697B` — **5.53:1** | `#008AA1` — **3.55:1** | `#01B6D4` — **7.79:1** | `#48CBE7` — **9.89:1** |
+| IA | `#674D91` — **6.00:1** | `#8669B7` — **3.88:1** | `#AF8FE8` — **7.14:1** | `#C3A6F8` — **9.14:1** |
+| SEA & UX | `#48691D` — **5.52:1** | `#638937` — **3.54:1** | `#87B357` — **7.77:1** | `#9FC774` — **9.83:1** |
+
+- **`--accent` porte du texte** : seuil 4.5:1. Les huit valeurs le passent, la plus basse
+  à 5.52:1 (SEA & UX en thème clair).
+- **`--accent-vif` ne porte JAMAIS de texte** : seuil non-texte 3:1. Les quatre valeurs
+  claires sont entre 3.54:1 et 3.88:1 — au-dessus de 3:1, **sous** 4.5:1. C'est la même
+  règle que celle qui s'appliquait déjà au cuivre vif, étendue aux quatre pôles : filets,
+  arêtes, liserés, jamais un mot.
+- En thème sombre, les seize valeurs dépassent 7:1 : aucune contrainte n'y est tendue.
+
+#### Ce que la palette ne résout pas
+
+Le bleu de la donnée est la seule teinte dont la **chroma est bridée par le gamut sRGB**
+en thème clair : 0.084 au lieu des 0.110 des trois autres. Le cyan profond n'existe pas
+plus saturé à cette clarté. La conséquence est visible — la donnée paraît légèrement
+moins colorée que ses voisines sur fond clair — et elle est assumée : baisser les trois
+autres à 0.084 aurait éteint toute la palette pour aligner une seule teinte.
+
+Le **daltonisme** est la limite réelle de cette issue, et elle mérite d'être dite en
+clair. Quatre teintes à clarté et chroma égales ne peuvent pas rester toutes
+distinguables entre elles sous une vision dichromate : c'est une propriété de l'espace
+des couleurs, pas un défaut d'implémentation. Le choix a donc porté sur la paire qui
+compte le plus — les deux sœurs :
+
+| Paire | Protanopie | Deutéranopie | Tritanopie |
+|-------|-----------|--------------|------------|
+| IA / SEA & UX (retenue, h 300 / 130) | ΔE 0.199 | ΔE 0.180 | ΔE 0.024 |
+| *cyan / magenta voisins (écartée, h 210 / 320)* | *ΔE 0.061* | *ΔE 0.003* | *ΔE 0.115* |
+
+ΔE en OKLab, simulation Viénot 1999. La paire voisine — celle qui aurait le mieux dit
+« même famille chromatique » — rend les deux suites **strictement identiques** pour une
+deutéranopie, qui touche environ 5 % des hommes. La paire retenue les sépare franchement
+sur les deux formes courantes de daltonisme, et faiblement sur la tritanopie, qui touche
+moins de 0.01 % de la population. Le prix payé est un écart de teinte plus large que
+l'idéal esthétique.
+
+Dans tous les cas, **la couleur n'est jamais le seul porteur d'information** (WCAG 1.4.1) :
+chaque pôle porte aussi son nom, son libellé de place et son temps.
+
+> **À trancher par Jérôme MARICHEZ.** Si l'écart de teinte entre l'IA et le SEA & UX
+> paraît trop large à l'œil, l'alternative est documentée ci-dessus, avec son coût exact.
+
+### `--signal` : la décision, et rien d'autre
+
+`--signal` n'est pas une couleur d'ambiance. Il marque **la ligne « vous tranchez »**,
+partout où un bloc éditorial en porte une (`decision:` dans les contenus — une trentaine
+d'occurrences), et le **témoin de mise en pause** du `MotionToggle`. Trois emplois, une
+seule idée : *ici, une décision*.
+
+| Où | Forme |
+|----|-------|
+| `ExpertiseBlock` | filet vertical à gauche du bloc de décision |
+| `ThreadSection` | l'étiquette « Vous tranchez » |
+| `MotionToggle` | la pastille de l'animation active |
+
+La **ligne de preuve** ne le porte plus : elle prend `--accent`. Une couleur qui sert à
+deux choses ne sert plus à rien.
+
+### Verre et élévation
+
+Le flou du verre était écrit en dur dans trois modules, et les ombres du site étaient
+quatre littéraux différents. Tout est en jetons dans [`verre.css`](../src/app/verre.css).
+
+**Le voile n'est pas le flou.** Deux réglages indépendants font une surface de verre : le
+flou de ce qui passe derrière, et la part de fond opaque mélangée à la teinte.
+
+| Jeton | Valeur | Où |
+|-------|--------|-----|
+| `--verre-flou` | `14px` | les six surfaces floutées, au-delà de 1024px |
+| `--verre-saturation` | `1.15` | les panneaux de verre |
+| `--verre-saturation-bande` | `1.1` | les bandes collantes : ce qui passe dessous est du texte, pas un décor |
+| `--verre-epaisseur` | `1px` | l'arête d'un panneau, le filet d'une bande |
+| `--verre-epaisseur-lueur` | `1px` | la lueur haute, à l'intérieur |
+| `--verre-voile` | `55%` | panneaux : la trame doit rester visible |
+| `--verre-voile-bande` | `88%` | en-tête du site |
+| `--verre-voile-barre` | `82%` | barre de pôle |
+
+L'**échelle d'élévation** compte trois crans, dans l'ordre, et pas un de plus — un cran
+sans emploi serait un jeton mort, exactement le défaut corrigé ici :
+
+| Jeton | Sens | Où |
+|-------|------|-----|
+| `--elevation-creuse` | un creux **dans** le papier | la plaque de logo d'une certification |
+| `--elevation-posee` | posé **sur** le papier : la lueur d'arête d'une surface au repos | `.glass-surface`, les plaques de la chaîne, le bloc de contact |
+| `--elevation-levee` | **au-dessus** : la seule vraie ombre portée du site, teintée par `--accent` | une action sous la main |
+
+**Six surfaces répliquent un flou hors de liquidGL** — la bibliothèque ignore le `sticky`,
+et tout n'est pas une lentille : `SiteHeader`, `PoleStickyBar`, `ChainDiagram`,
+`HomeView` (`.contact`), `ThreadSection`, `CertificationList`. Elles consomment toutes les
+jetons ci-dessus. C'est la condition pour qu'un réglage du verre les emmène ensemble au
+lieu d'en laisser cinq derrière.
 
 ### Typographie
 
@@ -238,9 +373,9 @@ des pôles on lisait, et l'action de contact était restée en bas.
 | Une ancre ne doit pas se poser sous les bandes | `--decalage-ancre`, redéfini localement sur la page de pôle |
 
 La barre consomme **`--accent`**, la teinte du pôle courant, posée par `data-pole` sur la
-page (mécanisme de l'issue #44). Aucun composant ne connaît la couleur d'un pôle : il ne
-connaît que `--accent`. Tant que les teintes ne sont pas définies, le repli est le
-cuivre — la barre est correcte avant elles, et juste après.
+page. Aucun composant ne connaît la couleur d'un pôle : il ne connaît que `--accent`. Elle
+consomme aussi `--verre-voile-barre`, `--verre-flou` et `--verre-saturation-bande` : son
+fond n'a plus une seule valeur qui lui soit propre.
 
 ## Le verre liquidGL
 

--- a/src/@shared/components/MotionToggle/motion-toggle.module.css
+++ b/src/@shared/components/MotionToggle/motion-toggle.module.css
@@ -22,7 +22,7 @@
 
 .bouton:hover {
   color: var(--encre);
-  border-color: var(--cuivre);
+  border-color: var(--accent);
 }
 
 .temoin {

--- a/src/@shared/components/SiteHeader/index.tsx
+++ b/src/@shared/components/SiteHeader/index.tsx
@@ -15,6 +15,10 @@ import styles from './site-header.module.css'
  * initiale et dériverait au défilement. Son fond est donc un `backdrop-filter` CSS
  * classique — moins spectaculaire, mais juste à toutes les positions de défilement.
  *
+ * Chaque entrée porte `data-pole` : le chiffre du temps prend la teinte de son pôle,
+ * et l'en-tête devient la légende de la palette du site. Aucune couleur n'est nommée
+ * ici — le lien ne connaît que `--accent`.
+ *
  * Le chiffre porté par chaque lien n'est pas un rang mais le **temps** de la chaîne, et
  * l'IA comme le SEA & UX portent le même : ce sont les deux suites de la donnée, et rien
  * ne les ordonne. C'est aussi pour cela que la liste est un `<ul>` et non un `<ol>` — un
@@ -36,7 +40,7 @@ export function SiteHeader() {
           <nav aria-label="Les quatre pôles" className={styles.navigation}>
             <ul className={styles.liste}>
               {POLES_NAV.map((pole) => (
-                <li key={pole.id}>
+                <li data-pole={pole.id} key={pole.id}>
                   <Link className={styles.lien} href={pole.route}>
                     <span aria-hidden="true" className={styles.temps}>
                       {pole.temps}

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -6,7 +6,7 @@
   position: sticky;
   top: 0;
   z-index: 50;
-  border-bottom: 1px solid color-mix(in srgb, var(--encre) 10%, transparent);
+  border-bottom: var(--verre-epaisseur) solid color-mix(in srgb, var(--encre) 10%, transparent);
   /* Fond translucide PLAT, sans flou. C'est le rendu de tous les petits écrans, et le
      cas d'école du jank au défilement : un en-tête `sticky` pleine largeur qui porte un
      `backdrop-filter` force le navigateur à reflouter la bande à chaque image, sur les
@@ -22,9 +22,9 @@
 @media (min-width: 1024px) {
   @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
     .entete {
-      background: color-mix(in srgb, var(--fond) 88%, transparent);
-      backdrop-filter: blur(14px) saturate(1.1);
-      -webkit-backdrop-filter: blur(14px) saturate(1.1);
+      background: color-mix(in srgb, var(--fond) var(--verre-voile-bande), transparent);
+      backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation-bande));
+      -webkit-backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation-bande));
     }
   }
 }
@@ -108,13 +108,13 @@
 }
 
 .lien:hover {
-  background: color-mix(in srgb, var(--cuivre) 12%, transparent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .temps {
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 /* Sous 720px, le chiffre du temps suffit à situer chaque pôle : les intitulés

--- a/src/@shared/components/SkipLink/skip-link.module.css
+++ b/src/@shared/components/SkipLink/skip-link.module.css
@@ -10,7 +10,7 @@
   border-radius: var(--rayon-petit);
   background: var(--fond);
   color: var(--encre);
-  border: 1px solid var(--cuivre);
+  border: 1px solid var(--accent);
   text-decoration: none;
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);

--- a/src/@vitrine/components/ArticleCard/article-card.module.css
+++ b/src/@vitrine/components/ArticleCard/article-card.module.css
@@ -31,7 +31,7 @@
 
 .lien:hover,
 .lien:focus-visible {
-  color: var(--cuivre);
+  color: var(--accent);
   text-decoration: underline;
   text-underline-offset: 0.18em;
 }

--- a/src/@vitrine/components/CertificationList/certification-list.module.css
+++ b/src/@vitrine/components/CertificationList/certification-list.module.css
@@ -5,8 +5,8 @@
  * paragraphe d'apport (issue #49).
  *
  * Aucun justificatif n'étant publié à ce jour, la liste s'affiche entièrement sans
- * lien. Le style ne simule donc pas de lien : rien n'est souligné ni coloré en
- * cuivre tant qu'il n'y a pas de cible réelle.
+ * lien. Le style ne simule donc pas de lien : rien n'est souligné ni coloré à
+ * l'accent tant qu'il n'y a pas de cible réelle.
  *
  * Aucune valeur de couleur en dur : les deux qui subsistaient (`#fbfaf7` sur la plaque
  * et `#4a5157` sur le repli) sont passées aux jetons de `globals.css`. La seconde était
@@ -44,7 +44,7 @@
   padding: var(--e-2) var(--e-3);
   border-radius: var(--rayon-petit);
   background: var(--fond-creux);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--encre) 10%, transparent);
+  box-shadow: var(--elevation-creuse);
 }
 
 .logo {
@@ -83,5 +83,5 @@
   font-size: var(--t--1);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
-  color: var(--cuivre);
+  color: var(--accent);
 }

--- a/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
+++ b/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
@@ -31,10 +31,10 @@
   gap: var(--e-1);
   max-width: 34rem;
   padding: var(--e-4);
-  border: 1px solid var(--verre-arete);
+  border: var(--verre-epaisseur) solid var(--verre-arete);
   border-radius: var(--rayon-verre);
-  background: color-mix(in srgb, var(--fond) 55%, transparent);
-  box-shadow: inset 0 1px 0 var(--verre-lueur);
+  background: color-mix(in srgb, var(--fond) var(--verre-voile), transparent);
+  box-shadow: var(--elevation-posee);
 }
 
 .place {
@@ -43,7 +43,7 @@
   font-size: var(--t--1);
   text-transform: uppercase;
   letter-spacing: var(--suivi-etiquette);
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .nom {
@@ -53,7 +53,7 @@
 
 .lien {
   color: var(--encre);
-  text-decoration-color: var(--cuivre-vif);
+  text-decoration-color: var(--accent-vif);
 }
 
 .promesse {
@@ -81,7 +81,7 @@
   flex: none;
   width: 2px;
   height: 1.6em;
-  background: var(--cuivre-vif);
+  background: var(--accent-vif);
 }
 
 .embranchement {
@@ -91,7 +91,7 @@
   font-size: var(--t--1);
   text-transform: uppercase;
   letter-spacing: 0.09em;
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .branches {

--- a/src/@vitrine/components/ChainDiagram/index.tsx
+++ b/src/@vitrine/components/ChainDiagram/index.tsx
@@ -64,7 +64,10 @@ export function ChainDiagram() {
         const unique = sortantes.length === 1 ? sortantes[0] : undefined
 
         return (
-          <li className={styles.maillon} key={pole.id}>
+          // `data-pole` porte la teinte du maillon : la plaque ET l'arête qui en part
+          // en héritent. Les branches, imbriquées, posent la leur et l'emportent — la
+          // cascade dit la structure sans qu'aucun module ne nomme une couleur.
+          <li className={styles.maillon} data-pole={pole.id} key={pole.id}>
             <Plaque pole={pole} />
 
             {unique ? <Arete jointure={unique} /> : null}
@@ -79,7 +82,7 @@ export function ChainDiagram() {
                     const entrante = jointureVers(suite.id)
 
                     return (
-                      <li className={styles.branche} key={suite.id}>
+                      <li className={styles.branche} data-pole={suite.id} key={suite.id}>
                         <Plaque pole={suite} />
                         {entrante ? <Arete jointure={entrante} /> : null}
                       </li>

--- a/src/@vitrine/components/EditorialSection/editorial-section.module.css
+++ b/src/@vitrine/components/EditorialSection/editorial-section.module.css
@@ -28,7 +28,7 @@
   font-size: var(--t--1);
   text-transform: uppercase;
   letter-spacing: var(--suivi-etiquette);
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .titre {

--- a/src/@vitrine/components/ExpertiseBlock/expertise-block.module.css
+++ b/src/@vitrine/components/ExpertiseBlock/expertise-block.module.css
@@ -1,6 +1,8 @@
 /* expertise-block.module.css — un point d'expertise.
  * La preuve et la décision sont les deux seules lignes qu'un dirigeant pressé lira :
- * elles sont repérables au filet cuivre, sans être criées. */
+ * elles sont repérables à leur filet, sans être criées : la teinte du pôle pour la
+ * preuve, `--signal` pour la décision. Ce filet vert est le marqueur de la décision
+ * partout sur le site — c'est sa seule fonction, avec le témoin de mise en pause. */
 
 .bloc {
   display: flex;
@@ -27,7 +29,7 @@
   gap: var(--e-0);
   max-width: 46ch;
   padding-left: var(--e-2);
-  border-left: 2px solid var(--cuivre-vif);
+  border-left: 2px solid var(--accent-vif);
   font-size: var(--t-note);
 }
 

--- a/src/@vitrine/components/HingeNote/hinge-note.module.css
+++ b/src/@vitrine/components/HingeNote/hinge-note.module.css
@@ -1,5 +1,5 @@
 /* hinge-note.module.css — la charnière.
- * Le filet vertical cuivre est le seul mouvement du site qui porte du sens : la
+ * Le filet vertical d'accent est le seul mouvement du site qui porte du sens : la
  * chaîne se trace. Il est purement décoratif au sens accessibilité — les lecteurs
  * d'écran n'entendent que la phrase. */
 
@@ -21,7 +21,7 @@
   inset-block: 0;
   left: 0;
   width: 2px;
-  background: var(--cuivre-vif);
+  background: var(--accent-vif);
   transform-origin: top;
   animation: tracer var(--duree-tracer) var(--courbe-tracer) both;
 }

--- a/src/@vitrine/components/HingeSection/hinge-section.module.css
+++ b/src/@vitrine/components/HingeSection/hinge-section.module.css
@@ -1,5 +1,5 @@
 /* hinge-section.module.css — la charnière.
- * Bande en retrait, filet cuivre vertical qui se trace à l'entrée : c'est le seul
+ * Bande en retrait, filet d'accent vertical qui se trace à l'entrée : c'est le seul
  * mouvement du site qui porte du sens — la chaîne se trace sous les yeux. */
 
 .charniere {
@@ -23,7 +23,7 @@
   inset-block: 0;
   left: 0;
   width: 2px;
-  background: var(--cuivre-vif);
+  background: var(--accent-vif);
   transform-origin: top;
   transition: transform var(--duree-tracer) var(--courbe-tracer);
 }
@@ -42,7 +42,7 @@
   font-size: var(--t--1);
   text-transform: uppercase;
   letter-spacing: var(--suivi-etiquette);
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .titre {

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -41,13 +41,13 @@
   color: var(--encre-douce);
 }
 
-/* La ligne de méthode : filet cuivre à gauche, comme le fil transverse plus bas dans la
+/* La ligne de méthode : filet d'accent à gauche, comme le fil transverse plus bas dans la
    page. Elle n'est pas une accroche de plus — c'est le rappel visuel qui relie le seuil
    à la section « Le fil ». */
 .methode {
   max-width: 52ch;
   padding-left: var(--e-3);
-  border-left: 2px solid var(--cuivre-vif);
+  border-left: 2px solid var(--accent-vif);
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   line-height: 1.6;
@@ -68,7 +68,7 @@
   display: inline-block;
   padding: var(--e-2) var(--e-4);
   border-radius: var(--rayon-petit);
-  background: var(--cuivre);
+  background: var(--accent);
   color: var(--fond);
   text-decoration: none;
   font-weight: 500;
@@ -76,7 +76,7 @@
 }
 
 .actionPrincipale:hover {
-  box-shadow: 0 6px 18px color-mix(in srgb, var(--cuivre) 30%, transparent);
+  box-shadow: var(--elevation-levee);
 }
 
 .actionSecondaire {
@@ -106,7 +106,7 @@
   font-size: var(--t-2);
   font-variant-numeric: tabular-nums;
   line-height: 1;
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .libelle {

--- a/src/@vitrine/components/PoleHero/pole-hero.module.css
+++ b/src/@vitrine/components/PoleHero/pole-hero.module.css
@@ -26,7 +26,7 @@
   font-size: var(--t-chiffre);
   font-variant-numeric: tabular-nums;
   line-height: 1;
-  color: color-mix(in srgb, var(--cuivre) 45%, transparent);
+  color: color-mix(in srgb, var(--accent) 45%, transparent);
 }
 
 .placeTexte {
@@ -47,7 +47,7 @@
   font-variation-settings: "opsz" 28;
   font-size: var(--t-2);
   line-height: 1.3;
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .accroche {
@@ -58,13 +58,13 @@
 }
 
 /* L'arête entrante : ce que le pôle amont remet, puis ce qui se passe quand le client
-   l'a déjà. Le liseré de cuivre à gauche la détache du récit du pôle — ce n'est pas une
+   l'a déjà. Le liseré d'accent à gauche la détache du récit du pôle — ce n'est pas une
    promesse de plus, c'est la condition d'entrée et son démenti dans la même phrase. */
 .jointure {
   max-width: var(--mesure-texte);
   padding-left: var(--e-3);
-  border-left: 2px solid var(--cuivre-vif);
-  font-size: 0.9375rem;
+  border-left: 2px solid var(--accent-vif);
+  font-size: var(--t-note);
   color: var(--encre-douce);
 }
 

--- a/src/@vitrine/components/PoleStickyBar/index.tsx
+++ b/src/@vitrine/components/PoleStickyBar/index.tsx
@@ -16,8 +16,8 @@ interface PoleStickyBarProps {
  * Cette barre répond aux deux, sans rien ajouter au discours.
  *
  * Elle prend `--accent`, la teinte du pôle courant, posée par `data-pole` sur la page
- * (mécanisme de l'issue #44). Tant que les teintes ne sont pas définies, le repli est
- * le cuivre : la barre est correcte avant elles, et juste après.
+ * (`poles.css`). Elle ne nomme aucune couleur : c'est la cascade qui décide, et la barre
+ * serait juste sur un cinquième pôle sans qu'une ligne d'ici ne bouge.
  *
  * Ce n'est **pas** une lentille de verre : liquidGL ignore délibérément les éléments
  * `sticky`, une lentille y resterait figée sur la capture initiale. Le fond suit donc

--- a/src/@vitrine/components/PoleStickyBar/pole-sticky-bar.module.css
+++ b/src/@vitrine/components/PoleStickyBar/pole-sticky-bar.module.css
@@ -4,13 +4,9 @@
  * pur, et il change de nature au seuil de 1024px, exactement comme `SiteHeader`. */
 
 .barre {
-  /* Repli tant que les teintes de pôle de l'issue #44 ne sont pas posées. Un seul
-     endroit le déclare ; le reste du module ne connaît que `--teinte-pole`. */
-  --teinte-pole: var(--accent, var(--cuivre));
-
   position: static;
   z-index: 40;
-  border-bottom: 1px solid color-mix(in srgb, var(--teinte-pole) 34%, transparent);
+  border-bottom: var(--verre-epaisseur) solid color-mix(in srgb, var(--accent) 34%, transparent);
   /* Opaque tant que le flou n'est pas là, pour la même raison que `SiteHeader` : sans
      flou, la translucidité ne fait que laisser passer un fantôme de texte. */
   background: var(--fond);
@@ -31,9 +27,9 @@
 @media (min-width: 1024px) {
   @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
     .barre {
-      background: color-mix(in srgb, var(--fond) 82%, transparent);
-      backdrop-filter: blur(14px) saturate(1.1);
-      -webkit-backdrop-filter: blur(14px) saturate(1.1);
+      background: color-mix(in srgb, var(--fond) var(--verre-voile-barre), transparent);
+      backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation-bande));
+      -webkit-backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation-bande));
     }
   }
 }
@@ -61,7 +57,7 @@
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   font-variant-numeric: tabular-nums;
-  color: var(--teinte-pole);
+  color: var(--accent);
 }
 
 .nom {
@@ -78,7 +74,7 @@
   flex: none;
   padding: var(--e-1) var(--e-3);
   border-radius: var(--rayon-petit);
-  background: var(--teinte-pole);
+  background: var(--accent);
   color: var(--fond);
   font-size: var(--t-note);
   font-weight: 500;

--- a/src/@vitrine/components/ProofWall/proof-wall.module.css
+++ b/src/@vitrine/components/ProofWall/proof-wall.module.css
@@ -14,7 +14,7 @@
   flex-direction: column;
   gap: var(--e-1);
   padding-top: var(--e-3);
-  border-top: 2px solid var(--cuivre-vif);
+  border-top: 2px solid var(--accent-vif);
 }
 
 .chiffre {

--- a/src/@vitrine/components/ThreadSection/thread-section.module.css
+++ b/src/@vitrine/components/ThreadSection/thread-section.module.css
@@ -1,5 +1,5 @@
 /* thread-section.module.css — le fil transverse.
- * Filet cuivre horizontal, tracé à l'entrée : perpendiculaire à celui des charnières,
+ * Filet d'accent horizontal, tracé à l'entrée : perpendiculaire à celui des charnières,
  * qui est vertical. La chaîne descend, le fil la coupe — la géométrie porte l'argument. */
 
 .fil {
@@ -19,7 +19,7 @@
   position: absolute;
   inset-inline: 0;
   height: 2px;
-  background: var(--cuivre-vif);
+  background: var(--accent-vif);
   transform-origin: left;
   transition: transform var(--duree-tracer) var(--courbe-tracer);
 }
@@ -55,7 +55,7 @@
   font-size: var(--t--1);
   text-transform: uppercase;
   letter-spacing: var(--suivi-etiquette);
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .titre {
@@ -86,14 +86,14 @@
   flex-direction: column;
   gap: var(--e-2);
   padding-top: var(--e-3);
-  border-top: 1px solid var(--verre-arete);
+  border-top: var(--verre-epaisseur) solid var(--verre-arete);
 }
 
 .rang {
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   letter-spacing: 0.12em;
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .etapeTitre {
@@ -117,8 +117,11 @@
   line-height: 1.5;
 }
 
+/* La preuve prend la teinte du pôle, pas le signal : `--signal` ne marque QUE la ligne
+   « vous tranchez » et le témoin de mise en pause. Une couleur qui sert à deux choses ne
+   sert plus à rien. */
 .preuve {
-  color: var(--signal);
+  color: var(--accent);
 }
 
 .decision {
@@ -132,7 +135,7 @@
   font-family: var(--police-mono-pile);
   text-transform: uppercase;
   letter-spacing: var(--suivi-etiquette);
-  color: var(--cuivre);
+  color: var(--signal);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/@vitrine/views/ArticleView/article-view.module.css
+++ b/src/@vitrine/views/ArticleView/article-view.module.css
@@ -41,7 +41,7 @@
   font-variation-settings: "opsz" 24;
   font-size: var(--t-2);
   line-height: 1.35;
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .corps {

--- a/src/@vitrine/views/HomeView/home-view.module.css
+++ b/src/@vitrine/views/HomeView/home-view.module.css
@@ -33,7 +33,7 @@
   font-size: var(--t--1);
   text-transform: uppercase;
   letter-spacing: var(--suivi-etiquette);
-  color: var(--cuivre);
+  color: var(--accent);
 }
 
 .chapo {
@@ -53,9 +53,12 @@
 
 .contact {
   padding: var(--e-5);
-  border: 1px solid var(--verre-arete);
+  border: var(--verre-epaisseur) solid var(--verre-arete);
   border-radius: var(--rayon-verre);
-  background: color-mix(in srgb, var(--fond-creux) 60%, transparent);
+  /* Même voile que les panneaux de verre : le bloc de contact en dupliquait un, à
+     60 %, et aurait décroché des autres surfaces au premier réglage du verre. */
+  background: color-mix(in srgb, var(--fond-creux) var(--verre-voile), transparent);
+  box-shadow: var(--elevation-posee);
   scroll-margin-top: var(--decalage-ancre);
 }
 
@@ -71,7 +74,7 @@
   display: inline-block;
   padding: var(--e-2) var(--e-4);
   border-radius: var(--rayon-petit);
-  background: var(--cuivre);
+  background: var(--accent);
   color: var(--fond);
   font-family: var(--police-mono-pile);
   text-decoration: none;
@@ -79,5 +82,5 @@
 }
 
 .action:hover {
-  box-shadow: 0 6px 18px color-mix(in srgb, var(--cuivre) 30%, transparent);
+  box-shadow: var(--elevation-levee);
 }

--- a/src/app/glass-surface.css
+++ b/src/app/glass-surface.css
@@ -28,9 +28,9 @@
   z-index: 2;
   pointer-events: none;
   overflow: clip;
-  border: 1px solid var(--verre-arete);
+  border: var(--verre-epaisseur) solid var(--verre-arete);
   border-radius: var(--rayon-verre);
-  box-shadow: inset 0 1px 0 var(--verre-lueur);
+  box-shadow: var(--elevation-posee);
   /* Fond translucide PLAT : ni flou, ni promesse au compositeur.
      C'est le rendu par défaut, celui de tous les petits écrans — et il n'est pas un
      pis-aller. En dessous de 1024px, liquidGL n'est jamais amorcé (voir
@@ -39,7 +39,7 @@
      image de défilement, et un `will-change: transform` promettait une couche GPU pour
      un mouvement qui n'arrive pas — deux coûts payés pour un effet que personne ne voit
      sur un téléphone. */
-  background: color-mix(in srgb, var(--fond) 55%, var(--verre-teinte));
+  background: color-mix(in srgb, var(--fond) var(--verre-voile), var(--verre-teinte));
 }
 
 /* Au-dessus du seuil, et là seulement, le verre devient un vrai verre : le flou paie sa
@@ -47,8 +47,8 @@
 @media (min-width: 1024px) {
   .glass-surface {
     background: var(--verre-teinte);
-    backdrop-filter: blur(14px) saturate(1.15);
-    -webkit-backdrop-filter: blur(14px) saturate(1.15);
+    backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation));
+    -webkit-backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation));
     will-change: transform;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,8 +4,9 @@
  * taille utilisée dans un module CSS vient d'ici : aucune couleur ni aucun espacement
  * en dur dans un composant (docs/design.md).
  *
- * Direction « L'Établi » : papier chaud, encre graphite, un seul accent cuivre, et du
- * verre qui laisse voir la trame technique du fond — la transparence est le sujet.
+ * Direction « L'Établi » : papier chaud, encre graphite, et du verre qui laisse voir la
+ * trame technique du fond — la transparence est le sujet. L'accent, lui, n'est plus
+ * unique : une teinte par pôle, mappée sur `--accent` par `poles.css`.
  */
 
 :root {
@@ -16,12 +17,19 @@
   --fond-creux: #e7e2d7;
   --encre: #14171a; /* 15.67:1 sur --fond */
   --encre-douce: #4a5157; /* 7.02:1 sur --fond */
-  --cuivre: #8f4520; /* 6.02:1 sur --fond — seul accent de texte */
+  /* Le cuivre est la teinte de marque ET celle du pôle « ingénierie web ». Aucun module
+     ne le nomme : ils consomment `--accent`, que `poles.css` mappe sur le pôle courant
+     et fait retomber ici hors de tout `data-pole`. */
+  --cuivre: #8f4520; /* 6.02:1 sur --fond */
   --cuivre-vif: #b4623a; /* 3.85:1 — NON-TEXTE : filets, arêtes, traits */
-  --signal: #1f5f52; /* 6.49:1 — disponibilité, coches */
+  /* `--signal` n'est PAS une couleur d'ambiance : il marque la ligne « vous tranchez »,
+     partout où un bloc en porte une, et le témoin de mise en pause. Nulle part ailleurs. */
+  --signal: #1f5f52; /* 6.49:1 */
   --trame: rgba(20, 23, 26, 0.055);
   --verre-teinte: rgba(255, 255, 255, 0.42);
-  --verre-arete: rgba(143, 69, 32, 0.28);
+  /* L'arête du verre est une DILUTION de `--accent`, pas une couleur de plus : seule
+     la part est fixée ici, la couleur est assemblée dans `poles.css`. */
+  --verre-arete-part: 28%;
   --verre-lueur: rgba(255, 255, 255, 0.7);
   --fond-degrade-haut: #f7f5f0;
   --fond-degrade-bas: #ede9e0;
@@ -119,7 +127,7 @@
     --signal: #5fd1ae; /* 10.12:1 */
     --trame: rgba(236, 231, 222, 0.06);
     --verre-teinte: rgba(236, 231, 222, 0.07);
-    --verre-arete: rgba(224, 139, 76, 0.32);
+    --verre-arete-part: 32%;
     --verre-lueur: rgba(255, 255, 255, 0.14);
     --fond-degrade-haut: #14181d;
     --fond-degrade-bas: #0b0e11;
@@ -240,7 +248,7 @@ p {
 }
 
 a {
-  color: var(--cuivre);
+  color: var(--accent);
   text-decoration-thickness: 1px;
   text-underline-offset: 0.18em;
   transition: text-decoration-thickness var(--duree-micro) ease-out;
@@ -251,7 +259,7 @@ a:hover {
 }
 
 :focus-visible {
-  outline: 2px solid var(--cuivre);
+  outline: 2px solid var(--accent);
   outline-offset: 3px;
   border-radius: 2px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,11 @@ import { SITE_IDENTITY, SITE_PROMESSE, SITE_THEME_COLORS, SITE_URL } from '@/@sh
 import { buildPersonSchema, buildProfessionalServiceSchema } from '@/@shared/seo/structured-data'
 import { FONT_VARIABLES } from '@/@shared/typography/fonts'
 import './globals.css'
+// Après `globals.css`, et pas avant : les deux fichiers s'appuient sur ses jetons
+// (`--cuivre`, `--encre`, `--verre-lueur`). Ils n'en sont séparés que par la limite de
+// 300 lignes du projet.
+import './poles.css'
+import './verre.css'
 import './glass-surface.css'
 
 export const metadata: Metadata = {

--- a/src/app/poles.css
+++ b/src/app/poles.css
@@ -1,0 +1,110 @@
+/* poles.css — une teinte par pôle.
+ *
+ * Extrait de `globals.css` pour une raison mécanique : la palette des quatre pôles y
+ * faisait passer le fichier au-dessus des 300 lignes du projet. C'est la seule raison —
+ * ces jetons sont des jetons de design comme les autres, et `globals.css` reste leur
+ * voisin immédiat.
+ *
+ * ## Le mécanisme
+ *
+ * Une page ou une section de pôle pose `data-pole="<id>"`. Le bloc correspondant
+ * ci-dessous mappe `--accent` et `--accent-vif` sur la teinte du pôle, et tout ce qui
+ * est dessous en hérite. **Aucun composant ne connaît la couleur d'un pôle** : il ne
+ * connaît que `--accent`. C'est ce qui évite de dupliquer la logique de couleur dans
+ * dix-huit modules CSS, et ce qui rend un cinquième pôle indolore.
+ *
+ * Hors de tout `data-pole` — accueil, blog, en-tête, pied de page — `--accent` vaut le
+ * cuivre. Ce n'est pas un repli faute de mieux : le cuivre est à la fois la teinte du
+ * socle (ingénierie web, temps 1) et la couleur de marque du site. Un visiteur qui n'est
+ * dans aucun pôle voit la couleur de la maison.
+ *
+ * ## Le choix des teintes
+ *
+ * Les quatre teintes sont posées en OKLCH sur **une seule clarté et une seule chroma par
+ * variante** : seule la teinte change. C'est ce qui interdit de lire une progression là
+ * où il n'y en a pas — en particulier entre l'IA et le SEA & UX, qui sont deux branches
+ * PARALLÈLES de la donnée et non deux étapes successives. Deux couleurs d'éclat
+ * différent auraient affirmé un ordre que le modèle nie (voir CLAUDE.md).
+ *
+ * - Ingénierie web (socle, temps 1) : cuivre, h≈45. Inchangé.
+ * - Data (passage, temps 2) : bleu d'encre, h=215. Le tronc refroidit en passant du
+ *   construire au mesurer.
+ * - IA et SEA & UX (suites, temps 3) : violet h=300 et vert h=130, à **85° de part et
+ *   d'autre** du bleu de la donnée. Même clarté, même chroma, écarts symétriques : la
+ *   branche ne progresse pas, elle se dédouble.
+ *
+ * L'écart de teinte entre les deux sœurs est volontairement large. Un écart étroit — un
+ * cyan et un magenta voisins, par exemple — aurait mieux dit « même famille », mais les
+ * deux teintes deviennent alors STRICTEMENT indiscernables pour une deutéranopie
+ * (ΔE OKLab mesuré : 0.004). Le compromis retenu tient l'égalité de clarté et de chroma,
+ * qui est ce qui fait lire deux sœurs, et paie en distance de teinte ce qui rend la
+ * distinction perceptible. Les ratios et les limites sont dans `docs/design.md`.
+ *
+ * La couleur n'est jamais le seul porteur d'information : chaque pôle porte aussi son
+ * nom, son libellé de place et son temps (WCAG 1.4.1).
+ */
+
+:root {
+  /* Le socle emprunte les jetons de marque de `globals.css` : une seule source pour le
+     cuivre, et le thème sombre suit sans être réécrit ici. */
+  --pole-ingenierie-web: var(--cuivre);
+  --pole-ingenierie-web-vif: var(--cuivre-vif);
+  --pole-data: #00697b; /* 5.53:1 sur --fond */
+  --pole-data-vif: #008aa1; /* 3.55:1 — NON-TEXTE */
+  --pole-ia: #674d91; /* 6.00:1 */
+  --pole-ia-vif: #8669b7; /* 3.88:1 — NON-TEXTE */
+  --pole-sea-ux: #48691d; /* 5.52:1 */
+  --pole-sea-ux-vif: #638937; /* 3.54:1 — NON-TEXTE */
+
+  --accent: var(--pole-ingenierie-web);
+  --accent-vif: var(--pole-ingenierie-web-vif);
+
+  /* Deux jetons sont DÉRIVÉS de `--accent`, et c'est pour cela qu'ils sont redéclarés
+     dans chacun des blocs de pôle plutôt qu'une fois pour toutes : une propriété
+     personnalisée est substituée au *computed-value time*, sur l'élément qui la déclare.
+     Écrite une seule fois ici, `--verre-arete` figerait la valeur racine — le cuivre —
+     et descendrait telle quelle dans toutes les pages de pôle. */
+  --verre-arete: color-mix(in srgb, var(--accent) var(--verre-arete-part), transparent);
+  --elevation-levee: 0 6px 18px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --pole-data: #01b6d4; /* 7.79:1 sur --fond */
+    --pole-data-vif: #48cbe7; /* 9.89:1 */
+    --pole-ia: #af8fe8; /* 7.14:1 */
+    --pole-ia-vif: #c3a6f8; /* 9.14:1 */
+    --pole-sea-ux: #87b357; /* 7.77:1 */
+    --pole-sea-ux-vif: #9fc774; /* 9.83:1 */
+  }
+}
+
+/* Les quatre seuls endroits du site où une teinte de pôle est nommée. Partout ailleurs,
+   c'est `--accent`. */
+[data-pole="ingenierie-web"] {
+  --accent: var(--pole-ingenierie-web);
+  --accent-vif: var(--pole-ingenierie-web-vif);
+  --verre-arete: color-mix(in srgb, var(--accent) var(--verre-arete-part), transparent);
+  --elevation-levee: 0 6px 18px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+[data-pole="data"] {
+  --accent: var(--pole-data);
+  --accent-vif: var(--pole-data-vif);
+  --verre-arete: color-mix(in srgb, var(--accent) var(--verre-arete-part), transparent);
+  --elevation-levee: 0 6px 18px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+[data-pole="ia"] {
+  --accent: var(--pole-ia);
+  --accent-vif: var(--pole-ia-vif);
+  --verre-arete: color-mix(in srgb, var(--accent) var(--verre-arete-part), transparent);
+  --elevation-levee: 0 6px 18px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+[data-pole="sea-ux"] {
+  --accent: var(--pole-sea-ux);
+  --accent-vif: var(--pole-sea-ux-vif);
+  --verre-arete: color-mix(in srgb, var(--accent) var(--verre-arete-part), transparent);
+  --elevation-levee: 0 6px 18px color-mix(in srgb, var(--accent) 30%, transparent);
+}

--- a/src/app/verre.css
+++ b/src/app/verre.css
@@ -1,0 +1,58 @@
+/* verre.css — jetons de verre et échelle d'élévation.
+ *
+ * Extrait de `globals.css` pour la même raison que `poles.css` : la limite de 300 lignes
+ * du projet. Ces jetons sont des jetons de design comme les autres.
+ *
+ * ## Pourquoi ces jetons existent
+ *
+ * `blur(14px) saturate(1.15)` était écrit en dur dans `glass-surface.css`, et deux autres
+ * modules le redupliquaient à leur façon. Les ombres du site étaient quatre littéraux
+ * différents. Tant que ces valeurs vivent dans les modules, intensifier le verre demande
+ * de retrouver toutes ses copies — et l'une d'elles est toujours oubliée, ce qui la fait
+ * décrocher visuellement du reste.
+ *
+ * ## Le voile n'est pas le flou
+ *
+ * Deux réglages indépendants font une surface de verre : le **flou** de ce qui passe
+ * derrière, et le **voile** — la part de fond opaque mélangée à la teinte. Le voile monte
+ * quand la surface doit rester lisible par-dessus n'importe quoi (les bandes collantes),
+ * et descend quand elle doit laisser voir la trame (les panneaux). D'où trois voiles, et
+ * un seul flou.
+ *
+ * ## L'échelle d'élévation
+ *
+ * Trois crans, dans l'ordre, et pas un de plus : un cran d'échelle sans emploi est un
+ * jeton mort, exactement le défaut que cette issue corrige ailleurs.
+ *
+ *   creuse → posée → levée
+ *
+ * `--elevation-creuse` est un creux DANS le papier (la plaque de logo), `--elevation-posee`
+ * la lueur d'arête d'une surface au repos, `--elevation-levee` la seule vraie ombre
+ * portée du site — celle d'une action sous la main, teintée par `--accent` pour qu'elle
+ * suive le pôle courant. Ce dernier cran est déclaré dans `poles.css` : il est dérivé de
+ * `--accent`, donc il se redéclare partout où `--accent` l'est.
+ */
+
+:root {
+  /* — Verre — */
+  --verre-flou: 14px;
+  --verre-saturation: 1.15;
+  /* Les bandes collantes saturent moins : elles couvrent toute la largeur de l'écran, et
+     ce qui passe dessous n'est pas un décor mais du texte. */
+  --verre-saturation-bande: 1.1;
+  --verre-epaisseur: 1px;
+  --verre-epaisseur-lueur: 1px;
+  /* Part de `--fond` mélangée à la teinte. Panneau : la trame doit rester visible.
+     Bandes : le texte qui défile dessous ne doit jamais se lire à travers. */
+  --verre-voile: 55%;
+  --verre-voile-bande: 88%;
+  --verre-voile-barre: 82%;
+
+  /* — Élévation — */
+  --elevation-creuse: inset 0 0 0 var(--verre-epaisseur)
+    color-mix(in srgb, var(--encre) 10%, transparent);
+  --elevation-posee: inset 0 var(--verre-epaisseur-lueur) 0 var(--verre-lueur);
+  /* `--elevation-levee` est teintée par `--accent` : elle est donc déclarée dans
+     `poles.css`, avec lui et partout où il est redéclaré — une propriété personnalisée
+     est substituée sur l'élément qui la déclare, pas sur celui qui la consomme. */
+}


### PR DESCRIPTION
Closes #44

## Ce que fait cette PR

**Une teinte par pôle**, mappée par `data-pole` sur `--accent` / `--accent-vif`
(`src/app/poles.css`). Les dix-huit modules CSS du site ne nomment plus aucune couleur de
pôle : ils ne connaissent que `--accent`. Hors de tout `data-pole` — accueil, blog,
en-tête, pied de page — `--accent` vaut le cuivre, qui est à la fois la teinte de marque
et celle du socle.

Trois endroits posent `data-pole` : la page de pôle (déjà en place sur `dev`), **chaque
maillon de `ChainDiagram`** et **chaque entrée du menu de `SiteHeader`** — l'en-tête
devient la légende de la palette.

### Le choix des teintes, et la contrainte du modèle

Les quatre teintes sont posées en **OKLCH sur une seule clarté et une seule chroma par
variante** : seule la teinte change. C'est ce qui interdit de lire une progression entre
l'IA et le SEA & UX, qui sont deux branches **parallèles** de la donnée.

| Pôle | Place | Teinte |
|------|-------|--------|
| Ingénierie web | socle, temps 1 | h ≈ 45, cuivre — **inchangée** |
| Data | passage, temps 2 | h = 215, bleu d'encre |
| IA | suite, temps 3 | h = 300, violet — **+85°** du bleu de la donnée |
| SEA & UX | suite, temps 3 | h = 130, vert — **−85°** du bleu de la donnée |

Les deux suites sont équidistantes de la teinte de leur parent, à clarté et chroma
strictement égales : la branche ne progresse pas, elle se dédouble.

## Les 16 ratios, mesurés

Luminance relative WCAG 2.x calculée sur les valeurs sRGB effectives. **Aucun arrondi,
aucune estimation.** Seuils : 4.5:1 pour `--accent` (porte du texte), 3:1 pour
`--accent-vif` (non-texte).

| Pôle | `--accent` clair | `--accent-vif` clair | `--accent` sombre | `--accent-vif` sombre |
|------|------------------|----------------------|-------------------|-----------------------|
| Ingénierie web | `#8F4520` — **6.02:1** | `#B4623A` — **3.85:1** | `#E08B4C` — **7.18:1** | `#F0A468` — **9.21:1** |
| Data | `#00697B` — **5.53:1** | `#008AA1` — **3.55:1** | `#01B6D4` — **7.79:1** | `#48CBE7` — **9.89:1** |
| IA | `#674D91` — **6.00:1** | `#8669B7` — **3.88:1** | `#AF8FE8` — **7.14:1** | `#C3A6F8` — **9.14:1** |
| SEA & UX | `#48691D` — **5.52:1** | `#638937` — **3.54:1** | `#87B357` — **7.77:1** | `#9FC774` — **9.83:1** |

**Les seize passent leur seuil.** Le plus tendu est `--accent` clair du SEA & UX à
5.52:1, à 1.02 point au-dessus de 4.5:1. Les quatre `--accent-vif` clairs sont entre
3.54:1 et 3.88:1 : au-dessus de 3:1, **sous** 4.5:1 — c'est la règle qui s'appliquait
déjà au cuivre vif, étendue aux quatre pôles. Ils ne portent jamais un mot.

## Ce qui ne passe pas, et qui doit être dit

**1. La chroma du bleu de la donnée est bridée par le gamut sRGB en thème clair** : 0.084
au lieu des 0.110 des trois autres. Le cyan profond n'existe pas plus saturé à cette
clarté. La donnée paraît donc légèrement moins colorée que ses voisines sur fond clair.
Baisser les trois autres à 0.084 aurait éteint toute la palette pour aligner une seule
teinte — je ne l'ai pas fait, mais c'est un arbitrage qui t'appartient.

**2. Le daltonisme est la limite réelle de cette palette.** Quatre teintes à clarté et
chroma égales ne peuvent pas rester toutes distinguables sous une vision dichromate :
c'est une propriété de l'espace des couleurs, pas un défaut d'implémentation. J'ai donc
optimisé la paire qui compte — les deux sœurs :

| Paire de sœurs | Protanopie | Deutéranopie | Tritanopie |
|----------------|-----------|--------------|------------|
| **Retenue** — violet h300 / vert h130 | ΔE 0.199 | ΔE 0.180 | ΔE 0.024 |
| *Écartée* — cyan h210 / magenta h320 | *ΔE 0.061* | *ΔE 0.003* | *ΔE 0.115* |

ΔE OKLab, simulation Viénot 1999, à clarté et chroma identiques dans les deux cas.

La paire écartée est celle qui aurait le mieux dit « même famille chromatique », avec un
écart de teinte étroit. Elle rend les deux suites **strictement identiques** pour une
deutéranopie (ΔE 0.003), qui touche environ 5 % des hommes — c'est exactement le piège de
l'axe rouge-vert. La paire retenue les sépare franchement sur les deux formes courantes,
et faiblement sur la tritanopie (moins de 0.01 % de la population). **Le prix payé est un
écart de teinte plus large que l'idéal esthétique** : les deux sœurs tiennent leur parenté
par l'égalité de clarté et de chroma, pas par la proximité de teinte.

Dans tous les cas, la couleur n'est jamais le seul porteur d'information (WCAG 1.4.1) :
chaque pôle porte aussi son nom, son libellé de place et son temps.

## Jetons de verre et d'élévation (`src/app/verre.css`)

`blur(14px) saturate(1.15)` n'existe plus nulle part en dur.

| Jeton | Valeur | Emplois |
|-------|--------|---------|
| `--verre-flou` | `14px` | 6 |
| `--verre-saturation` / `--verre-saturation-bande` | `1.15` / `1.1` | 2 / 4 |
| `--verre-epaisseur` / `--verre-epaisseur-lueur` | `1px` / `1px` | 7 / 1 |
| `--verre-voile` / `-bande` / `-barre` | `55%` / `88%` / `82%` | 3 / 1 / 1 |
| `--elevation-creuse` → `-posee` → `-levee` | échelle à 3 crans | 1 / 3 / 2 |

**Le voile n'est pas le flou** : deux réglages indépendants font une surface de verre, et
seul le premier monte quand la bande doit rester lisible par-dessus du texte.

L'échelle d'élévation a trois crans, **tous employés** : un cran sans emploi serait un
jeton mort, exactement le défaut corrigé ici. `--elevation-levee` est teintée par
`--accent` : l'ombre d'une action suit son pôle.

**Les six surfaces qui répliquent un flou hors de liquidGL** consomment désormais ces
jetons : `SiteHeader`, `PoleStickyBar`, `ChainDiagram`, `HomeView` (`.contact`),
`ThreadSection`, `CertificationList`. Le bloc de contact dupliquait un voile à 60 % ; il
prend le voile commun (55 %) — c'est le seul écart visuel volontaire de ce lot.

### Un piège CSS qui vaut d'être signalé

`--verre-arete` et `--elevation-levee` sont **dérivées de `--accent`**. Une propriété
personnalisée est substituée au *computed-value time*, **sur l'élément qui la déclare** :
écrites une seule fois sur `:root`, elles y auraient figé le cuivre et seraient descendues
telles quelles dans toutes les pages de pôle. Elles sont donc redéclarées dans chaque bloc
`[data-pole]`, avec un commentaire qui dit pourquoi. C'est le genre de détail qui se
réintroduit tout seul à la première simplification.

## `--signal` recentré

`--signal` ne marque plus que **la décision** : le filet du bloc « vous tranchez »
(`ExpertiseBlock`, sur les ~39 blocs qui portent une ligne `decision:`), son étiquette
(`ThreadSection`), et le témoin de mise en pause (`MotionToggle`). La **ligne de preuve**
de `ThreadSection` le portait aussi : elle prend `--accent`. Une couleur qui sert à deux
choses ne sert plus à rien.

## Contrainte des 300 lignes

`globals.css` était à 277 lignes. La palette et les jetons de verre l'auraient fait
dépasser : ils vivent dans `poles.css` et `verre.css`, importés par `layout.tsx` juste
après `globals.css`, dont ils dépendent. Aucun contrôle n'a été contourné — `globals.css`
finit à 284 lignes.

## Intention de test — à poser par Jérôme MARICHEZ

**Je n'ai écrit aucun fichier de test.** Voici ce que je proposerais, à toi de trancher.

### Unitaire — `tests/unitaire/pole-accent.spec.tsx`

*Intention : le mécanisme de teinte est un contrat de balisage, pas une couleur — c'est
`data-pole` qui doit être vérifié, jamais une valeur hexadécimale (jsdom ne résout ni
`color-mix` ni les modules CSS).*

- `PolePageView` rend une racine portant `data-pole` égal à l'identifiant du pôle reçu —
  cas limites : les quatre identifiants, dont les deux suites `ia` et `sea-ux`.
- `ChainDiagram` rend **quatre** éléments porteurs de `data-pole`, un par pôle, et les
  deux suites sont **imbriquées** dans le maillon de la donnée — c'est ce qui fait que la
  cascade dit la structure.
- `SiteHeader` rend un `data-pole` par entrée de menu, dans l'ordre de `POLES_NAV`.
- Jeu de données : `POLES_NAV` et `JOINTURES` réels, pas de doublure.

### Unitaire — `tests/unitaire/palette-contraste.spec.ts`

*Intention : les seize ratios du tableau ci-dessus ne doivent pas pouvoir dériver sans que
la CI le dise. Le test lit `src/app/poles.css` et `globals.css`, extrait les valeurs
hexadécimales, recalcule la luminance relative WCAG et compare aux seuils.*

- Chaque `--pole-*` (sans `-vif`) atteint **≥ 4.5:1** sur le `--fond` de son thème.
- Chaque `--pole-*-vif` atteint **≥ 3:1** — et le test ne vérifie **pas** 4.5:1 sur eux :
  la variante vive est non-texte par contrat.
- Cas limite : un jeton dont la valeur n'est pas une couleur littérale (`var(--cuivre)`
  pour le socle) est résolu avant calcul, sinon le test passerait à côté du pôle 1.
- Jeu de données : les fichiers CSS eux-mêmes, `tests/fixtures/` n'a rien à porter ici.

### Acceptation — `uat/`

Un contrôle de contraste automatisé (axe / Lighthouse a11y) sur les quatre pages de pôle
en thème clair **et** sombre attraperait toute régression de palette sur le rendu réel,
là où le test unitaire ne voit que des jetons. À proposer si tu veux le filet complet.

## Vérifications

- `make lint` — vert (`✓ Aucun fichier source ne dépasse 300 lignes` ; seul l'avertissement
  pré-existant `noImgElement` de `CertificationList` subsiste).
- `make type-check` — vert.
- `make build` — vert, 18 routes prérendues.
