### PR TITLE
feature: resserrer le contenu editorial des quatre poles

### DIFF
--- a/src/@shared/components/SiteFooter/index.tsx
+++ b/src/@shared/components/SiteFooter/index.tsx
@@ -21,8 +21,7 @@ export function SiteFooter() {
         <div className={styles.appel}>
           <p className={styles.promesse}>
             Un seul interlocuteur, du cadrage au run, et il répond de tout. Décrivez votre
-            situation, je vous dis ce que j'en ferais — et si ce n'est pas pour moi, je vous le dis
-            aussi.
+            situation, je vous dis ce que j'en ferais.
           </p>
           <a className={styles.contact} href={`mailto:${SITE_IDENTITY.email}`}>
             {SITE_IDENTITY.email}
@@ -71,7 +70,7 @@ export function SiteFooter() {
 
       <p className={styles.mentions}>
         {SITE_IDENTITY.nom} — {SITE_IDENTITY.titre} à {SITE_IDENTITY.ville}. Site conçu, développé
-        et exploité par moi-même, comme le reste.
+        et exploité par moi-même.
       </p>
     </footer>
   )

--- a/src/@vitrine/contenu/accueil-data.ts
+++ b/src/@vitrine/contenu/accueil-data.ts
@@ -28,18 +28,14 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
   kicker: 'Le passage · Comprendre',
   titre: 'Comprendre votre métier, puis choisir la solution',
   chapo:
-    'Je ne commence pas par un modèle. Je commence par ce que votre activité sait déjà ' +
-    'sans l’avoir écrit : ses règles de décision, ses profils de clients, ce que raconte ' +
-    'son historique. La stratégie data, la gouvernance et la technique en découlent, dans ' +
-    'cet ordre — et la réponse n’est pas toujours de l’IA.',
+    'Je ne commence pas par un modèle, mais par ce que votre activité sait déjà sans l’avoir ' +
+    'écrit. La réponse n’est pas toujours de l’IA.',
   blocs: [
     {
       titre: 'Découvrir ce que votre métier sait déjà',
       texte:
-        'Insights métier tirés de l’historique, profils de clients dégagés par clustering ' +
-        '(KNN), règles de décision appliquées par vos équipes sans avoir jamais été ' +
-        'formalisées. C’est une prestation à part entière : elle se livre, et vous pouvez ' +
-        'vous arrêter là.',
+        'Insights métier, profils de clients par clustering (KNN), règles formalisées. Vous ' +
+        'pouvez vous arrêter là.',
       preuve:
         'AMOA de la startup biotech Artedrone : besoin recueilli auprès des équipes ' +
         'scientifiques et dirigeantes, traduit en spécifications exploitables par des ' +
@@ -51,10 +47,8 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
     {
       titre: 'La stratégie data : la déployer ou s’appuyer sur l’existante',
       texte:
-        'Quand rien n’est en place, on décide quoi mesurer à partir des questions du ' +
-        'métier. Quand la donnée existe, on la reprend : agrégation et réconciliation ' +
-        'multi-sources, dédoublonnage, contrôles d’intégrité et de véracité dès ' +
-        'l’ingestion.',
+        'Décider quoi mesurer quand rien n’existe ; reprendre et réconcilier quand la donnée ' +
+        'est là.',
       preuve:
         'Système d’analyse multi-sources conforme RGPD mesurant la rentabilité client à ' +
         'long terme, branché sur Google Ads et Bing Ads.',
@@ -62,11 +56,7 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
     },
     {
       titre: 'Gouvernance et droit, avant la technique',
-      texte:
-        'Qui possède quoi, ce qui a le droit d’être collecté et traité, ce qui doit rester ' +
-        'chez vous. RGPD, base légale, consentement géré par une CMP, cadrage des ' +
-        'traitements avec le juridique. La réponse écarte des solutions entières : mieux ' +
-        'vaut la connaître avant de construire.',
+      texte: 'Qui possède quoi, ce qui a le droit d’être traité, ce qui doit rester chez vous.',
       preuve:
         'Conformité RGPD et DORA tenue en appels d’offres grands comptes — distribution, ' +
         'assurance, banque.',
@@ -75,12 +65,8 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
     {
       titre: 'La solution répond au problème posé au départ',
       texte:
-        'Souvent, une règle métier intégrée à vos systèmes existants suffit — et c’est un ' +
-        'livrable complet. Sinon, un modèle supervisé ou non supervisé ; et si le problème ' +
-        'est du langage, un LLM arbitré sur le coût d’inférence, la latence, la qualité et ' +
-        'la confidentialité : Claude sur Vertex AI, OpenAI, Gemini, fine-tuning de Llama 3 ' +
-        'pour l’application mobile Prézage, RAG documentaire fait maison sur recherche ' +
-        'vectorielle PostgreSQL.',
+        'Souvent une règle métier intégrée à l’existant suffit ; sinon un modèle, ou un LLM si ' +
+        'le problème est du langage.',
       preuve:
         'Règles anti-fraude implémentées dans le produit : fraude en baisse, conversion ' +
         'des inscriptions en hausse. Modèle supervisé anticipant les échecs de dépôt ' +

--- a/src/@vitrine/contenu/accueil-sections.ts
+++ b/src/@vitrine/contenu/accueil-sections.ts
@@ -25,17 +25,12 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kicker: 'Le socle · Construire',
     titre: 'Site internet, produit SaaS, application mobile',
     chapo:
-      "Concevoir, développer et mettre en production, puis rester pour l'exploiter. " +
-      "L'architecture, le front, le back, la donnée, la qualité et le run sont tenus par " +
-      'la même personne — ce qui supprime la moitié des allers-retours de spécification.',
+      "Concevoir, développer, mettre en production, puis rester pour l'exploiter. Front, back, " +
+      'donnée, qualité et run tenus par la même personne.',
     blocs: [
       {
         titre: 'Front et stratégie de rendu',
-        texte:
-          'React et Next.js, avec une stratégie de rendu différenciée par type de page — ' +
-          'CSR, SSR, SSG ou ISR. Le choix arbitre trois choses en même temps : performance ' +
-          'perçue, coût serveur et référencement. Angular et Ionic pour le mobile iOS et ' +
-          'Android.',
+        texte: 'React et Next.js côté web, Angular et Ionic pour le mobile iOS et Android.',
         preuve:
           'Lighthouse 98/100 sur la plateforme SaaS « Sms En Masse », conformité RGAA / WCAG.',
         decision: 'Quelle page se rend au build, laquelle à la requête, et ce que chacune coûte.',
@@ -43,20 +38,15 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       {
         titre: 'Back, données et architecture',
         texte:
-          'Node.js et Express, API REST, webhooks, cloud functions et traitements ' +
-          'asynchrones distribués via Google Cloud Pub/Sub. PostgreSQL en relationnel, en ' +
-          'séries temporelles et en vectoriel, MySQL, Firebase, validation des entrées par ' +
-          'schéma Zod. Arbitrage monolithe ou microservices posé explicitement, pas subi.',
+          'Node.js, API REST, cloud functions et Pub/Sub ; PostgreSQL, MySQL, Firebase, ' +
+          'entrées validées par Zod.',
         decision: "Ce qu'on découpe maintenant, ce qu'on garde monolithique, et jusqu'à quand.",
       },
       {
         titre: 'Qualité certifiée et outillée',
         texte:
-          'Développement piloté par les tests, et développement en IA augmentée — Claude ' +
-          'Code et Gemini au quotidien avec agents, hooks, skills, loop et serveurs MCP ' +
-          'internes — le test faisant foi avant, pendant et après la génération. Jest, ' +
-          'Cypress, Playwright, tests de mutation Stryker, Postman, Lighthouse, ' +
-          'accessibilité RGAA / WCAG / W3C.',
+          'Développement piloté par les tests, en IA augmentée : Claude Code et Gemini, le ' +
+          'test faisant foi.',
         preuve: 'Certification ISTQB Foundation. Non-régression rejouée à chaque livraison.',
         decision: 'Quel niveau de test vous vous autorisez à ne pas payer, et sur quoi.',
       },
@@ -64,9 +54,7 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
         titre: 'Migrations sans coupure',
         texte:
           "Sortir d'un socle en fin de vie sans arrêter le service ni geler la feuille de " +
-          'route. PHP 5 vers 7 puis réécriture Node.js et front jQuery vers React chez un ' +
-          "joaillier dont le site marchand ne pouvait pas s'arrêter ; Ionic 6 vers 8 et " +
-          "Angular 15 vers 19 sur l'application mobile Prézage.",
+          'route.',
         preuve:
           'Trois migrations majeures, aucune interruption de service, chiffre d’affaires maintenu.',
         decision: "Ce qu'on migre ce trimestre, ce qu'on gèle, et le coût réel de l'attente.",
@@ -81,13 +69,12 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kicker: 'Charnière · vers la donnée',
     titre: 'On ne livre pas, on exploite',
     chapo:
-      "La mise en production n'est pas la fin du projet : c'est le moment où le produit " +
-      "commence à produire des données. Exploiter, c'est mesurer — et c'est le run qui " +
-      "fait naître le besoin de data et d'IA, pas l'inverse, et pas avant.",
+      "La mise en production n'est pas la fin du projet : c'est le run qui fait naître le " +
+      "besoin de data et d'IA.",
     blocs: [
       {
         titre: 'SLI / SLO / SLA',
-        texte: 'définis, suivis, et opposables — pas des intentions écrites après l’incident.',
+        texte: 'définis, suivis et opposables, pas écrits après l’incident.',
       },
       {
         titre: 'PCA et PRA',
@@ -96,15 +83,14 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       {
         titre: 'Pics d’affluence',
         texte:
-          'absorbés sans incident, contrôles post-déploiement exécutés en production, ' +
-          'conformité RGPD et DORA tenue en appels d’offres grands comptes.',
+          'absorbés sans incident, conformité RGPD et DORA tenue en appels d’offres ' +
+          'grands comptes.',
       },
       {
         titre: 'La preuve que le lien existe',
         texte:
-          'les règles anti-fraude n’ont pas été imaginées avant la mise en production : ' +
-          'elles sont issues de la reprise de l’historique que l’exploitation a produit. ' +
-          'Sans run, pas de matière — et donc pas de pôle Data.',
+          'les règles anti-fraude sont issues de l’historique produit par l’exploitation. Sans ' +
+          'run, pas de pôle Data.',
       },
     ],
   },
@@ -118,15 +104,13 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kicker: 'Charnière · vers l’arbitrage',
     titre: 'Sans donnée claire, le budget brûle',
     chapo:
-      'La donnée mise au propre devient la matière première des arbitrages : quel canal ' +
-      "financer, quelle étape du parcours supprimer, quelle page rendre en SSR plutôt qu'en " +
-      "CSR. Sans elle, le SEA achète du volume et l'UX devient une affaire de goût.",
+      'La donnée mise au propre devient la matière des arbitrages. Sans elle, le SEA achète du ' +
+      "volume et l'UX devient une affaire de goût.",
     blocs: [
       {
         titre: 'LTV plutôt que coût par clic',
         texte:
-          'les budgets s’arbitrent sur la rentabilité client réelle, pas sur les métriques ' +
-          'natives des régies.',
+          'les budgets s’arbitrent sur la rentabilité client réelle, pas sur celles des régies.',
       },
       {
         titre: 'Réconciliation des identités',
@@ -136,8 +120,7 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
         titre: 'La preuve que le lien existe',
         texte:
           'le système d’analyse multi-sources mesure la rentabilité client dans la durée. ' +
-          'C’est sur ce chiffre-là que les budgets sont arbitrés — pas sur les métriques ' +
-          'que chaque régie produit sur elle-même.',
+          'C’est sur ce chiffre-là que les budgets sont arbitrés.',
       },
     ],
   },
@@ -148,46 +131,35 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kicker: 'Une suite · Arbitrer',
     titre: 'Je ne dessine pas vos maquettes, je tranche vos parcours',
     chapo:
-      'Disons-le tout de suite : je ne vends pas de création graphique. Ce que je vends, ' +
-      'ce sont des arbitrages pris sur la donnée — quel parcours, quelle étape supprimée, ' +
-      'quel formulaire raccourci, quel test A/B tranché — et je les implémente moi-même ' +
-      'dans le produit, au lieu de les transmettre à quelqu’un d’autre.',
+      'Pas de création graphique : des arbitrages pris sur la donnée, que j’implémente ' +
+      'moi-même.',
     blocs: [
       {
         titre: 'La mesure est construite dans le code',
         texte:
-          'Google Tag Manager en conteneur web et server-side, dataLayer, Measurement ' +
-          "Protocol, plan de taggage et nomenclature d'événements documentée et opposable. " +
-          'Google Analytics, Matomo, Search Console ; côté mobile, Firebase Analytics et ' +
-          "Crashlytics. Je lis le code à l'endroit où l'événement doit être posé, au lieu de " +
-          'le deviner depuis une interface.',
+          'GTM en conteneur web et server-side, plan de taggage opposable ; Firebase Analytics ' +
+          'et Crashlytics côté mobile.',
         decision: 'Quels événements existent, ce qu’ils portent, et qui répond de leur exactitude.',
       },
       {
         titre: 'Conformité par construction',
-        texte:
-          'RGPD, CMP et déclenchement conditionnel des tags par catégorie de consentement, ' +
-          'cadrage des traitements avec le juridique. La conformité n’est pas une case ' +
-          'cochée après coup : elle conditionne l’architecture de collecte.',
+        texte: 'RGPD, CMP et déclenchement conditionnel des tags par catégorie de consentement.',
         decision:
           'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
       },
       {
         titre: 'Arbitrages de parcours, pris sur la mesure',
         texte:
-          'Refonte des parcours pilotée par la donnée : A/B testing des pages et des ' +
-          'designs, heatmaps, taux de rebond, part de trafic mobile. Une étape disparaît ' +
-          'parce que les chiffres le disent, pas parce qu’elle déplaît.',
+          'A/B testing des pages, heatmaps, taux de rebond : une étape disparaît parce que les ' +
+          'chiffres le disent.',
         preuve: 'Panier moyen en hausse de 50 % sur un e-commerce de joaillerie de luxe.',
         decision: 'Quelle étape du tunnel disparaît, et ce que vous gagnez à la supprimer.',
       },
       {
         titre: 'Pilotage de l’acquisition',
         texte:
-          'Google Ads, Bing Ads, SEO, SEA et SMA. Tableaux de bord construits pour votre ' +
-          'produit et non repris d’un gabarit, profilage clients par clustering KNN, ' +
-          'référencement technique traité comme une propriété du produit — stratégie de ' +
-          'rendu, Core Web Vitals, accessibilité.',
+          'Google Ads, Bing Ads, SEO, SEA et SMA ; référencement technique traité comme une ' +
+          'propriété du produit.',
         preuve:
           '100 000 € de budget ADS / SEO pilotés chez Truffle Capital, environ 25 000 € ' +
           'd’encadrement de prestataires SEA chez Verhoeven Joaillier.',
@@ -195,9 +167,7 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       },
     ],
     transition:
-      'Ce que la mesure révèle repart en construction. Et comme c’est toujours la même ' +
-      'personne, l’arbitrage décidé le lundi est implémenté dans la semaine — il n’attend ' +
-      'pas le devis d’un tiers.',
+      'L’arbitrage décidé le lundi est implémenté dans la semaine, sans devis d’un tiers.',
   },
   {
     id: 'un-seul-interlocuteur',
@@ -205,27 +175,22 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kicker: 'L’objection',
     titre: 'Un seul interlocuteur — et si je disparais ?',
     chapo:
-      'C’est la question à poser, et elle mérite mieux qu’un haussement d’épaules. Vendre ' +
-      'un interlocuteur unique, c’est concentrer un risque : autant dire tout de suite ' +
-      'comment il est traité, plutôt que d’attendre que vous le souleviez en réunion.',
+      'Vendre un interlocuteur unique, c’est concentrer un risque : autant dire tout de suite ' +
+      'comment il est traité.',
     blocs: [
       {
         titre: 'Le produit n’est pas dans ma tête',
         texte:
-          'Développement piloté par les tests, non-régression rejouée à chaque livraison, ' +
-          'tests de mutation pour vérifier que les tests eux-mêmes valent quelque chose, ' +
-          'pipelines CI/CD exécutés à chaque livraison. Une base couverte et déployable ' +
-          'automatiquement se reprend ; une base sans filet ne se reprend pas.',
+          'Tests écrits avant le code, non-régression, CI/CD et mutation à chaque livraison. ' +
+          'Une base couverte se reprend.',
         preuve:
           'Jest, Cypress, Playwright, mutation Stryker, Postman. Certification ISTQB Foundation.',
       },
       {
         titre: 'Les spécifications sont écrites pour quelqu’un d’autre que moi',
         texte:
-          'C’est le métier que j’ai exercé avant : recueillir un besoin auprès d’équipes ' +
-          'scientifiques et dirigeantes, puis le traduire en spécifications exploitables ' +
-          'par des prestataires qui ne connaissent pas le domaine. BPMN 2.0, cartographie ' +
-          'du système d’information, nomenclature d’événements documentée et opposable.',
+          'Traduire un besoin en spécifications exploitables par des tiers extérieurs au ' +
+          'domaine : c’est le métier que j’exerçais avant.',
         preuve:
           'AMOA de la startup biotech Artedrone. Serveurs MCP et plugins n8n, Make et Zapier documentés.',
       },
@@ -233,9 +198,10 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
         titre: 'Le relais, je l’ai déjà passé',
         texte:
           'Encadrer des prestataires externes, c’est exactement l’exercice : leur donner ' +
-          'de quoi travailler sans moi. Une équipe marketing de 5 à 10 personnes et trois ' +
-          'prestataires coordonnés chez Truffle Capital, les prestataires SEA, SEO et SMA ' +
-          'encadrés chez Verhoeven Joaillier.',
+          'de quoi travailler sans moi.',
+        preuve:
+          'Une équipe marketing de 5 à 10 personnes et trois prestataires coordonnés chez ' +
+          'Truffle Capital ; prestataires SEA, SEO et SMA encadrés chez Verhoeven Joaillier.',
         decision:
           'Ce que vous exigez de moi contractuellement — documentation, accès, revue de ' +
           'reprise — et à quel moment vous voulez pouvoir le vérifier.',

--- a/src/@vitrine/contenu/accueil.ts
+++ b/src/@vitrine/contenu/accueil.ts
@@ -16,10 +16,8 @@ import { SECTIONS_ACCUEIL } from './accueil-sections'
 export const HERO_ACCUEIL = {
   titre: "Je construis, j'exploite, je mesure. Le même interlocuteur, du cadrage au run.",
   chapo:
-    'Ingénieur logiciel à Lille, 9 ans. Un seul interlocuteur pour votre produit ' +
-    'digital, du cadrage au run : celui qui cadre est celui qui code, qui mesure et ' +
-    'qui exploite. Vous parlez à la personne qui fait le travail, et c’est elle qui ' +
-    'répond de tout.',
+    'Ingénieur logiciel à Lille, 9 ans. Celui qui cadre est celui qui code, qui mesure ' +
+    'et qui exploite — et c’est lui qui répond de tout.',
   // Le fil IA se dit dès le seuil, sinon il se découvre au pôle Data et se lit comme une
   // offre. Formulation tenue par les règles de véracité : l'IA instruit et produit, le
   // test décide — jamais l'inverse.
@@ -47,14 +45,12 @@ export const HERO_ACCUEIL = {
 export const THESE_CHAINE = {
   titre: 'Quatre pôles, une seule chaîne',
   chapo:
-    "Ce ne sont pas quatre offres posées côte à côte au catalogue. C'est une prise en " +
-    'charge continue : on construit, ce qui est construit se met à tourner, ce qui tourne ' +
-    'produit de la donnée — et c’est cette donnée qui ouvre l’IA et l’arbitrage des ' +
-    'budgets et des parcours. L’une, l’autre, ou les deux.',
+    'Pas quatre offres au catalogue : ce qui est construit tourne, ce qui tourne produit de la ' +
+    'donnée — et cette donnée ouvre l’IA et l’arbitrage des budgets et des parcours. L’une, ' +
+    'l’autre, ou les deux.',
   appui:
-    "Cette chaîne ne tient que parce que c'est la même personne à chaque poste. " +
-    "Découpée entre plusieurs prestataires, elle se casse à chaque jointure — et c'est " +
-    'toujours au client de recoller les morceaux.',
+    'La chaîne ne tient que parce que c’est la même personne à chaque poste. Découpée entre ' +
+    'prestataires, elle casse à chaque jointure.',
 } as const
 
 export const PAGE_ACCUEIL: IEditorialPage = {

--- a/src/@vitrine/contenu/data-sections.ts
+++ b/src/@vitrine/contenu/data-sections.ts
@@ -25,19 +25,14 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     kicker: 'Le point de départ',
     titre: 'Je commence par votre métier, pas par votre donnée',
     chapo:
-      'Une activité qui tourne depuis des années sait déjà beaucoup de choses : qui sont ' +
-      'ses bons clients, quand une commande sent mauvais, ce qu’on accepte et ce qu’on ' +
-      'refuse. Ce savoir est rarement écrit quelque part. Le faire émerger et le mettre ' +
-      'noir sur blanc est une prestation à part entière — pas une étape préparatoire.',
+      'Une activité qui tourne sait déjà beaucoup de choses, rarement écrites. Le mettre noir ' +
+      'sur blanc est une prestation à part entière.',
     blocs: [
       {
         titre: 'Faire émerger les règles qui existent déjà',
         texte:
-          'Vos équipes appliquent des règles de décision qu’elles n’ont jamais formalisées. ' +
-          'Je les recueille auprès de ceux qui les appliquent, je les écris, puis je les ' +
-          'confronte à votre historique pour voir lesquelles tiennent encore. C’est le ' +
-          'métier que j’exerçais avant de le faire pour de la donnée : recueillir un ' +
-          'besoin, puis le traduire en quelque chose d’implémentable.',
+          'Je recueille les règles de décision auprès de ceux qui les appliquent, puis je les ' +
+          'confronte à votre historique.',
         preuve:
           'AMOA de la startup biotech Artedrone : besoin recueilli auprès des équipes ' +
           'scientifiques et dirigeantes, traduit en spécifications exploitables par des ' +
@@ -50,10 +45,8 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'Découvrir vos profils de clients',
         texte:
-          'Profilage par clustering (KNN) sur vos données réelles : les groupes ne sont ' +
-          'pas décidés à l’avance, ils sortent de l’analyse. La restitution est visuelle ' +
-          'et pensée pour la décision — ce que vous devez trancher apparaît, le reste ' +
-          'disparaît.',
+          'Profilage par clustering (KNN) : les groupes sortent de l’analyse, pas d’un a ' +
+          'priori.',
         decision:
           'Quel segment vous voulez servir mieux, et lequel vous coûte plus qu’il ne ' +
           'rapporte.',
@@ -61,10 +54,8 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'Faire parler l’historique',
         texte:
-          'Reprise de l’historique, analyse exploratoire sous Orange Data Mining, ' +
-          'pondération et sélection des variables, élimination des corrélations fortes et ' +
-          'des variables porteuses de bruit. On cherche ce que votre activité fait déjà ' +
-          'sans le savoir, pas une performance de modèle.',
+          'Analyse exploratoire de l’historique sous Orange Data Mining, pondération et ' +
+          'sélection des variables.',
         preuve:
           'Analyse de l’historique des inscriptions ayant abouti à des règles anti-fraude : ' +
           'fraude en baisse, conversion des inscriptions en hausse.',
@@ -72,10 +63,8 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'Cette phase se livre pour elle-même',
         texte:
-          'Elle produit un document : ce que votre donnée dit de votre activité, les ' +
-          'règles formalisées, les profils identifiés, et les questions auxquelles ' +
-          'personne ne peut répondre aujourd’hui. Vous pouvez vous arrêter là. Si rien ne ' +
-          'justifie d’aller plus loin, je le dis.',
+          'Un document : règles formalisées, profils identifiés, ce que votre donnée dit de ' +
+          'votre activité. Vous pouvez vous arrêter là.',
         decision: 'S’il y a un problème qui mérite d’être traité par la technique — et lequel.',
       },
     ],
@@ -87,29 +76,21 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     kicker: 'La stratégie data',
     titre: 'Construire la stratégie data, ou s’appuyer sur celle qui existe',
     chapo:
-      'Deux situations, et elles ne demandent pas le même travail. Soit vous n’avez pas ' +
-      'de donnée exploitable et il faut décider quoi mesurer — en partant des questions ' +
-      'de l’étape précédente, pas d’un gabarit. Soit vous en avez déjà, et il s’agit d’en ' +
-      'tirer quelque chose sans tout refaire.',
+      'Soit il faut décider quoi mesurer, soit la donnée existe et il s’agit d’en tirer ' +
+      'quelque chose sans tout refaire.',
     blocs: [
       {
         titre: 'Quand rien n’est en place',
         texte:
-          'Ce qu’on mesure découle des questions posées au métier. Définition des ' +
-          'indicateurs, plan de collecte, pipelines d’ingestion, puis modélisation : ' +
-          'PostgreSQL en relationnel, en séries temporelles ou en vectoriel, MySQL, ' +
-          'Firebase. Le choix du stockage suit la question qu’on veut poser à la donnée, ' +
-          'pas l’inverse.',
+          'Indicateurs, plan de collecte, pipelines d’ingestion, modélisation : PostgreSQL ' +
+          'relationnel, séries temporelles ou vectoriel, MySQL, Firebase.',
         decision: 'Ce que vous commencez à mesurer maintenant, et ce qui peut attendre six mois.',
       },
       {
         titre: 'Quand la donnée existe déjà',
         texte:
-          'Reprise de l’existant, agrégation et réconciliation multi-sources, ' +
-          'dédoublonnage des identités selon votre modèle métier et non selon un ' +
-          'connecteur générique. Contrôles d’intégrité et de véracité dès l’ingestion, ' +
-          'détection d’anomalies : les écarts sont corrigés avant de contaminer les ' +
-          'tableaux de bord, pas une fois que quelqu’un s’est étonné d’un chiffre.',
+          'Réconciliation multi-sources et dédoublonnage selon votre modèle métier, écarts ' +
+          'corrigés dès l’ingestion.',
         preuve:
           'Système d’analyse multi-sources conforme RGPD mesurant la rentabilité client à ' +
           'long terme, branché sur Google Ads et Bing Ads.',
@@ -119,9 +100,8 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'La qualité n’est pas un correctif',
         texte:
-          'Un modèle entraîné sur une donnée sale produit une décision sale, plus vite et ' +
-          'avec plus d’assurance. C’est pour cette raison que cette étape passe avant la ' +
-          'technique, et non parce que la propreté serait une vertu en soi.',
+          'Un modèle entraîné sur une donnée sale produit une décision sale, plus vite et avec ' +
+          'plus d’assurance.',
       },
     ],
   },
@@ -132,26 +112,19 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     kicker: 'Gouvernance et droit',
     titre: 'Qui possède quoi, et ce qui a le droit d’être traité',
     chapo:
-      'Cette question se pose avant d’écrire la moindre ligne, parce que sa réponse écarte ' +
-      'des solutions entières. Y répondre après coup coûte le double : il faut alors ' +
-      'défaire ce qui a été construit sur la mauvaise hypothèse.',
+      'Elle se pose avant la moindre ligne de code : sa réponse écarte des solutions entières, ' +
+      'et y répondre après coup coûte le double.',
     blocs: [
       {
         titre: 'Qui possède la donnée',
         texte:
-          'Cartographie des sources et de leur propriété : ce qui est à vous, ce qui ' +
-          'appartient à vos clients, ce qui reste la propriété d’une régie ou d’un ' +
-          'prestataire. On en déduit ce qui peut sortir de chez vous et ce qui doit y ' +
-          'rester.',
+          'Cartographie des sources et de leur propriété : à vous, à vos clients, ou à une ' +
+          'régie.',
         decision: 'Quelle donnée reste chez vous, et ce que vous acceptez d’envoyer à un tiers.',
       },
       {
         titre: 'Ce qui a le droit d’être collecté et traité',
-        texte:
-          'RGPD, base légale du traitement, consentement géré par une CMP avec ' +
-          'déclenchement conditionnel des tags par catégorie, cadrage des traitements avec ' +
-          'le juridique. La conformité n’est pas une case cochée après coup : elle ' +
-          'conditionne l’architecture de collecte.',
+        texte: 'RGPD, base légale, consentement géré par une CMP, cadrage avec le juridique.',
         preuve:
           'Conformité RGPD et DORA tenue en appels d’offres grands comptes — distribution, ' +
           'assurance, banque. Cadrage RGPD des données clients chez un e-commerçant de ' +
@@ -162,10 +135,8 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'La contrainte oriente la solution',
         texte:
-          'Si une donnée ne peut pas quitter votre système, un service tiers est écarté ' +
-          'd’office et la comparaison se joue entre un modèle open-weight que l’on héberge ' +
-          '— Llama 3 par exemple — et une règle explicite. C’est une contrainte de départ, ' +
-          'pas une déception à annoncer en fin de projet.',
+          'Si une donnée ne peut pas quitter votre système, le service tiers est écarté : ' +
+          'reste un modèle open-weight hébergé — Llama 3 — ou une règle explicite.',
       },
     ],
   },
@@ -183,23 +154,16 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     kicker: 'Charnière · vers le SEA & UX',
     titre: 'Un métier compris devient un budget arbitrable',
     chapo:
-      'Quand les règles sont écrites, les profils identifiés et la donnée gouvernée, on ne ' +
-      'regarde plus un tableau de bord de plus : on tient la matière des décisions ' +
-      'd’acquisition et de parcours. Quel canal financer, quelle étape supprimer, quelle ' +
-      'page rendre autrement. Sans elle, le SEA achète du volume et l’expérience ' +
-      'utilisateur devient une affaire de goût.',
+      'Règles écrites, profils identifiés, donnée gouvernée : on tient la matière des ' +
+      'arbitrages. Sans elle, le SEA achète du volume.',
     blocs: [
       {
         titre: 'Rentabilité à long terme',
-        texte:
-          'la mesure de la valeur client dans la durée remplace le coût par clic comme ' +
-          'critère d’arbitrage.',
+        texte: 'la valeur client dans la durée remplace le coût par clic.',
       },
       {
         titre: 'Et ensuite',
-        texte:
-          'le pôle SEA & UX tranche sur ces chiffres — puis implémente l’arbitrage dans le ' +
-          'produit, sans passer par un tiers.',
+        texte: 'le pôle SEA & UX tranche sur ces chiffres, puis implémente l’arbitrage lui-même.',
       },
     ],
   },

--- a/src/@vitrine/contenu/fil-ia.ts
+++ b/src/@vitrine/contenu/fil-ia.ts
@@ -19,29 +19,21 @@ export const SECTION_FIL_IA: IEditorialSection = {
   kicker: 'Le fil · tous les pôles',
   titre: 'Je conçois, je développe et je pilote avec l’IA',
   chapo:
-    'L’IA apparaît deux fois sur ce site, et il faut les distinguer : elle est ce que je ' +
-    'livre au pôle IA, et elle est la façon dont je travaille sur tous. Cette ' +
-    'section-ci parle de la seconde — de la première option d’architecture jusqu’à ' +
-    'l’arbitrage d’un budget SEA. Une règle la tient d’un bout à l’autre : l’IA propose, ' +
-    'les tests tranchent.',
+    'L’IA est ce que je livre au pôle IA, et la façon dont je travaille sur tous. Ici, la ' +
+    'seconde : l’IA propose, les tests tranchent.',
   blocs: [
     {
       titre: 'Concevoir — instruire les options, pas les recevoir',
       texte:
-        'Au cadrage et à l’architecture, l’IA sert à instruire : faire produire plusieurs ' +
-        'scénarios, les confronter, exposer leurs coûts et leurs angles morts avant que le ' +
-        'premier fichier soit écrit. La décision reste la mienne et s’écrit noir sur blanc — ' +
-        'arbitrage monolithe ou microservices, stratégie de rendu page par page, découpage ' +
-        'des services.',
+        'L’IA instruit : plusieurs scénarios, leurs coûts, leurs angles morts. La décision ' +
+        'reste la mienne et s’écrit noir sur blanc.',
       decision: 'Le scénario d’architecture retenu, ceux qui ont été écartés, et sur quel critère.',
     },
     {
       titre: 'Construire — Claude Code et Gemini, pilotés par les tests',
       texte:
-        'Agents, hooks, skills, loop et serveurs MCP internes au quotidien, avec le test ' +
-        'écrit avant, exécuté pendant et rejoué après la génération. Les tests de mutation ' +
-        'vérifient que les tests eux-mêmes valent quelque chose : sans eux, une base générée ' +
-        'donne surtout l’illusion d’être couverte.',
+        'Agents, hooks, skills et serveurs MCP internes, le test écrit avant et rejoué après ' +
+        'la génération.',
       preuve:
         'Jest, Cypress, Playwright, mutation Stryker. Certification ISTQB Foundation. Ce ' +
         'site est construit ainsi, de bout en bout.',
@@ -50,21 +42,15 @@ export const SECTION_FIL_IA: IEditorialSection = {
     {
       titre: 'Livrer — l’IA dans le produit qui tourne',
       texte:
-        'C’est le pôle IA : donnée mise au propre, apprentissage supervisé en production, LLM ' +
-        'et agents avec le coût d’inférence, la latence et le RGPD tenus. La méthode et ' +
-        'l’offre partagent les mêmes outils, elles ne se confondent pas — ce que le pôle IA ' +
-        'vend, c’est de l’IA qui tourne chez vous, pas ma manière d’écrire du code.',
+        'De l’IA qui tourne chez vous, coût d’inférence, latence et RGPD tenus — pas ma ' +
+        'manière d’écrire du code.',
       preuve:
         'Modèle supervisé en production, fine-tuning de Llama 3 sur corpus métier, RAG ' +
         'documentaire fait maison.',
     },
     {
       titre: 'Piloter — le SEA et l’UX décidés sur ce que la donnée dit',
-      texte:
-        'Au bout de la chaîne, la même donnée sert à trancher : profilage clients par ' +
-        'clustering, rentabilité client dans la durée, A/B testing des parcours. Un budget se ' +
-        'coupe et une étape de tunnel disparaît parce que le chiffre le dit — puis c’est la ' +
-        'même personne qui l’implémente dans le produit.',
+      texte: 'La même donnée sert à trancher, puis la même personne implémente l’arbitrage.',
       preuve:
         'Panier moyen en hausse de 50 % sur un e-commerce de joaillerie, 100 000 € de budget ' +
         'ADS / SEO pilotés.',

--- a/src/@vitrine/contenu/ia-sections.ts
+++ b/src/@vitrine/contenu/ia-sections.ts
@@ -27,17 +27,14 @@ export const SECTIONS_IA: IEditorialSection[] = [
     kicker: 'La réponse technique',
     titre: 'La solution répond au problème — et ce n’est pas toujours de l’IA',
     chapo:
-      'C’est seulement ici que la technique arrive, et elle est arbitrée contre le travail ' +
-      'de la donnée : le problème métier posé au départ, la donnée réellement ' +
-      'disponible, et ce que le droit autorise. Pas contre l’état de l’art.',
+      'La technique n’arrive qu’ici, arbitrée contre le problème métier, la donnée disponible ' +
+      'et ce que le droit autorise. Pas contre l’état de l’art.',
     blocs: [
       {
         titre: 'Souvent, une règle métier suffit',
         texte:
-          'Une règle explicite est moins chère à faire tourner, plus facile à expliquer à ' +
-          'un régulateur et plus simple à corriger qu’un modèle. Quand elle suffit, je le ' +
-          'dis, et je l’intègre dans vos systèmes existants au lieu d’ajouter une brique ' +
-          'de plus. C’est un livrable complet, pas un lot de consolation.',
+          'Moins chère, plus facile à expliquer à un régulateur, plus simple à corriger qu’un ' +
+          'modèle. Quand elle suffit, je le dis.',
         preuve:
           'Règles anti-fraude définies puis implémentées dans le produit par la même ' +
           'personne : fraude en baisse, conversion des inscriptions en hausse, latence ' +
@@ -50,26 +47,19 @@ export const SECTIONS_IA: IEditorialSection[] = [
       {
         titre: 'Un modèle, quand la règle ne tient plus',
         texte:
-          'Apprentissage supervisé — classification, réseaux de neurones — ou non ' +
-          'supervisé, selon ce que la donnée permet. Exemple livré : un modèle supervisé ' +
-          'anticipant les échecs de dépôt vocal, qui évite d’emprunter une route coûteuse ' +
-          'quand l’échec est probable. La méthode d’extraction des caractéristiques du ' +
-          'signal audio est publiée sur arXiv ; je l’ai implémentée moi-même, adaptée aux ' +
-          'données réelles, validée, puis industrialisée. Entraînement TensorFlow, ' +
-          'inférence en cloud functions.',
+          'Apprentissage supervisé ou non supervisé, selon ce que la donnée permet. La méthode ' +
+          'd’extraction des caractéristiques du signal audio est publiée sur arXiv ; je l’ai ' +
+          'implémentée moi-même, puis industrialisée. TensorFlow, inférence en cloud ' +
+          'functions.',
         preuve: 'Routes vocales coûteuses évitées.',
       },
       {
         titre: 'Un LLM, quand le problème est du langage',
         texte:
-          'Claude sur Vertex AI et par l’API Anthropic, OpenAI, Gemini, Llama : comparés ' +
-          'en continu et arbitrés cas d’usage par cas d’usage sur quatre axes — coût ' +
-          'd’inférence, latence, qualité attendue, confidentialité. Fine-tuning de Llama 3 ' +
-          'sur corpus métier pour l’application mobile Prézage, complété d’un procédé ' +
-          'maison d’augmentation du contexte proche du RAG. RAG documentaire pour le ' +
-          'support de niveau 1 : recherche vectorielle PostgreSQL et API OpenAI, réponses ' +
-          'ancrées sur votre documentation interne et non sur la mémoire du modèle. Aucun ' +
-          'framework tiers — la chaîne est écrite, donc lisible et corrigeable.',
+          'Claude sur Vertex AI et par l’API Anthropic, OpenAI, Gemini, Llama, arbitrés sur le ' +
+          'coût d’inférence, la latence, la qualité et la confidentialité. Fine-tuning de ' +
+          'Llama 3 pour l’application mobile Prézage, RAG documentaire fait maison, aucun ' +
+          'framework tiers.',
         preuve: 'Charge de travail des prestataires réduite.',
         decision: 'Modèle hébergé ou service tiers, et ce que chacun vous coûte par mois.',
       },
@@ -82,24 +72,21 @@ export const SECTIONS_IA: IEditorialSection[] = [
     kicker: 'Et ensuite',
     titre: 'Ce qui est livré tourne, et reste explicable',
     chapo:
-      'Une solution qui ne survit pas à six mois d’exploitation n’a pas résolu le ' +
-      'problème, elle l’a déplacé. Le déploiement, la surveillance et la conformité font ' +
-      'donc partie du même lot, tenus par la même personne.',
+      'Une solution qui ne survit pas à six mois d’exploitation a déplacé le problème. ' +
+      'Déploiement, surveillance et conformité sont dans le même lot.',
     blocs: [
       {
         titre: 'Déploiement et surveillance',
         texte:
-          'Déploiement, versioning et monitoring des modèles, CI/CD Docker et GitHub ' +
-          'Actions, Vertex AI, Pub/Sub, Cloud Run, cloud functions, VM Compute Engine ' +
-          'auto-scalées. Pas de cluster Kubernetes administré en propre : je m’en tiens à ' +
-          'ce que je sais exploiter seul, et je le dis avant le devis plutôt qu’après.',
+          'Versioning et monitoring des modèles, CI/CD Docker et GitHub Actions, Vertex AI, ' +
+          'Pub/Sub, Cloud Run, VM auto-scalées. Pas de cluster Kubernetes administré en ' +
+          'propre.',
       },
       {
         titre: 'Rendre votre produit appelable',
         texte:
-          'Conception, développement et documentation de serveurs MCP et de plugins n8n, ' +
-          'Make et Zapier : votre produit devient utilisable par un agent IA ou par un ' +
-          'scénario no-code, chez vous comme chez vos propres clients.',
+          'Serveurs MCP et plugins n8n, Make et Zapier : votre produit devient appelable par ' +
+          'un agent ou un scénario no-code.',
         decision: 'Ce que vous ouvrez à l’automatisation, et ce qui reste fermé.',
       },
     ],

--- a/src/@vitrine/contenu/ingenierie-web-sections.ts
+++ b/src/@vitrine/contenu/ingenierie-web-sections.ts
@@ -15,16 +15,14 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'Ce que je construis',
     titre: 'Trois natures de produit, une seule façon de les tenir',
     chapo:
-      'Un site, un produit SaaS et une application mobile ne se pilotent pas pareil : ils ' +
-      "n'ont ni le même cycle de vie, ni les mêmes contraintes de mise en production, ni " +
-      'les mêmes utilisateurs. Je les ai menés tous les trois, de la conception au run.',
+      "Un site, un produit SaaS et une application mobile n'ont ni le même cycle de vie, ni " +
+      'les mêmes contraintes. Je les ai menés tous les trois, de la conception au run.',
     blocs: [
       {
         titre: 'Site internet',
         texte:
-          'Vitrine, e-commerce ou site institutionnel lu par des investisseurs et par la ' +
-          "presse. Le référencement et la performance n'y sont pas des options à ajouter " +
-          'ensuite : ils se décident au moment de choisir la stratégie de rendu.',
+          'Vitrine, e-commerce ou site institutionnel : référencement et performance se ' +
+          'décident au moment de choisir la stratégie de rendu.',
         preuve:
           'Sites du fonds Truffle Capital et de ses participations (truffle.com, ' +
           'truffle100.fr, artedrone.fr), de la conception à l’exploitation.',
@@ -33,19 +31,16 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
       {
         titre: 'Produit SaaS',
         texte:
-          'Un produit vendu à des grands comptes, avec ce que cela implique : montée en ' +
-          'charge, disponibilité contractuelle, conformité exigée en appel d’offres. ' +
-          'Conception et réalisation de bout en bout de la plateforme BtoB « Sms En Masse », ' +
-          'en remplacement d’une solution tierce exploitée en marque blanche.',
+          'Montée en charge, disponibilité contractuelle, conformité exigée en appel d’offres. ' +
+          'Plateforme BtoB « Sms En Masse » conçue et réalisée de bout en bout.',
         preuve: 'Conformité RGPD et DORA tenue en appels d’offres distribution, assurance, banque.',
         decision: 'Ce que vous internalisez, et ce que vous continuez de louer à un tiers.',
       },
       {
         titre: 'Application mobile',
         texte:
-          'iOS et Android sous Ionic et Angular, jusqu’aux magasins d’applications. Suivi ' +
-          'des parcours et des échecs via Firebase Analytics et Crashlytics, du signal ' +
-          'jusqu’au correctif livré.',
+          'iOS et Android sous Ionic et Angular. Parcours et échecs suivis via Firebase ' +
+          'Analytics et Crashlytics.',
         preuve:
           'Application « Prézage » : migration Ionic 6 vers 8 et Angular 15 vers 19 menée ' +
           'sans interruption ni gel de la roadmap.',
@@ -59,17 +54,14 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'Avant la première ligne',
     titre: 'Le cadrage, tenu par celui qui devra le coder',
     chapo:
-      'Neuf ans dont deux en double casquette technique et pilotage. Je recueille le ' +
-      'besoin, je le traduis en spécifications, et je sais ce que chaque ligne coûtera à ' +
-      'implémenter — parce que c’est moi qui l’implémenterai.',
+      'Neuf ans dont deux en double casquette technique et pilotage. Je traduis le besoin en ' +
+      'spécifications en sachant ce que chaque ligne coûtera.',
     blocs: [
       {
         titre: 'Recueil du besoin et spécifications',
         texte:
           'Modélisation des flux en BPMN 2.0, cartographie du système d’information, ' +
-          'matrice de risques, recette et tests d’acceptation. Le besoin d’équipes ' +
-          'scientifiques ou dirigeantes est traduit en spécifications exploitables par des ' +
-          'prestataires qui ne connaissent pas leur domaine.',
+          'matrice de risques, recette et tests d’acceptation.',
         preuve:
           'AMOA de la startup biotech Artedrone ; intégration de l’ERP M3 Soft et ' +
           'synchronisation boutique physique / e-commerce, survente évitée sur des pièces uniques.',
@@ -78,9 +70,8 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
       {
         titre: 'Interfaces et parcours',
         texte:
-          'Maquettage, catalogue de composants sous Storybook, accessibilité RGAA, WCAG et ' +
-          'W3C traitée pendant la conception et non en rattrapage. Les parcours sont ' +
-          'refondus sur la mesure — c’est le pôle SEA & UX qui fournit les chiffres.',
+          'Maquettage, catalogue de composants sous Storybook, accessibilité RGAA, WCAG et W3C ' +
+          'traitée pendant la conception.',
         preuve: 'Panier moyen en hausse de 50 % après refonte des tunnels d’achat.',
       },
       {
@@ -99,36 +90,29 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'La construction',
     titre: 'Front, back, architecture et exploitation',
     chapo:
-      'La même personne décide de la stratégie de rendu, du modèle de données et de la ' +
-      'façon dont le tout est déployé. Les arbitrages sont donc pris en connaissant leurs ' +
-      'trois conséquences en même temps, pas les unes après les autres.',
+      'La même personne décide de la stratégie de rendu, du modèle de données et du ' +
+      'déploiement : les trois conséquences sont connues en même temps.',
     blocs: [
       {
         titre: 'Front-end',
         texte:
-          'React et Next.js avec stratégie de rendu différenciée par type de page — CSR, ' +
-          'SSR, SSG, ISR — pour arbitrer performance perçue, coût serveur et ' +
-          'référencement. Angular, Ionic, Redux, Zustand, React Query, Tailwind, Material UI, ' +
-          'SCSS et CSS-in-JS.',
+          'React et Next.js, rendu différencié par type de page — CSR, SSR, SSG, ISR. Angular, ' +
+          'Ionic, Redux, Zustand, React Query, Tailwind, Material UI.',
         preuve: 'Lighthouse 98/100, conformité RGAA / WCAG tenue en parallèle.',
       },
       {
         titre: 'Back-end et données',
         texte:
-          'Node.js et Express, API REST, webhooks, cloud functions, traitements ' +
-          'asynchrones distribués via Google Cloud Pub/Sub. PostgreSQL en relationnel, en ' +
-          'séries temporelles et en vectoriel, MySQL, Firebase. Toute entrée externe est ' +
-          'validée par un schéma Zod à la frontière.',
+          'Node.js et Express, API REST, webhooks, cloud functions, Pub/Sub. PostgreSQL, ' +
+          'MySQL, Firebase ; toute entrée externe est validée par un schéma Zod.',
         decision: 'Ce qui reste synchrone, et ce qui part en file — avec le coût de chaque choix.',
       },
       {
         titre: 'Architecture et exploitation',
         texte:
-          'Arbitrage monolithe ou microservices posé explicitement. Docker, CI/CD GitHub ' +
-          'Actions, Google Cloud — Cloud Run, VM Compute Engine auto-scalées, cloud ' +
-          'functions, Pub/Sub —, Vercel, serveurs on-premise et IaaS sous Apache, Nginx et ' +
-          'Linux. Pas de cluster Kubernetes administré en propre : c’est écrit ici parce ' +
-          'que vous méritez de le savoir avant de signer.',
+          'Monolithe ou microservices arbitré explicitement. Docker, CI/CD GitHub Actions, ' +
+          'Cloud Run, VM Compute Engine auto-scalées, Pub/Sub, Vercel, Apache, Nginx et Linux. ' +
+          'Pas de cluster Kubernetes administré en propre.',
         preuve:
           'SLI / SLO / SLA définis et suivis, PCA et PRA testés par exercices de bascule, ' +
           'déploiements sans interruption de service.',
@@ -143,34 +127,29 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'La qualité',
     titre: 'Certifiée et outillée, pas promise',
     chapo:
-      'Chez MailingVox, il n’y avait ni QA ni équipe data : la qualité a été industrialisée ' +
-      'parce qu’elle ne pouvait venir de personne d’autre. C’est cette méthode-là que vous ' +
-      'achetez, pas une intention.',
+      'Chez MailingVox, il n’y avait ni QA ni équipe data : la qualité a été ' +
+      'industrialisée parce qu’elle ne pouvait venir de personne d’autre.',
     blocs: [
       {
         titre: 'ISTQB Foundation',
         texte:
-          'La certification apporte un vocabulaire de recette commun et opposable : niveaux ' +
-          'de test, critères d’entrée et surtout critères d’arrêt sont écrits avant la ' +
-          'livraison, pas négociés pendant. C’est le seul niveau que je détiens, et c’est ' +
-          'donc le seul que j’affiche.',
+          'Un vocabulaire de recette commun et opposable : critères d’entrée et d’arrêt écrits ' +
+          'avant la livraison. C’est le seul niveau que je détiens, et c’est donc le seul que ' +
+          'j’affiche.',
         decision: 'À partir de quand une version est livrable — et qui le dit.',
       },
       {
         titre: 'Développement piloté par les tests, en IA augmentée',
         texte:
-          'Claude Code et Gemini au quotidien : agents, hooks, skills, loop et serveurs MCP ' +
-          'internes. Le test fait foi avant, pendant et après la génération — c’est ce qui ' +
-          'rend la vélocité gagnée réellement exploitable plutôt que dangereuse.',
+          'Claude Code et Gemini au quotidien : agents, hooks, skills et serveurs MCP ' +
+          'internes, le test faisant foi.',
         preuve: 'Vélocité augmentée à effectif constant.',
       },
       {
         titre: 'Outillage réellement en place',
         texte:
-          'Jest, Cypress, Playwright, tests de mutation Stryker, Postman, Lighthouse. Tests ' +
-          'fonctionnels et recette des parcours critiques, tests d’acceptation avec le ' +
-          'product owner et les clients. Non fonctionnels : non-régression à chaque ' +
-          'livraison, performance et charge sur les pics d’envoi, accessibilité.',
+          'Jest, Cypress, Playwright, mutation Stryker, Postman, Lighthouse. Recette des ' +
+          'parcours critiques, non-régression à chaque livraison, charge sur les pics d’envoi.',
         decision: 'Quel niveau de test vous vous autorisez à ne pas payer, et sur quel périmètre.',
       },
     ],
@@ -181,10 +160,8 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'Charnière · vers la donnée',
     titre: 'La livraison n’est pas la fin, c’est le début du run',
     chapo:
-      'Un produit mis en production se met à tourner, et ce qui tourne produit de la ' +
-      'donnée : volumes, échecs, parcours abandonnés, coûts d’infrastructure. Exploiter, ' +
-      'c’est mesurer. C’est ce moment précis qui fait naître le besoin de data et d’IA — ' +
-      'pas une mode, et pas avant que le produit existe.',
+      'Ce qui tourne produit de la donnée. C’est ce moment précis qui fait naître le besoin de ' +
+      'data et d’IA — pas une mode, et pas avant que le produit existe.',
     blocs: [
       {
         titre: 'Contrôles post-déploiement',
@@ -196,9 +173,7 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
       },
       {
         titre: 'Et ensuite',
-        texte:
-          'la donnée produite par le run devient la matière du pôle Data — qualité, règles ' +
-          'métier, modèles et IA en production.',
+        texte: 'la donnée produite par le run devient la matière du pôle Data.',
       },
     ],
   },

--- a/src/@vitrine/contenu/jointures.ts
+++ b/src/@vitrine/contenu/jointures.ts
@@ -19,37 +19,31 @@ export const JOINTURES: IJointure[] = [
     amont: 'ingenierie-web',
     aval: 'data',
     matiere:
-      'Un produit en production, exploité et mesuré : c’est le run qui fabrique la ' +
-      'donnée, jamais l’inverse. Les règles anti-fraude que j’ai implémentées ne sont pas ' +
-      'nées d’une intuition, mais de la reprise de l’historique que l’exploitation avait ' +
-      'produit.',
+      'Un produit en production, exploité et mesuré : c’est le run qui fabrique la donnée, ' +
+      'jamais l’inverse.',
     siDejaEnPlace:
-      'Si votre produit tourne déjà, on part de lui. Je ne le réécris pas pour avoir le ' +
-      'droit de le mesurer : l’ingénierie web n’est pas un préalable à vous facturer, ' +
-      'c’est simplement l’endroit d’où la donnée vient.',
+      'Si votre produit tourne déjà, on part de lui. L’ingénierie web n’est pas un préalable à ' +
+      'vous facturer, c’est l’endroit d’où la donnée vient.',
   },
   {
     amont: 'data',
     aval: 'ia',
     matiere:
-      'Un métier formalisé et une donnée gouvernée : les règles de décision écrites, ce ' +
-      'que dit réellement l’historique, et ce qui a le droit d’être traité. Sans ça, un ' +
-      'modèle apprend l’erreur de cadrage au lieu de la corriger.',
+      'Un métier formalisé et une donnée gouvernée. Sans ça, un modèle apprend l’erreur de ' +
+      'cadrage au lieu de la corriger.',
     siDejaEnPlace:
-      'Si votre stratégie data tient déjà, on la reprend telle quelle et on va droit à la ' +
-      'solution. Le pôle data se livre pour lui-même — il ne se rachète pas pour avoir ' +
-      'accès à l’IA.',
+      'Si votre stratégie data tient déjà, on la reprend telle quelle. Le pôle data se livre ' +
+      'pour lui-même — il ne se rachète pas pour accéder à l’IA.',
   },
   {
     amont: 'data',
     aval: 'sea-ux',
     matiere:
-      'La même donnée gouvernée, tournée vers l’arbitrage : quel canal financer, quelle ' +
-      'étape du parcours supprimer, quelle page rendre autrement. Sans elle, le SEA achète ' +
-      'du volume et l’UX redevient une affaire de goût.',
+      'La même donnée gouvernée, tournée vers l’arbitrage. Sans elle, le SEA achète du volume ' +
+      'et l’UX redevient une affaire de goût.',
     siDejaEnPlace:
-      'Si la mesure est en place et qu’elle est fiable, on arbitre dessus dès le premier ' +
-      'jour. Et rien n’oblige à prendre l’IA pour tirer parti de la donnée : les deux ' +
-      'suites se prennent séparément ou ensemble.',
+      'Si la mesure est fiable, on arbitre dessus dès le premier jour. Rien n’oblige à prendre ' +
+      'l’IA pour tirer parti de la donnée : les deux suites se prennent séparément ou ' +
+      'ensemble.',
   },
 ]

--- a/src/@vitrine/contenu/limites.ts
+++ b/src/@vitrine/contenu/limites.ts
@@ -12,34 +12,31 @@ export const LIMITES: IBoundary[] = [
   {
     hors: 'Aucune couche commerciale, aucun transfert de dossier',
     alaPlace:
-      "Vous parlez à la personne qui écrit le code. C'est la même du cadrage au run, " +
-      'sur les quatre pôles. Si la taille du projet demande un renfort — c’est rare — je ' +
-      'choisis le prestataire, je le cadre et j’en réponds : votre interlocuteur, lui, ' +
-      'ne change pas.',
+      'Vous parlez à la personne qui écrit le code, du cadrage au run, sur les quatre pôles. ' +
+      'Si la taille du projet demande un renfort — c’est rare — je le choisis, je le cadre et ' +
+      'j’en réponds : votre interlocuteur, lui, ne change pas.',
   },
   {
     hors: 'Pas de cluster Kubernetes administré en propre',
     alaPlace:
-      'Cloud Run, VM Compute Engine auto-scalées, cloud functions et Pub/Sub. Le run ' +
-      'tourne, il est mesuré, et il ne repose pas sur une compétence que je ne tiens pas.',
+      'Cloud Run, VM Compute Engine auto-scalées, cloud functions et Pub/Sub. Le run tourne, ' +
+      'il est mesuré, et il ne repose sur aucune compétence que je ne tiens pas.',
   },
   {
     hors: 'Pas de framework RAG tiers',
     alaPlace:
-      'Le RAG est fait maison : recherche vectorielle PostgreSQL et API OpenAI, réponses ' +
-      'ancrées sur votre documentation interne, pas sur la mémoire du modèle.',
+      'RAG fait maison : recherche vectorielle PostgreSQL et API OpenAI, réponses ancrées sur ' +
+      'votre documentation interne.',
   },
   {
     hors: 'Pas de création graphique ni de design d’interface',
     alaPlace:
-      'Des arbitrages de parcours pris sur la donnée : quelle étape disparaît, quel ' +
-      'formulaire raccourcit, quelle page se rend en SSR plutôt qu’en CSR.',
+      'Des arbitrages de parcours pris sur la donnée : quelle étape disparaît, quel formulaire ' +
+      'raccourcit.',
   },
   {
     hors: 'Deux régies publicitaires, pas douze',
-    alaPlace:
-      'Google Ads et Bing Ads, en SEO, SEA et SMA. Ce que je pilote, je l’ai déjà piloté — ' +
-      'je ne me forme pas à un canal sur votre budget.',
+    alaPlace: 'Google Ads et Bing Ads, en SEO, SEA et SMA. Ce que je pilote, je l’ai déjà piloté.',
   },
   {
     hors: 'Une équipe technique de trois, pas un service',
@@ -51,15 +48,15 @@ export const LIMITES: IBoundary[] = [
   {
     hors: 'Un seul outillage de mesure mobile',
     alaPlace:
-      'Firebase Analytics et Crashlytics, et rien d’autre — je ne cite pas d’outil que je ' +
-      'n’ai pas exploité. Côté web : Google Tag Manager en conteneur web et server-side, ' +
-      'Measurement Protocol, Google Analytics, Matomo, gestion du consentement.',
+      'Firebase Analytics et Crashlytics, et rien d’autre. Côté web : Google Tag Manager en ' +
+      'conteneur web et server-side, Measurement Protocol, Google Analytics, Matomo, gestion ' +
+      'du consentement.',
   },
   {
     hors: 'ISTQB Foundation, et rien au-delà',
     alaPlace:
-      'C’est le seul niveau que je détiens, c’est donc le seul qui est affiché. Ce qui est ' +
-      'outillé l’est réellement : développement piloté par les tests, Jest, Cypress, ' +
-      'Playwright, tests de mutation Stryker, Postman, Lighthouse.',
+      'C’est le seul niveau que je détiens, c’est donc le seul affiché. Ce qui est outillé ' +
+      'l’est réellement : tests d’abord, Jest, Cypress, Playwright, mutation Stryker, Postman, ' +
+      'Lighthouse.',
   },
 ]

--- a/src/@vitrine/contenu/poles-nav.ts
+++ b/src/@vitrine/contenu/poles-nav.ts
@@ -22,9 +22,8 @@ export const POLES_NAV: IPole[] = [
     route: ROUTES['ingenierie-web'],
     promesse: 'Je construis le produit, et je le fais tourner.',
     accroche:
-      'Site, produit SaaS, application mobile : conception, développement, mise en production ' +
-      'et exploitation. Une seule personne du cadrage au run, avec une qualité outillée et ' +
-      'certifiée plutôt que promise.',
+      'Site, produit SaaS, application mobile : de la conception au run, par une seule ' +
+      'personne, avec une qualité outillée et certifiée plutôt que promise.',
   },
   {
     id: 'data',
@@ -34,10 +33,8 @@ export const POLES_NAV: IPole[] = [
     route: ROUTES.data,
     promesse: 'Je pars de votre métier ; la technique vient en dernier.',
     accroche:
-      'Faire émerger ce que votre activité sait déjà sans l’avoir formalisé : ses règles ' +
-      'de décision, ses profils de clients, ce que dit son historique. Puis la stratégie ' +
-      'data, la gouvernance et le droit. C’est une prestation à part entière : elle se ' +
-      'livre, et vous pouvez vous arrêter là.',
+      'Faire émerger ce que votre activité sait déjà sans l’avoir formalisé, puis la stratégie ' +
+      'data, la gouvernance et le droit. Elle se livre seule : vous pouvez vous arrêter là.',
   },
   {
     id: 'ia',
@@ -47,10 +44,8 @@ export const POLES_NAV: IPole[] = [
     route: ROUTES.ia,
     promesse: 'La réponse n’est pas toujours un modèle, et je le dis avant d’en construire un.',
     accroche:
-      'Souvent, une règle métier intégrée à vos systèmes existants suffit — et c’est un ' +
-      'livrable complet. Sinon, un modèle supervisé ou non supervisé ; et si le problème ' +
-      'est du langage, un LLM arbitré sur le coût d’inférence, la latence, la qualité et ' +
-      'la confidentialité.',
+      'Souvent une règle métier intégrée à l’existant suffit ; sinon un modèle, ou un LLM ' +
+      'arbitré sur le coût d’inférence, la latence et la confidentialité.',
   },
   {
     id: 'sea-ux',
@@ -60,8 +55,7 @@ export const POLES_NAV: IPole[] = [
     route: ROUTES['sea-ux'],
     promesse: 'Je ne dessine pas vos maquettes, je tranche vos parcours.',
     accroche:
-      'Mesure construite dans le code, conformité du consentement, rentabilité à long terme ' +
-      'plutôt que coût par clic, et des arbitrages de parcours décidés sur la donnée — puis ' +
-      'implémentés par la même personne.',
+      'Mesure construite dans le code, consentement conforme, rentabilité à long terme plutôt ' +
+      'que coût par clic, et des arbitrages décidés sur la donnée puis implémentés.',
   },
 ]

--- a/src/@vitrine/contenu/renforts.ts
+++ b/src/@vitrine/contenu/renforts.ts
@@ -19,31 +19,23 @@ export const SECTION_RENFORTS: IEditorialSection = {
   kicker: 'L’objection inverse',
   titre: 'Et si le projet dépasse une personne ?',
   chapo:
-    'Cela arrive rarement, et quand cela arrive je préfère le dire plutôt que de tenir ' +
-    'une promesse contre les faits. Sur un projet dont la taille le demande, je ' +
-    'm’entoure de prestataires que je choisis, que je cadre et dont je réponds. Ce qui ' +
-    'ne change pas : vous ne gérez personne d’autre que moi.',
+    'Cela arrive rarement, et je préfère le dire. Sur un projet dont la taille le demande, je ' +
+    'm’entoure de prestataires que je choisis, que je cadre et dont je réponds — vous ne gérez ' +
+    'personne d’autre que moi.',
   blocs: [
     {
       titre: 'C’est rare, et la rareté se dit',
       texte:
-        'La très grande majorité des projets que je prends tient sur une personne du ' +
-        'cadrage au run — c’est même toute la raison d’être de la chaîne décrite plus ' +
-        'haut. Le renfort n’est pas le mode normal : il se déclenche quand le volume de ' +
-        'travail dépasserait ce que je peux tenir sans faire attendre le projet. Le ' +
-        'reconnaître coûte moins cher que de le découvrir en cours de route.',
+        'La très grande majorité des projets tient sur une personne du cadrage au run. Le ' +
+        'renfort se déclenche quand le volume dépasserait ce que je peux tenir.',
       decision:
         'À quel moment vous préférez un renfort plutôt qu’un délai — l’arbitrage est le vôtre.',
     },
     {
       titre: 'Choisis, cadrés, et sous ma responsabilité',
       texte:
-        'Un renfort travaille sur des spécifications que j’ai écrites, dans le dépôt que ' +
-        'je tiens, avec les mêmes tests et la même chaîne d’intégration continue. C’est ' +
-        'l’exercice de la section précédente pris dans l’autre sens : donner à quelqu’un ' +
-        'de quoi travailler sans avoir à connaître le domaine. Je ne transmets pas votre ' +
-        'dossier — je reste la personne qui répond de ce qui est livré, y compris de ce ' +
-        'que je n’ai pas tapé moi-même.',
+        'Un renfort travaille sur mes spécifications, dans mon dépôt, avec les mêmes tests. Je ' +
+        'réponds de ce qui est livré, y compris de ce que je n’ai pas tapé moi-même.',
       preuve:
         'AMOA de la startup biotech Artedrone : spécifications écrites pour des tiers ' +
         'extérieurs au domaine, BPMN 2.0 et cartographie du système d’information.',
@@ -51,11 +43,8 @@ export const SECTION_RENFORTS: IEditorialSection = {
     {
       titre: 'Vous ne gérez personne d’autre que moi',
       texte:
-        'Pas de chef de projet intermédiaire, pas de comptes rendus à recouper, pas de ' +
-        'second contrat à négocier. Vous parlez à la même personne qu’au premier jour, ' +
-        'elle connaît le produit parce qu’elle l’a construit, et c’est elle qui porte le ' +
-        'planning, le budget et la qualité du renfort. Encadrer des prestataires, c’est ' +
-        'le travail que je faisais déjà avant de vendre ce site.',
+        'Pas de chef de projet intermédiaire, pas de second contrat. Je porte le planning, le ' +
+        'budget et la qualité du renfort.',
       preuve:
         'Environ 25 000 € d’encadrement de prestataires SEA, SEO et SMA chez Verhoeven ' +
         'Joaillier : périmètre, budget et qualité sont restés de mon côté.',

--- a/src/@vitrine/contenu/sea-ux-sections.ts
+++ b/src/@vitrine/contenu/sea-ux-sections.ts
@@ -20,33 +20,27 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'Disons-le tout de suite',
     titre: 'Je ne dessine pas vos maquettes',
     chapo:
-      'Ce pôle ne vend pas de création graphique ni de design d’interface. Il vend des ' +
-      'arbitrages : quel parcours, quelle étape supprimée, quel formulaire raccourci, quel ' +
-      'test A/B tranché, quelle page rendue en SSR plutôt qu’en CSR. Des décisions, prises ' +
-      'sur des chiffres, puis implémentées dans le produit.',
+      'Ce pôle ne vend pas de création graphique. Il vend des arbitrages — quelle étape ' +
+      'supprimée, quel formulaire raccourci — pris sur des chiffres, puis implémentés.',
     blocs: [
       {
         titre: 'Ce que je fais',
         texte:
-          'Je regarde ce que la donnée dit du parcours réel, je propose la modification, ' +
-          'je la teste, et j’écris le code qui l’applique. La boucle complète, sans ' +
-          'intermédiaire ni transfert de dossier.',
+          'Je lis ce que la donnée dit du parcours réel, je propose, je teste, et j’écris le ' +
+          'code.',
         decision: 'Quelle étape du tunnel disparaît, et ce que vous gagnez à la supprimer.',
       },
       {
         titre: 'Ce que je ne fais pas',
         texte:
-          'Je ne produis pas d’identité visuelle, pas de direction artistique, pas de ' +
-          'maquette esthétique livrée en fichier. Si c’est ce dont vous avez besoin, il ' +
-          'vous faut un designer — et je travaille volontiers avec le vôtre.',
+          'Pas d’identité visuelle, pas de direction artistique. Si c’est ce dont vous avez ' +
+          'besoin, il vous faut un designer — je travaille volontiers avec le vôtre.',
       },
       {
         titre: 'Pourquoi ça marche',
         texte:
-          'Parce que les chiffres viennent du pôle Data et que le code vient de ' +
-          'l’ingénierie web. Un ' +
-          'arbitrage n’est utile que s’il repose sur une mesure fiable et qu’il finit ' +
-          'réellement implémenté ; ici, toute la chaîne est tenue par la même personne.',
+          'Les chiffres viennent du pôle Data, le code de l’ingénierie web : toute la ' +
+          'chaîne est tenue par la même personne.',
       },
     ],
   },
@@ -57,39 +51,33 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'La mesure',
     titre: 'Construite dans le code, pas déclarée dans une interface',
     chapo:
-      'C’est ce qui distingue cette prestation de celle d’une agence : je lis le code à ' +
-      'l’endroit exact où l’événement doit être posé, au lieu de le deviner depuis un ' +
-      'tableau de bord. La donnée qui en sort n’est pas approximative.',
+      'Je lis le code à l’endroit exact où l’événement doit être posé, au lieu de le deviner ' +
+      'depuis un tableau de bord.',
     blocs: [
       {
         titre: 'Plan de taggage opposable',
         texte:
           'Conventions de nommage, propriétés attendues, cycle de vie de chaque événement, ' +
-          'documentation tenue à jour et opposable aux équipes. Sans ce document, chaque ' +
-          'nouvelle fonctionnalité ajoute un dialecte de plus.',
+          'documentation opposable aux équipes.',
         decision: 'Quels événements existent, ce qu’ils portent, et qui répond de leur exactitude.',
       },
       {
         titre: 'Collecte web et server-side',
         texte:
-          'Google Tag Manager en conteneur web et server-side, dataLayer, Measurement ' +
-          'Protocol : les événements partent de serveur à serveur, moins exposés aux ' +
-          'bloqueurs et à la perte de signal côté navigateur. Google Analytics, Matomo, ' +
-          'Search Console.',
+          'GTM en conteneur web et server-side, dataLayer, Measurement Protocol : les ' +
+          'événements partent de serveur à serveur. Google Analytics, Matomo, Search Console.',
       },
       {
         titre: 'Mobile',
         texte:
           'Firebase Analytics et Crashlytics : événements in-app, parcours et échecs suivis ' +
-          'jusqu’au correctif livré. Pas d’autre outillage mobile revendiqué — ce serait ' +
-          'inventé.',
+          'jusqu’au correctif. Pas d’autre outillage mobile revendiqué.',
       },
       {
         titre: 'Recette de la donnée',
         texte:
-          'Les implémentations de tracking sont recettées événement par événement, avec la ' +
-          'même méthode que le reste du produit. Contrôles d’intégrité dès l’ingestion, ' +
-          'dédoublonnage, correction des anomalies avant qu’elles n’atteignent un rapport.',
+          'Le tracking est recetté événement par événement, avec contrôles d’intégrité et ' +
+          'dédoublonnage dès l’ingestion.',
         preuve: 'Méthode de recette adossée à la certification ISTQB Foundation.',
       },
     ],
@@ -102,23 +90,21 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     titre: 'Par construction, pas en rattrapage',
     chapo:
       'Le consentement ne se rajoute pas sur une collecte existante : il conditionne son ' +
-      'architecture. Une collecte conçue sans lui devra être refaite, pas corrigée.',
+      'architecture. Conçue sans lui, elle devra être refaite.',
     blocs: [
       {
         titre: 'RGPD et gestion du consentement',
         texte:
           'Plateforme de gestion du consentement, déclenchement conditionnel des tags par ' +
-          'catégorie, cadrage des traitements avec le juridique. Finalité et durée de ' +
-          'conservation décidées avant la première ligne de collecte.',
+          'catégorie, cadrage des traitements avec le juridique.',
         decision:
           'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
       },
       {
         titre: 'Exigences grands comptes',
         texte:
-          'RGPD et DORA, tels qu’ils sont réellement demandés en appel d’offres par la ' +
-          'distribution, l’assurance et la banque. Ce sont des questionnaires auxquels il ' +
-          'faut savoir répondre avec des preuves, pas avec des intentions.',
+          'RGPD et DORA, tels qu’ils sont demandés en appel d’offres par la distribution, ' +
+          'l’assurance et la banque.',
       },
     ],
   },
@@ -129,24 +115,21 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'Le pilotage',
     titre: 'Arbitrer sur la rentabilité réelle, pas sur les métriques des régies',
     chapo:
-      'Une régie publicitaire mesure ce qu’elle a servi. Elle ne mesure pas ce que le ' +
-      'client vous rapportera sur deux ans. Tant que l’arbitrage se fait sur ses chiffres ' +
-      'à elle, le budget suit son intérêt, pas le vôtre.',
+      'Une régie mesure ce qu’elle a servi, pas ce que le client vous rapportera sur deux ans. ' +
+      'Le budget suit alors son intérêt, pas le vôtre.',
     blocs: [
       {
         titre: 'Valeur client à long terme',
         texte:
           'Agrégation des sources d’acquisition, réconciliation et dédoublonnage des ' +
-          'identités, mesure de la rentabilité dans la durée. Les budgets sont ensuite ' +
-          'arbitrés là-dessus.',
+          'identités, mesure de la rentabilité dans la durée.',
         decision: 'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre.',
       },
       {
         titre: 'Campagnes et référencement',
         texte:
-          'Google Ads, Bing Ads, SEO, SEA et SMA. Optimisation du taux de conversion, ' +
-          'A/B testing des pages et des designs, analyse comportementale — heatmaps, taux ' +
-          'de rebond, part de trafic mobile.',
+          'Google Ads, Bing Ads, SEO, SEA et SMA. Taux de conversion, A/B testing, heatmaps, ' +
+          'taux de rebond.',
         preuve:
           '100 000 € de budget ADS / SEO pilotés, mesurés et justifiés auprès des ' +
           'dirigeants chez Truffle Capital ; environ 25 000 € d’encadrement de prestataires ' +
@@ -154,17 +137,13 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
       },
       {
         titre: 'Tableaux de bord sur mesure',
-        texte:
-          'Un tableau de bord par client et par produit, construit sur son modèle métier — ' +
-          'pas un gabarit rempli par un connecteur générique. Profilage clients par ' +
-          'clustering pour rendre la décision lisible.',
+        texte: 'Un tableau de bord par client et par produit, construit sur son modèle métier.',
       },
       {
         titre: 'Référencement technique',
         texte:
-          'Le SEO traité comme une propriété du produit : stratégie de rendu Next.js par ' +
-          'type de page, Core Web Vitals, Lighthouse, accessibilité. Ce n’est pas une ' +
-          'prestation à part, c’est une conséquence des choix du pôle 1.',
+          'Le SEO traité comme une propriété du produit : stratégie de rendu, Core Web Vitals, ' +
+          'Lighthouse, accessibilité.',
         preuve: 'Lighthouse 98/100 sur la plateforme SaaS livrée.',
       },
     ],
@@ -175,22 +154,18 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'La boucle',
     titre: 'Ce que la mesure révèle repart en construction',
     chapo:
-      'Le dernier maillon renvoie au premier. Un arbitrage décidé le lundi est implémenté ' +
-      'dans la semaine, parce qu’il n’attend ni le devis d’une agence ni la disponibilité ' +
-      'd’un intégrateur. C’est là que l’interlocuteur unique cesse d’être un argument de ' +
-      'confort et devient un gain de délai mesurable.',
+      'Le dernier maillon renvoie au premier : un arbitrage décidé le lundi est implémenté ' +
+      'dans la semaine, sans devis d’agence.',
     blocs: [
       {
         titre: 'Aucun transfert de dossier',
-        texte:
-          'la personne qui a lu le chiffre est celle qui modifie le code — rien ne se perd ' +
-          'à la jointure.',
+        texte: 'la personne qui a lu le chiffre est celle qui modifie le code.',
       },
       {
-        titre: 'Retour au pôle 1',
+        titre: 'Retour à l’ingénierie web',
         texte:
-          'la modification suit le même cycle que le reste : test d’abord, non-régression, ' +
-          'mise en production sans coupure.',
+          'la modification suit le même cycle : test d’abord, non-régression, mise en ' +
+          'production sans coupure.',
       },
     ],
   },

--- a/src/@vitrine/views/HomeView/index.tsx
+++ b/src/@vitrine/views/HomeView/index.tsx
@@ -50,8 +50,7 @@ export function HomeView() {
             <p className={styles.kicker}>Vérifiable</p>
             <h2 id="preuves-titre">Ce qui est mesuré, pas ce qui est promis</h2>
             <p className={styles.chapo}>
-              Chaque chiffre porte son contexte : où, quand, et sur quel produit. Sans cela, un
-              chiffre n'est qu'une affirmation de plus.
+              Chaque chiffre porte son contexte : où, quand, et sur quel produit.
             </p>
             <ProofWall preuves={PREUVES} />
           </Reveal>
@@ -63,7 +62,7 @@ export function HomeView() {
             <h2 id="limites-titre">Ce que je ne fais pas</h2>
             <p className={styles.chapo}>
               Un prestataire qui sait tout faire ne sait rien faire. Voici ce que je laisse à
-              d'autres, et ce que je fais à la place — c'est le bloc qui rend le reste croyable.
+              d'autres, et ce que je fais à la place.
             </p>
             <BoundaryList limites={LIMITES} />
           </Reveal>
@@ -75,8 +74,6 @@ export function HomeView() {
             <h2 id="certifications-titre">Ce qui a été évalué par quelqu'un d'autre que moi</h2>
             <p className={styles.chapo}>
               Aucun justificatif n'est publié en ligne à ce jour : ils sont communiqués sur demande.
-              Un lien mort sur un site qui vend de la rigueur coûterait plus cher que l'absence de
-              lien.
             </p>
             <CertificationList certifications={CERTIFICATIONS} />
           </Reveal>
@@ -86,8 +83,8 @@ export function HomeView() {
           <Reveal className={styles.corpsContact}>
             <h2 id="contact-titre">Décrivez-moi votre situation</h2>
             <p className={styles.chapo}>
-              Vous écrivez à la personne qui fera le travail. Je vous dis ce que j'en ferais — et si
-              ce n'est pas pour moi, je vous le dis aussi.
+              Vous écrivez à la personne qui fera le travail. Si ce n'est pas pour moi, je vous le
+              dis aussi.
             </p>
             <MagneticAction className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
               {SITE_IDENTITY.email}

--- a/src/@vitrine/views/PolePageView/index.tsx
+++ b/src/@vitrine/views/PolePageView/index.tsx
@@ -57,8 +57,8 @@ export function PolePageView({ pole, page, suites }: PolePageViewProps) {
           >
             <h2 id="certifications-titre">Ce qui est certifié sur ce pôle</h2>
             <p className={styles.chapo}>
-              Une certification ne remplace pas une réalisation. Elle dit seulement que la méthode a
-              été évaluée par quelqu'un d'autre que moi.
+              Une certification ne remplace pas une réalisation : elle dit seulement que la méthode
+              a été évaluée par un tiers.
             </p>
             <CertificationList certifications={certifications} />
           </Reveal>


### PR DESCRIPTION
## Type

feature

## Description

Coupe éditoriale sur `src/@vitrine/contenu/` et sur la prose figée en JSX. **Aucun
changement de structure, de style ou de code de rendu : uniquement du texte.**

### Volume mesuré

Le chiffre de l'issue (6 304 mots) datait d'avant le lot topologique #66, qui a déplacé
et réécrit une partie du contenu. **Recompté sur `dev` avant de commencer**, sur les
mêmes champs éditoriaux (`titre`, `kicker`, `chapo`, `texte`, `preuve`, `decision`,
`promesse`, `accroche`, `matiere`, `siDejaEnPlace`, `alaPlace`, `hors`, `contexte`,
`description`), hors `contenu/blog/` :

| | Avant (`dev`) | Après | Δ |
|---|---:|---:|---:|
| `src/@vitrine/contenu/` | **7 132** | **4 809** | **−32,6 %** |
| dont `texte` | 2 966 | 1 361 | −54,1 % |
| dont `chapo` | 1 177 | 626 | −46,8 % |
| dont `alaPlace` / `accroche` / `matiere` / `siDejaEnPlace` | 648 | 461 | −28,9 % |
| `preuve` + `decision` + `contexte` | 1 311 | 1 336 | intacts (+25, voir plus bas) |
| Prose figée en JSX (`HomeView`, `PolePageView`, `SiteFooter`) | ~220 | ~150 | ≈ −32 % |

**La cible de −50 % n'est pas atteinte, et c'est un choix assumé plutôt qu'un
abandon — voir « Le point à trancher » en fin de description.**

### Règle de coupe appliquée

On garde le **titre**, la **preuve chiffrée** et la **décision**. Les paragraphes
`texte` tombent à une phrase, les `chapo` à deux. Aucun bloc éditorial n'est supprimé,
aucune `preuve` ni aucune `decision` n'est perdue ni réécrite.

### Affirmations reformulées dont le sens pouvait bouger

Toutes ont été vérifiées contre la table des règles de véracité du `CLAUDE.md`.

| # | Avant | Après | Pourquoi c'est sûr |
|---|---|---|---|
| 1 | « Vous parlez à la personne qui écrit le code. C'est la même du cadrage au run, sur les quatre pôles. Si la taille du projet demande un renfort — c'est rare — je choisis le prestataire, je le cadre et j'en réponds : votre interlocuteur, lui, ne change pas. » | « Vous parlez à la personne qui écrit le code, du cadrage au run, sur les quatre pôles. Si la taille du projet demande un renfort — c'est rare — je le choisis, je le cadre et j'en réponds : votre interlocuteur, lui, ne change pas. » | La clause de renfort et la mention de rareté sont conservées **mot pour mot**. Rien ne se rapproche d'une promesse d'absence de tiers. |
| 2 | Chapô renforts : « Cela arrive rarement, et quand cela arrive je préfère le dire plutôt que de tenir une promesse contre les faits. Sur un projet dont la taille le demande, … Ce qui ne change pas : vous ne gérez personne d'autre que moi. » | « Cela arrive rarement, et je préfère le dire. Sur un projet dont la taille le demande, je m'entoure de prestataires que je choisis, que je cadre et dont je réponds — vous ne gérez personne d'autre que moi. » | Les trois éléments contraints sont gardés : la **rareté**, la **condition** (taille du projet) et le fait que le client ne gère personne d'autre. |
| 3 | « La certification apporte un vocabulaire de recette commun et opposable : niveaux de test, critères d'entrée et surtout critères d'arrêt … C'est le seul niveau que je détiens, et c'est donc le seul que j'affiche. » | « Un vocabulaire de recette commun et opposable : critères d'entrée et d'arrêt écrits avant la livraison. C'est le seul niveau que je détiens, et c'est donc le seul que j'affiche. » | La phrase qui borne le niveau est **intacte**. Toutes les autres occurrences du site disent « ISTQB Foundation » en toutes lettres ; aucune ne dit « certifié ISTQB » seul. |
| 4 | « C'est le seul niveau que je détiens, c'est donc le seul qui est affiché. Ce qui est outillé l'est réellement : développement piloté par les tests, Jest… » (`limites.ts`) | « C'est le seul niveau que je détiens, c'est donc le seul affiché. Ce qui est outillé l'est réellement : tests d'abord, Jest… » | Idem, borne conservée. |
| 5 | « Encadrement d'équipes marketing et SEO/SEA de 5 à 10 personnes, de prestataires externes, d'alternants et de stagiaires. Côté technique, le titre est Lead Tech dans une équipe de deux développeurs et un product owner. » | **Inchangé, mot pour mot**, dans `ingenierie-web-sections.ts` et dans `limites.ts`. | Le périmètre d'encadrement est le point le plus exposé de la table : il n'a pas été touché. Aucune formulation du site ne dit « management d'équipes » sans qualificatif. |
| 6 | Bloc « Le relais, je l'ai déjà passé » : les chiffres (équipe marketing de 5 à 10 personnes, trois prestataires chez Truffle Capital, prestataires SEA/SEO/SMA chez Verhoeven Joaillier) vivaient **dans le paragraphe `texte`**. | Le paragraphe est ramené à une phrase et les chiffres sont **déplacés dans un champ `preuve`** du même bloc. | Un fait chiffré ne pouvait pas partir avec le paragraphe qui le portait. Ce bloc n'avait pas de `preuve` : il en a une maintenant, sans qu'aucun mot du fait ne change. (C'est l'origine du +25 sur la ligne `preuve` du tableau de volume.) |
| 7 | « Panier moyen en hausse de 50 % sur un e-commerce de joaillerie de luxe. » | **Inchangé**, avec son contexte. | Jamais raccourci en « +50 % de CA » ni « +50 % de conversion ». Toutes les `preuve` sont reprises telles quelles. |
| 8 | « Règles anti-fraude implémentées dans le produit : fraude en baisse, conversion des inscriptions en hausse. » | **Inchangé**. | Résultat directionnel : il reste directionnel, aucun chiffre n'a été inventé. |
| 9 | « Fine-tuning de Llama 3 sur corpus métier pour l'application mobile Prézage, complété d'un procédé maison d'augmentation du contexte proche du RAG. RAG documentaire … Aucun framework tiers — la chaîne est écrite, donc lisible et corrigeable. » | « Fine-tuning de Llama 3 pour l'application mobile Prézage, RAG documentaire fait maison, aucun framework tiers. » | « fait maison » et « aucun framework tiers » sont conservés. Prézage et Llama 3 restent nommés (autorisé) ; rien du corpus ni des chiffres du projet n'apparaît. |
| 10 | « Pas de cluster Kubernetes administré en propre : c'est écrit ici parce que vous méritez de le savoir avant de signer. » | « Pas de cluster Kubernetes administré en propre. » | L'aveu subsiste ; seul le commentaire de posture disparaît. Idem dans `ia-sections.ts`. |
| 11 | « Firebase Analytics et Crashlytics, et rien d'autre — je ne cite pas d'outil que je n'ai pas exploité. » | « Firebase Analytics et Crashlytics, et rien d'autre. » | L'exclusivité mobile est conservée ; c'est la justification qui tombe, pas la borne. |
| 12 | « Google Ads et Bing Ads, en SEO, SEA et SMA. Ce que je pilote, je l'ai déjà piloté — je ne me forme pas à un canal sur votre budget. » | « Google Ads et Bing Ads, en SEO, SEA et SMA. Ce que je pilote, je l'ai déjà piloté. » | Les deux régies restent nommément les deux seules. Aucune régie n'est ajoutée. |
| 13 | « La méthode d'extraction des caractéristiques du signal audio est publiée sur arXiv ; je l'ai implémentée moi-même, adaptée aux données réelles, validée, puis industrialisée. » | « … publiée sur arXiv ; je l'ai implémentée moi-même, puis industrialisée. » | « publiée sur arXiv » et « implémentée moi-même » sont conservés : aucune collaboration institutionnelle n'est suggérée. |
| 14 | « Ce n'est pas une prestation à part, c'est une conséquence des choix du **pôle 1**. » et titre « Retour au **pôle 1** » | « … une conséquence des choix de **l'ingénierie web**. » et « Retour à **l'ingénierie web** » | Correction d'un reste de numérotation d'avant le modèle à quatre pôles. Aucun changement de fond. |

### Narration du modèle : ce qui a été protégé

Ces phrases sont des arguments de vente, pas du remplissage. Elles ont été raccourcies
sans perdre leur force, jamais supprimées :

- « **Vous pouvez vous arrêter là** » après la phase data — conservée dans `accueil-data.ts`, `data-sections.ts` et `poles-nav.ts`.
- « **Si votre produit tourne déjà, on part de lui** » / « **Si votre stratégie data tient déjà, on la reprend telle quelle** » / « **Si la mesure est fiable, on arbitre dessus dès le premier jour** » — les trois `siDejaEnPlace` de `jointures.ts` sont conservés, avec la phrase qui refuse le préalable facturé.
- « **Les deux suites se prennent séparément ou ensemble** » et « **L'une, l'autre, ou les deux** » — l'inclusivité de l'embranchement est intacte sur l'accueil et dans les jointures.
- « **Le pôle data se livre pour lui-même — il ne se rachète pas pour accéder à l'IA.** »
- « **C'est le run qui fait naître le besoin de data et d'IA, pas l'inverse.** »

### Ce qui mérite d'être repris dans `/realisations/`

Le détail coupé n'est pas perdu ; il attend son espace. À reprendre là-bas :

- Le **récit des trois migrations** : PHP 5 → 7 puis réécriture Node.js et jQuery → React chez le joaillier dont le site marchand ne pouvait pas s'arrêter ; Ionic 6 → 8 et Angular 15 → 19 sur Prézage.
- La **plateforme « Sms En Masse »** : remplacement d'une solution tierce exploitée en marque blanche, et ce que ça a changé.
- L'**AMOA Artedrone** dans le détail : BPMN 2.0, cartographie du SI, spécifications écrites pour des prestataires non spécialistes.
- L'**intégration ERP M3 Soft** et la synchronisation boutique / e-commerce (survente évitée sur des pièces uniques).
- Le **modèle supervisé d'anticipation des échecs de dépôt vocal** : ce qu'il évite concrètement.
- Le **procédé maison d'augmentation de contexte** proche du RAG sur Prézage.
- Le **système d'analyse multi-sources** : réconciliation d'identités, contrôles d'intégrité, détection d'anomalies avant contamination des tableaux de bord.
- Les **arguments de méthode** qui justifiaient les listes d'outils : pourquoi les tests de mutation, pourquoi le plan de taggage opposable, pourquoi le server-side.

### Le point à trancher (@Jerome-Marichez)

**La cible de −50 % et le critère « aucun bloc ne perd sa `preuve` ni sa `decision` »
ne sont pas simultanément atteignables sans un changement de modèle de contenu.**

L'arithmétique est nette. Après coupe, il reste 4 809 mots, dont **2 674 dans des champs
que l'issue protège** (`titre` 582, `preuve` 623, `decision` 554, `contexte` 159,
`kicker` 81, `libelle` 45, `hors` 51, `description` 116, `title` 41, `chiffre` 13). Le
reste — 2 135 mots de `texte`, `chapo`, `alaPlace`, `accroche`, `matiere`,
`siDejaEnPlace` — devrait tomber à 892 pour atteindre 3 566. Les `chapo` sont déjà à deux
phrases et les `texte` à une ; en dessous, ce ne sont plus des phrases mais des
fragments, et c'est là que le risque d'élargir une affirmation devient réel.

Il se trouve que `texte` pèse aujourd'hui **1 361 mots**, soit presque exactement l'écart
qui reste (1 243). Autrement dit, la cible de l'issue correspond à ce que l'issue écrit
elle-même : « les paragraphes `texte` … **disparaissent** ». Sur un bloc qui porte déjà
un titre, une preuve chiffrée et une décision, le paragraphe est le seul des quatre
éléments qui n'apporte rien à un dirigeant pressé.

Ce n'est pas fait ici, pour deux raisons : `IEditorialBlock.texte` est un champ
**obligatoire** (le rendre optionnel touche l'interface et les trois composants qui le
rendent — `ExpertiseBlock`, `HingeSection`, `ThreadSection`), et l'issue précise
« aucun changement de structure ». **C'est une décision de modèle de contenu, pas un
arbitrage de rédaction : elle vous revient.**

Si la réponse est oui, l'implémentation est petite et je propose le test suivant, à
poser par vous :

> **Intention du test** — niveau **unitaire**, `tests/unitaire/contenu-editorial.spec.ts`.
> Jeu de données : les tableaux réels de `src/@vitrine/contenu/` (pas de fixture — le
> contenu publié *est* la donnée sous test).
> 1. **Un bloc sans `texte` reste rendu sans `<p>` vide.** Rendre un `IEditorialBlock`
>    dont `texte` est absent via `ExpertiseBlock`, `HingeSection` et `ThreadSection` :
>    le titre, la preuve et la décision sont présents, et le document ne contient aucun
>    paragraphe vide. Cas limite : `texte: ''` doit être traité comme absent.
> 2. **Un bloc sans `texte` porte au moins une `preuve` ou une `decision`.** Parcourir
>    tous les blocs de toutes les sections publiées : un bloc dépourvu des trois champs
>    à la fois est une erreur — c'est ce qui empêche la coupe de vider une page.
> 3. **Verrou de véracité sur le contenu publié** (utile indépendamment de la décision
>    ci-dessus) : concaténer tous les champs textuels de `src/@vitrine/contenu/` et
>    vérifier qu'aucune formulation interdite n'y apparaît — `/aucune sous-traitance/i`,
>    `/0 sous-traitant/i`, `/istqb/i` non suivi de `Foundation`, `/kubernetes/i` non
>    précédé d'une négation, `LangChain`, `LlamaIndex`, `AppsFlyer`, `Adjust`,
>    `Amplitude`, `Tealium`, `Adobe (Launch|Analytics)`, `Meta Ads`, `LinkedIn Ads`,
>    `GraphQL`, `NestJS`, `Prisma`, `Cucumber`, `Gherkin`, `PyTorch`, et
>    `/management (d'|de )?(l')?équipes? (de )?dév/i`. Cas limite : le test doit lire les
>    valeurs, pas les commentaires — la table du `CLAUDE.md` est recopiée en en-tête de
>    plusieurs fichiers et déclencherait un faux positif.

Je n'ai pas posé ce fichier : le test précède le code, et c'est vous qui l'écrivez.

## Critères d'acceptation

- [x] La coupe porte sur `texte` et `chapo` ; aucun bloc ne perd sa `preuve` ni sa `decision`.
- [x] La prose figée en JSX est resserrée dans la même proportion.
- [x] Aucune reformulation n'élargit une affirmation ; les affirmations sensibles sont listées ci-dessus.
- [x] Aucun fait, chiffre ou preuve inventé ou extrapolé.
- [x] `make lint`, `make type-check`, `make test` et `make build` sont verts.
- [ ] **Volume réduit d'au moins la moitié** — atteint à −32,6 %. Voir « Le point à trancher ».

## Impacts

`src/@vitrine/contenu/` : `accueil.ts`, `accueil-sections.ts`, `accueil-data.ts`,
`fil-ia.ts`, `renforts.ts`, `limites.ts`, `jointures.ts`, `poles-nav.ts`,
`data-sections.ts`, `ia-sections.ts`, `ingenierie-web-sections.ts`, `sea-ux-sections.ts`.
`src/@vitrine/views/HomeView/index.tsx`, `src/@vitrine/views/PolePageView/index.tsx`,
`src/@shared/components/SiteFooter/index.tsx`.

Aucun composant, aucun style, aucune interface modifiés.

Refs #45

https://claude.ai/code/session_01Vz8szo5e81R85kUGnwNftH
