### PR TITLE
feature: rendre le paragraphe des blocs editoriaux optionnel

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -29,6 +29,45 @@ TypeScript dans `src/@vitrine/contenu/`, et sa forme est tenue par des interface
 | `IBlogIndex` | `src/interfaces/IBlogIndex.ts` | L'en-tête éditoriale de `/blog` | — |
 | `IBreadcrumbItem` | `src/interfaces/IBreadcrumbItem.ts` | Un niveau de fil d'Ariane | lu par le rendu **et** par le JSON-LD |
 
+## Le bloc éditorial (`IEditorialBlock`)
+
+C'est l'unité la plus fine du site : un point d'expertise à l'intérieur d'une section.
+
+| Champ | Type | Obligatoire | Rôle |
+|-------|------|-------------|------|
+| `titre` | `string` | oui | Intitulé court du point d'expertise |
+| `texte` | `string` | **non** | Corps du bloc, une à trois phrases |
+| `preuve` | `string` | non | Preuve chiffrée réelle (montant, pourcentage, durée, contrainte tenue) |
+| `decision` | `string` | non | Ce que le client peut trancher grâce à ce point |
+
+### Pourquoi `texte` est optionnel
+
+Trois champs sur quatre sont facultatifs, mais pas pour la même raison. `preuve` et
+`decision` le sont parce que le type ne peut pas garantir qu'une preuve existe : leur
+absence est un **signal de relecture**, pas un état souhaitable.
+
+`texte` l'est pour la raison inverse. Quand un bloc porte déjà un titre, une preuve
+chiffrée et une décision, le paragraphe redit en prose ce que les trois autres
+établissent — et c'est le seul des quatre qui n'apporte rien à un dirigeant pressé
+(issue #45). Dans ce cas précis, il s'omet.
+
+### Contraintes d'intégrité
+
+Aucune n'est vérifiée à l'exécution : elles sont tenues par la relecture.
+
+- **Un bloc dépourvu de `preuve` et de `decision` garde son `texte`.** Sans lui, il ne
+  reste qu'un titre orphelin. Les repères des charnières sont exactement ce cas.
+- **Un `texte` supprimé ne transfère jamais sa charge.** Si le paragraphe portait un fait
+  qui n'existe nulle part ailleurs, ce fait se **déplace** dans `preuve` ou `decision` ; il
+  ne se jette pas, et le champ d'accueil ne s'élargit pas pour l'absorber.
+- **Les bornes de véracité restent dans le paragraphe qui les porte.** « ISTQB Foundation
+  est le seul niveau que je détiens », « pas de cluster Kubernetes administré en propre »,
+  « RAG fait maison, aucun framework tiers », « pas d'autre outillage mobile revendiqué » :
+  ces phrases sont la raison d'être de leur bloc, jamais du remplissage.
+- **Les trois composants de rendu ne produisent pas de paragraphe vide.**
+  `ExpertiseBlock`, `HingeSection` et `ThreadSection` conditionnent l'élément à la
+  présence de la valeur.
+
 ## L'article (`IArticle`)
 
 C'est la seule entité **datée** du site, et c'est ce qui la distingue du reste du

--- a/src/@vitrine/components/ExpertiseBlock/index.tsx
+++ b/src/@vitrine/components/ExpertiseBlock/index.tsx
@@ -23,7 +23,7 @@ export function ExpertiseBlock({ bloc, headingLevel = 'h3' }: ExpertiseBlockProp
   return (
     <article className={styles.bloc}>
       <Heading className={styles.titre}>{bloc.titre}</Heading>
-      <p className={styles.texte}>{bloc.texte}</p>
+      {bloc.texte ? <p className={styles.texte}>{bloc.texte}</p> : null}
 
       {bloc.preuve ? (
         <p className={styles.preuve}>

--- a/src/@vitrine/components/HingeSection/index.tsx
+++ b/src/@vitrine/components/HingeSection/index.tsx
@@ -42,7 +42,7 @@ export function HingeSection({ section }: HingeSectionProps) {
           {section.blocs.map((bloc) => (
             <li className={styles.repere} key={bloc.titre}>
               <span className={styles.repereTitre}>{bloc.titre}</span>
-              <span className={styles.repereTexte}>{bloc.texte}</span>
+              {bloc.texte ? <span className={styles.repereTexte}>{bloc.texte}</span> : null}
             </li>
           ))}
         </ul>

--- a/src/@vitrine/components/ThreadSection/index.tsx
+++ b/src/@vitrine/components/ThreadSection/index.tsx
@@ -41,7 +41,7 @@ export function ThreadSection({ section }: ThreadSectionProps) {
               {String(index + 1).padStart(2, '0')}
             </span>
             <h3 className={styles.etapeTitre}>{bloc.titre}</h3>
-            <p className={styles.etapeTexte}>{bloc.texte}</p>
+            {bloc.texte ? <p className={styles.etapeTexte}>{bloc.texte}</p> : null}
             {bloc.preuve ? <p className={styles.preuve}>{bloc.preuve}</p> : null}
             {bloc.decision ? (
               <p className={styles.decision}>

--- a/src/@vitrine/contenu/accueil-data.ts
+++ b/src/@vitrine/contenu/accueil-data.ts
@@ -28,14 +28,12 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
   kicker: 'Le passage · Comprendre',
   titre: 'Comprendre votre métier, puis choisir la solution',
   chapo:
-    'Je ne commence pas par un modèle, mais par ce que votre activité sait déjà sans l’avoir ' +
-    'écrit. La réponse n’est pas toujours de l’IA.',
+    'Je commence par ce que votre activité sait déjà sans l’avoir écrit. La réponse n’est pas ' +
+    'toujours de l’IA.',
   blocs: [
     {
       titre: 'Découvrir ce que votre métier sait déjà',
-      texte:
-        'Insights métier, profils de clients par clustering (KNN), règles formalisées. Vous ' +
-        'pouvez vous arrêter là.',
+      texte: 'C’est une prestation à part entière : vous pouvez vous arrêter là.',
       preuve:
         'AMOA de la startup biotech Artedrone : besoin recueilli auprès des équipes ' +
         'scientifiques et dirigeantes, traduit en spécifications exploitables par des ' +
@@ -46,9 +44,6 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
     },
     {
       titre: 'La stratégie data : la déployer ou s’appuyer sur l’existante',
-      texte:
-        'Décider quoi mesurer quand rien n’existe ; reprendre et réconcilier quand la donnée ' +
-        'est là.',
       preuve:
         'Système d’analyse multi-sources conforme RGPD mesurant la rentabilité client à ' +
         'long terme, branché sur Google Ads et Bing Ads.',
@@ -56,7 +51,6 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
     },
     {
       titre: 'Gouvernance et droit, avant la technique',
-      texte: 'Qui possède quoi, ce qui a le droit d’être traité, ce qui doit rester chez vous.',
       preuve:
         'Conformité RGPD et DORA tenue en appels d’offres grands comptes — distribution, ' +
         'assurance, banque.',
@@ -64,9 +58,6 @@ export const SECTION_ACCUEIL_DATA: IEditorialSection = {
     },
     {
       titre: 'La solution répond au problème posé au départ',
-      texte:
-        'Souvent une règle métier intégrée à l’existant suffit ; sinon un modèle, ou un LLM si ' +
-        'le problème est du langage.',
       preuve:
         'Règles anti-fraude implémentées dans le produit : fraude en baisse, conversion ' +
         'des inscriptions en hausse. Modèle supervisé anticipant les échecs de dépôt ' +

--- a/src/@vitrine/contenu/accueil-sections.ts
+++ b/src/@vitrine/contenu/accueil-sections.ts
@@ -25,36 +25,26 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kicker: 'Le socle · Construire',
     titre: 'Site internet, produit SaaS, application mobile',
     chapo:
-      "Concevoir, développer, mettre en production, puis rester pour l'exploiter. Front, back, " +
-      'donnée, qualité et run tenus par la même personne.',
+      "Concevoir, développer, mettre en production, puis rester pour l'exploiter — la même " +
+      'personne à chaque poste.',
     blocs: [
       {
         titre: 'Front et stratégie de rendu',
-        texte: 'React et Next.js côté web, Angular et Ionic pour le mobile iOS et Android.',
         preuve:
           'Lighthouse 98/100 sur la plateforme SaaS « Sms En Masse », conformité RGAA / WCAG.',
         decision: 'Quelle page se rend au build, laquelle à la requête, et ce que chacune coûte.',
       },
       {
         titre: 'Back, données et architecture',
-        texte:
-          'Node.js, API REST, cloud functions et Pub/Sub ; PostgreSQL, MySQL, Firebase, ' +
-          'entrées validées par Zod.',
         decision: "Ce qu'on découpe maintenant, ce qu'on garde monolithique, et jusqu'à quand.",
       },
       {
         titre: 'Qualité certifiée et outillée',
-        texte:
-          'Développement piloté par les tests, en IA augmentée : Claude Code et Gemini, le ' +
-          'test faisant foi.',
         preuve: 'Certification ISTQB Foundation. Non-régression rejouée à chaque livraison.',
         decision: 'Quel niveau de test vous vous autorisez à ne pas payer, et sur quoi.',
       },
       {
         titre: 'Migrations sans coupure',
-        texte:
-          "Sortir d'un socle en fin de vie sans arrêter le service ni geler la feuille de " +
-          'route.',
         preuve:
           'Trois migrations majeures, aucune interruption de service, chiffre d’affaires maintenu.',
         decision: "Ce qu'on migre ce trimestre, ce qu'on gèle, et le coût réel de l'attente.",
@@ -69,8 +59,8 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kicker: 'Charnière · vers la donnée',
     titre: 'On ne livre pas, on exploite',
     chapo:
-      "La mise en production n'est pas la fin du projet : c'est le run qui fait naître le " +
-      "besoin de data et d'IA.",
+      "La mise en production n'est pas la fin : c'est le run qui fait naître le besoin de data " +
+      "et d'IA.",
     blocs: [
       {
         titre: 'SLI / SLO / SLA',
@@ -103,9 +93,7 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     kind: 'charniere',
     kicker: 'Charnière · vers l’arbitrage',
     titre: 'Sans donnée claire, le budget brûle',
-    chapo:
-      'La donnée mise au propre devient la matière des arbitrages. Sans elle, le SEA achète du ' +
-      "volume et l'UX devient une affaire de goût.",
+    chapo: "Sans donnée mise au propre, le SEA achète du volume et l'UX reste une affaire de goût.",
     blocs: [
       {
         titre: 'LTV plutôt que coût par clic',
@@ -119,8 +107,8 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       {
         titre: 'La preuve que le lien existe',
         texte:
-          'le système d’analyse multi-sources mesure la rentabilité client dans la durée. ' +
-          'C’est sur ce chiffre-là que les budgets sont arbitrés.',
+          'le système d’analyse multi-sources mesure la rentabilité client dans la durée, et ' +
+          'les budgets s’arbitrent dessus.',
       },
     ],
   },
@@ -136,30 +124,20 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
     blocs: [
       {
         titre: 'La mesure est construite dans le code',
-        texte:
-          'GTM en conteneur web et server-side, plan de taggage opposable ; Firebase Analytics ' +
-          'et Crashlytics côté mobile.',
         decision: 'Quels événements existent, ce qu’ils portent, et qui répond de leur exactitude.',
       },
       {
         titre: 'Conformité par construction',
-        texte: 'RGPD, CMP et déclenchement conditionnel des tags par catégorie de consentement.',
         decision:
           'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
       },
       {
         titre: 'Arbitrages de parcours, pris sur la mesure',
-        texte:
-          'A/B testing des pages, heatmaps, taux de rebond : une étape disparaît parce que les ' +
-          'chiffres le disent.',
         preuve: 'Panier moyen en hausse de 50 % sur un e-commerce de joaillerie de luxe.',
         decision: 'Quelle étape du tunnel disparaît, et ce que vous gagnez à la supprimer.',
       },
       {
         titre: 'Pilotage de l’acquisition',
-        texte:
-          'Google Ads, Bing Ads, SEO, SEA et SMA ; référencement technique traité comme une ' +
-          'propriété du produit.',
         preuve:
           '100 000 € de budget ADS / SEO pilotés chez Truffle Capital, environ 25 000 € ' +
           'd’encadrement de prestataires SEA chez Verhoeven Joaillier.',
@@ -181,24 +159,18 @@ export const SECTIONS_ACCUEIL: IEditorialSection[] = [
       {
         titre: 'Le produit n’est pas dans ma tête',
         texte:
-          'Tests écrits avant le code, non-régression, CI/CD et mutation à chaque livraison. ' +
-          'Une base couverte se reprend.',
+          'Tests écrits avant le code, non-régression, CI/CD et mutation à chaque livraison : ' +
+          'une base couverte se reprend.',
         preuve:
           'Jest, Cypress, Playwright, mutation Stryker, Postman. Certification ISTQB Foundation.',
       },
       {
         titre: 'Les spécifications sont écrites pour quelqu’un d’autre que moi',
-        texte:
-          'Traduire un besoin en spécifications exploitables par des tiers extérieurs au ' +
-          'domaine : c’est le métier que j’exerçais avant.',
         preuve:
           'AMOA de la startup biotech Artedrone. Serveurs MCP et plugins n8n, Make et Zapier documentés.',
       },
       {
         titre: 'Le relais, je l’ai déjà passé',
-        texte:
-          'Encadrer des prestataires externes, c’est exactement l’exercice : leur donner ' +
-          'de quoi travailler sans moi.',
         preuve:
           'Une équipe marketing de 5 à 10 personnes et trois prestataires coordonnés chez ' +
           'Truffle Capital ; prestataires SEA, SEO et SMA encadrés chez Verhoeven Joaillier.',

--- a/src/@vitrine/contenu/accueil.ts
+++ b/src/@vitrine/contenu/accueil.ts
@@ -46,11 +46,10 @@ export const THESE_CHAINE = {
   titre: 'Quatre pôles, une seule chaîne',
   chapo:
     'Pas quatre offres au catalogue : ce qui est construit tourne, ce qui tourne produit de la ' +
-    'donnée — et cette donnée ouvre l’IA et l’arbitrage des budgets et des parcours. L’une, ' +
-    'l’autre, ou les deux.',
+    'donnée — et cette donnée ouvre l’IA et l’arbitrage. L’une, l’autre, ou les deux.',
   appui:
-    'La chaîne ne tient que parce que c’est la même personne à chaque poste. Découpée entre ' +
-    'prestataires, elle casse à chaque jointure.',
+    'La chaîne ne tient que parce que c’est la même personne à chaque poste : découpée, elle ' +
+    'casse à chaque jointure.',
 } as const
 
 export const PAGE_ACCUEIL: IEditorialPage = {

--- a/src/@vitrine/contenu/data-sections.ts
+++ b/src/@vitrine/contenu/data-sections.ts
@@ -25,14 +25,11 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     kicker: 'Le point de départ',
     titre: 'Je commence par votre métier, pas par votre donnée',
     chapo:
-      'Une activité qui tourne sait déjà beaucoup de choses, rarement écrites. Le mettre noir ' +
-      'sur blanc est une prestation à part entière.',
+      'Une activité qui tourne sait déjà beaucoup de choses, rarement écrites. Les mettre noir ' +
+      'sur blanc se livre pour soi.',
     blocs: [
       {
         titre: 'Faire émerger les règles qui existent déjà',
-        texte:
-          'Je recueille les règles de décision auprès de ceux qui les appliquent, puis je les ' +
-          'confronte à votre historique.',
         preuve:
           'AMOA de la startup biotech Artedrone : besoin recueilli auprès des équipes ' +
           'scientifiques et dirigeantes, traduit en spécifications exploitables par des ' +
@@ -62,9 +59,7 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       },
       {
         titre: 'Cette phase se livre pour elle-même',
-        texte:
-          'Un document : règles formalisées, profils identifiés, ce que votre donnée dit de ' +
-          'votre activité. Vous pouvez vous arrêter là.',
+        texte: 'Un document : règles formalisées, profils identifiés. Vous pouvez vous arrêter là.',
         decision: 'S’il y a un problème qui mérite d’être traité par la technique — et lequel.',
       },
     ],
@@ -76,21 +71,15 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     kicker: 'La stratégie data',
     titre: 'Construire la stratégie data, ou s’appuyer sur celle qui existe',
     chapo:
-      'Soit il faut décider quoi mesurer, soit la donnée existe et il s’agit d’en tirer ' +
-      'quelque chose sans tout refaire.',
+      'Soit il faut décider quoi mesurer, soit la donnée existe et il faut en tirer quelque ' +
+      'chose sans tout refaire.',
     blocs: [
       {
         titre: 'Quand rien n’est en place',
-        texte:
-          'Indicateurs, plan de collecte, pipelines d’ingestion, modélisation : PostgreSQL ' +
-          'relationnel, séries temporelles ou vectoriel, MySQL, Firebase.',
         decision: 'Ce que vous commencez à mesurer maintenant, et ce qui peut attendre six mois.',
       },
       {
         titre: 'Quand la donnée existe déjà',
-        texte:
-          'Réconciliation multi-sources et dédoublonnage selon votre modèle métier, écarts ' +
-          'corrigés dès l’ingestion.',
         preuve:
           'Système d’analyse multi-sources conforme RGPD mesurant la rentabilité client à ' +
           'long terme, branché sur Google Ads et Bing Ads.',
@@ -112,19 +101,14 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     kicker: 'Gouvernance et droit',
     titre: 'Qui possède quoi, et ce qui a le droit d’être traité',
     chapo:
-      'Elle se pose avant la moindre ligne de code : sa réponse écarte des solutions entières, ' +
-      'et y répondre après coup coûte le double.',
+      'Elle se pose avant la moindre ligne de code : sa réponse écarte des solutions entières.',
     blocs: [
       {
         titre: 'Qui possède la donnée',
-        texte:
-          'Cartographie des sources et de leur propriété : à vous, à vos clients, ou à une ' +
-          'régie.',
         decision: 'Quelle donnée reste chez vous, et ce que vous acceptez d’envoyer à un tiers.',
       },
       {
         titre: 'Ce qui a le droit d’être collecté et traité',
-        texte: 'RGPD, base légale, consentement géré par une CMP, cadrage avec le juridique.',
         preuve:
           'Conformité RGPD et DORA tenue en appels d’offres grands comptes — distribution, ' +
           'assurance, banque. Cadrage RGPD des données clients chez un e-commerçant de ' +
@@ -135,8 +119,8 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'La contrainte oriente la solution',
         texte:
-          'Si une donnée ne peut pas quitter votre système, le service tiers est écarté : ' +
-          'reste un modèle open-weight hébergé — Llama 3 — ou une règle explicite.',
+          'Donnée qui ne peut pas sortir de chez vous : le service tiers est écarté, reste un ' +
+          'modèle open-weight hébergé — Llama 3 — ou une règle explicite.',
       },
     ],
   },
@@ -155,7 +139,7 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     titre: 'Un métier compris devient un budget arbitrable',
     chapo:
       'Règles écrites, profils identifiés, donnée gouvernée : on tient la matière des ' +
-      'arbitrages. Sans elle, le SEA achète du volume.',
+      'arbitrages.',
     blocs: [
       {
         titre: 'Rentabilité à long terme',

--- a/src/@vitrine/contenu/fil-ia.ts
+++ b/src/@vitrine/contenu/fil-ia.ts
@@ -20,20 +20,14 @@ export const SECTION_FIL_IA: IEditorialSection = {
   titre: 'Je conçois, je développe et je pilote avec l’IA',
   chapo:
     'L’IA est ce que je livre au pôle IA, et la façon dont je travaille sur tous. Ici, la ' +
-    'seconde : l’IA propose, les tests tranchent.',
+    'seconde : elle propose, les tests tranchent.',
   blocs: [
     {
       titre: 'Concevoir — instruire les options, pas les recevoir',
-      texte:
-        'L’IA instruit : plusieurs scénarios, leurs coûts, leurs angles morts. La décision ' +
-        'reste la mienne et s’écrit noir sur blanc.',
       decision: 'Le scénario d’architecture retenu, ceux qui ont été écartés, et sur quel critère.',
     },
     {
       titre: 'Construire — Claude Code et Gemini, pilotés par les tests',
-      texte:
-        'Agents, hooks, skills et serveurs MCP internes, le test écrit avant et rejoué après ' +
-        'la génération.',
       preuve:
         'Jest, Cypress, Playwright, mutation Stryker. Certification ISTQB Foundation. Ce ' +
         'site est construit ainsi, de bout en bout.',
@@ -50,7 +44,6 @@ export const SECTION_FIL_IA: IEditorialSection = {
     },
     {
       titre: 'Piloter — le SEA et l’UX décidés sur ce que la donnée dit',
-      texte: 'La même donnée sert à trancher, puis la même personne implémente l’arbitrage.',
       preuve:
         'Panier moyen en hausse de 50 % sur un e-commerce de joaillerie, 100 000 € de budget ' +
         'ADS / SEO pilotés.',

--- a/src/@vitrine/contenu/ia-sections.ts
+++ b/src/@vitrine/contenu/ia-sections.ts
@@ -27,14 +27,11 @@ export const SECTIONS_IA: IEditorialSection[] = [
     kicker: 'La réponse technique',
     titre: 'La solution répond au problème — et ce n’est pas toujours de l’IA',
     chapo:
-      'La technique n’arrive qu’ici, arbitrée contre le problème métier, la donnée disponible ' +
-      'et ce que le droit autorise. Pas contre l’état de l’art.',
+      'La technique n’arrive qu’ici, arbitrée contre le problème métier et ce que le droit ' +
+      'autorise. Pas contre l’état de l’art.',
     blocs: [
       {
         titre: 'Souvent, une règle métier suffit',
-        texte:
-          'Moins chère, plus facile à expliquer à un régulateur, plus simple à corriger qu’un ' +
-          'modèle. Quand elle suffit, je le dis.',
         preuve:
           'Règles anti-fraude définies puis implémentées dans le produit par la même ' +
           'personne : fraude en baisse, conversion des inscriptions en hausse, latence ' +
@@ -47,19 +44,16 @@ export const SECTIONS_IA: IEditorialSection[] = [
       {
         titre: 'Un modèle, quand la règle ne tient plus',
         texte:
-          'Apprentissage supervisé ou non supervisé, selon ce que la donnée permet. La méthode ' +
-          'd’extraction des caractéristiques du signal audio est publiée sur arXiv ; je l’ai ' +
-          'implémentée moi-même, puis industrialisée. TensorFlow, inférence en cloud ' +
+          'La méthode d’extraction des caractéristiques du signal audio est publiée sur arXiv ' +
+          '; je l’ai implémentée moi-même, puis industrialisée. TensorFlow, inférence en cloud ' +
           'functions.',
         preuve: 'Routes vocales coûteuses évitées.',
       },
       {
         titre: 'Un LLM, quand le problème est du langage',
         texte:
-          'Claude sur Vertex AI et par l’API Anthropic, OpenAI, Gemini, Llama, arbitrés sur le ' +
-          'coût d’inférence, la latence, la qualité et la confidentialité. Fine-tuning de ' +
-          'Llama 3 pour l’application mobile Prézage, RAG documentaire fait maison, aucun ' +
-          'framework tiers.',
+          'Claude sur Vertex AI, OpenAI, Gemini, Llama. Fine-tuning de Llama 3 pour ' +
+          'l’application mobile Prézage, RAG documentaire fait maison, aucun framework tiers.',
         preuve: 'Charge de travail des prestataires réduite.',
         decision: 'Modèle hébergé ou service tiers, et ce que chacun vous coûte par mois.',
       },
@@ -72,15 +66,14 @@ export const SECTIONS_IA: IEditorialSection[] = [
     kicker: 'Et ensuite',
     titre: 'Ce qui est livré tourne, et reste explicable',
     chapo:
-      'Une solution qui ne survit pas à six mois d’exploitation a déplacé le problème. ' +
-      'Déploiement, surveillance et conformité sont dans le même lot.',
+      'Une solution qui ne survit pas à six mois d’exploitation a déplacé le problème, pas ' +
+      'résolu.',
     blocs: [
       {
         titre: 'Déploiement et surveillance',
         texte:
-          'Versioning et monitoring des modèles, CI/CD Docker et GitHub Actions, Vertex AI, ' +
-          'Pub/Sub, Cloud Run, VM auto-scalées. Pas de cluster Kubernetes administré en ' +
-          'propre.',
+          'Versioning et monitoring des modèles, Vertex AI, Pub/Sub, Cloud Run, VM ' +
+          'auto-scalées. Pas de cluster Kubernetes administré en propre.',
       },
       {
         titre: 'Rendre votre produit appelable',

--- a/src/@vitrine/contenu/ingenierie-web-sections.ts
+++ b/src/@vitrine/contenu/ingenierie-web-sections.ts
@@ -15,14 +15,11 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'Ce que je construis',
     titre: 'Trois natures de produit, une seule façon de les tenir',
     chapo:
-      "Un site, un produit SaaS et une application mobile n'ont ni le même cycle de vie, ni " +
-      'les mêmes contraintes. Je les ai menés tous les trois, de la conception au run.',
+      'Trois natures de produit, trois jeux de contraintes. Je les ai menés tous les trois, de ' +
+      'la conception au run.',
     blocs: [
       {
         titre: 'Site internet',
-        texte:
-          'Vitrine, e-commerce ou site institutionnel : référencement et performance se ' +
-          'décident au moment de choisir la stratégie de rendu.',
         preuve:
           'Sites du fonds Truffle Capital et de ses participations (truffle.com, ' +
           'truffle100.fr, artedrone.fr), de la conception à l’exploitation.',
@@ -30,9 +27,6 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
       },
       {
         titre: 'Produit SaaS',
-        texte:
-          'Montée en charge, disponibilité contractuelle, conformité exigée en appel d’offres. ' +
-          'Plateforme BtoB « Sms En Masse » conçue et réalisée de bout en bout.',
         preuve: 'Conformité RGPD et DORA tenue en appels d’offres distribution, assurance, banque.',
         decision: 'Ce que vous internalisez, et ce que vous continuez de louer à un tiers.',
       },
@@ -54,14 +48,11 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'Avant la première ligne',
     titre: 'Le cadrage, tenu par celui qui devra le coder',
     chapo:
-      'Neuf ans dont deux en double casquette technique et pilotage. Je traduis le besoin en ' +
-      'spécifications en sachant ce que chaque ligne coûtera.',
+      'Neuf ans dont deux en double casquette technique et pilotage : je chiffre ce que chaque ' +
+      'ligne de spécification coûtera.',
     blocs: [
       {
         titre: 'Recueil du besoin et spécifications',
-        texte:
-          'Modélisation des flux en BPMN 2.0, cartographie du système d’information, ' +
-          'matrice de risques, recette et tests d’acceptation.',
         preuve:
           'AMOA de la startup biotech Artedrone ; intégration de l’ERP M3 Soft et ' +
           'synchronisation boutique physique / e-commerce, survente évitée sur des pièces uniques.',
@@ -69,9 +60,6 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
       },
       {
         titre: 'Interfaces et parcours',
-        texte:
-          'Maquettage, catalogue de composants sous Storybook, accessibilité RGAA, WCAG et W3C ' +
-          'traitée pendant la conception.',
         preuve: 'Panier moyen en hausse de 50 % après refonte des tunnels d’achat.',
       },
       {
@@ -90,14 +78,11 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'La construction',
     titre: 'Front, back, architecture et exploitation',
     chapo:
-      'La même personne décide de la stratégie de rendu, du modèle de données et du ' +
-      'déploiement : les trois conséquences sont connues en même temps.',
+      'Rendu, modèle de données et déploiement décidés par la même personne : les trois ' +
+      'conséquences sont connues ensemble.',
     blocs: [
       {
         titre: 'Front-end',
-        texte:
-          'React et Next.js, rendu différencié par type de page — CSR, SSR, SSG, ISR. Angular, ' +
-          'Ionic, Redux, Zustand, React Query, Tailwind, Material UI.',
         preuve: 'Lighthouse 98/100, conformité RGAA / WCAG tenue en parallèle.',
       },
       {
@@ -110,9 +95,8 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
       {
         titre: 'Architecture et exploitation',
         texte:
-          'Monolithe ou microservices arbitré explicitement. Docker, CI/CD GitHub Actions, ' +
-          'Cloud Run, VM Compute Engine auto-scalées, Pub/Sub, Vercel, Apache, Nginx et Linux. ' +
-          'Pas de cluster Kubernetes administré en propre.',
+          'Docker, CI/CD GitHub Actions, Cloud Run, VM Compute Engine auto-scalées, Pub/Sub, ' +
+          'Vercel, Apache, Nginx et Linux. Pas de cluster Kubernetes administré en propre.',
         preuve:
           'SLI / SLO / SLA définis et suivis, PCA et PRA testés par exercices de bascule, ' +
           'déploiements sans interruption de service.',
@@ -127,29 +111,22 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'La qualité',
     titre: 'Certifiée et outillée, pas promise',
     chapo:
-      'Chez MailingVox, il n’y avait ni QA ni équipe data : la qualité a été ' +
-      'industrialisée parce qu’elle ne pouvait venir de personne d’autre.',
+      'Chez MailingVox, ni QA ni équipe data : la qualité a été industrialisée parce qu’elle ' +
+      'ne pouvait venir de personne d’autre.',
     blocs: [
       {
         titre: 'ISTQB Foundation',
         texte:
-          'Un vocabulaire de recette commun et opposable : critères d’entrée et d’arrêt écrits ' +
-          'avant la livraison. C’est le seul niveau que je détiens, et c’est donc le seul que ' +
-          'j’affiche.',
+          'Critères d’entrée et d’arrêt écrits avant la livraison. C’est le seul niveau que je ' +
+          'détiens, et c’est donc le seul que j’affiche.',
         decision: 'À partir de quand une version est livrable — et qui le dit.',
       },
       {
         titre: 'Développement piloté par les tests, en IA augmentée',
-        texte:
-          'Claude Code et Gemini au quotidien : agents, hooks, skills et serveurs MCP ' +
-          'internes, le test faisant foi.',
         preuve: 'Vélocité augmentée à effectif constant.',
       },
       {
         titre: 'Outillage réellement en place',
-        texte:
-          'Jest, Cypress, Playwright, mutation Stryker, Postman, Lighthouse. Recette des ' +
-          'parcours critiques, non-régression à chaque livraison, charge sur les pics d’envoi.',
         decision: 'Quel niveau de test vous vous autorisez à ne pas payer, et sur quel périmètre.',
       },
     ],
@@ -160,8 +137,8 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
     kicker: 'Charnière · vers la donnée',
     titre: 'La livraison n’est pas la fin, c’est le début du run',
     chapo:
-      'Ce qui tourne produit de la donnée. C’est ce moment précis qui fait naître le besoin de ' +
-      'data et d’IA — pas une mode, et pas avant que le produit existe.',
+      'Ce qui tourne produit de la donnée : c’est ce moment-là qui fait naître le besoin de ' +
+      'data et d’IA.',
     blocs: [
       {
         titre: 'Contrôles post-déploiement',

--- a/src/@vitrine/contenu/jointures.ts
+++ b/src/@vitrine/contenu/jointures.ts
@@ -22,8 +22,8 @@ export const JOINTURES: IJointure[] = [
       'Un produit en production, exploité et mesuré : c’est le run qui fabrique la donnée, ' +
       'jamais l’inverse.',
     siDejaEnPlace:
-      'Si votre produit tourne déjà, on part de lui. L’ingénierie web n’est pas un préalable à ' +
-      'vous facturer, c’est l’endroit d’où la donnée vient.',
+      'Si votre produit tourne déjà, on part de lui : l’ingénierie web n’est pas un préalable ' +
+      'à vous facturer.',
   },
   {
     amont: 'data',
@@ -32,18 +32,16 @@ export const JOINTURES: IJointure[] = [
       'Un métier formalisé et une donnée gouvernée. Sans ça, un modèle apprend l’erreur de ' +
       'cadrage au lieu de la corriger.',
     siDejaEnPlace:
-      'Si votre stratégie data tient déjà, on la reprend telle quelle. Le pôle data se livre ' +
-      'pour lui-même — il ne se rachète pas pour accéder à l’IA.',
+      'Si votre stratégie data tient déjà, on la reprend telle quelle : le pôle data ne se ' +
+      'rachète pas pour accéder à l’IA.',
   },
   {
     amont: 'data',
     aval: 'sea-ux',
     matiere:
-      'La même donnée gouvernée, tournée vers l’arbitrage. Sans elle, le SEA achète du volume ' +
-      'et l’UX redevient une affaire de goût.',
+      'La même donnée gouvernée, tournée vers l’arbitrage. Sans elle, le SEA achète du volume.',
     siDejaEnPlace:
       'Si la mesure est fiable, on arbitre dessus dès le premier jour. Rien n’oblige à prendre ' +
-      'l’IA pour tirer parti de la donnée : les deux suites se prennent séparément ou ' +
-      'ensemble.',
+      'l’IA : les deux suites se prennent séparément ou ensemble.',
   },
 ]

--- a/src/@vitrine/contenu/limites.ts
+++ b/src/@vitrine/contenu/limites.ts
@@ -19,14 +19,14 @@ export const LIMITES: IBoundary[] = [
   {
     hors: 'Pas de cluster Kubernetes administré en propre',
     alaPlace:
-      'Cloud Run, VM Compute Engine auto-scalées, cloud functions et Pub/Sub. Le run tourne, ' +
-      'il est mesuré, et il ne repose sur aucune compétence que je ne tiens pas.',
+      'Cloud Run, VM Compute Engine auto-scalées, cloud functions et Pub/Sub. Le run est ' +
+      'mesuré, et il tient sur les seules compétences que je maîtrise.',
   },
   {
     hors: 'Pas de framework RAG tiers',
     alaPlace:
       'RAG fait maison : recherche vectorielle PostgreSQL et API OpenAI, réponses ancrées sur ' +
-      'votre documentation interne.',
+      'votre documentation interne, pas sur la mémoire du modèle.',
   },
   {
     hors: 'Pas de création graphique ni de design d’interface',
@@ -48,15 +48,13 @@ export const LIMITES: IBoundary[] = [
   {
     hors: 'Un seul outillage de mesure mobile',
     alaPlace:
-      'Firebase Analytics et Crashlytics, et rien d’autre. Côté web : Google Tag Manager en ' +
-      'conteneur web et server-side, Measurement Protocol, Google Analytics, Matomo, gestion ' +
-      'du consentement.',
+      'Firebase Analytics et Crashlytics, et rien d’autre. Côté web : Google Tag Manager web ' +
+      'et server-side, Measurement Protocol, Google Analytics, Matomo, consentement.',
   },
   {
     hors: 'ISTQB Foundation, et rien au-delà',
     alaPlace:
-      'C’est le seul niveau que je détiens, c’est donc le seul affiché. Ce qui est outillé ' +
-      'l’est réellement : tests d’abord, Jest, Cypress, Playwright, mutation Stryker, Postman, ' +
-      'Lighthouse.',
+      'C’est le seul niveau que je détiens, c’est donc le seul affiché. Outillage réel : tests ' +
+      'd’abord, Jest, Cypress, Playwright, mutation Stryker, Postman, Lighthouse.',
   },
 ]

--- a/src/@vitrine/contenu/poles-nav.ts
+++ b/src/@vitrine/contenu/poles-nav.ts
@@ -22,8 +22,8 @@ export const POLES_NAV: IPole[] = [
     route: ROUTES['ingenierie-web'],
     promesse: 'Je construis le produit, et je le fais tourner.',
     accroche:
-      'Site, produit SaaS, application mobile : de la conception au run, par une seule ' +
-      'personne, avec une qualité outillée et certifiée plutôt que promise.',
+      'Site, produit SaaS, application mobile : de la conception au run, avec une qualité ' +
+      'outillée et certifiée plutôt que promise.',
   },
   {
     id: 'data',
@@ -33,8 +33,8 @@ export const POLES_NAV: IPole[] = [
     route: ROUTES.data,
     promesse: 'Je pars de votre métier ; la technique vient en dernier.',
     accroche:
-      'Faire émerger ce que votre activité sait déjà sans l’avoir formalisé, puis la stratégie ' +
-      'data, la gouvernance et le droit. Elle se livre seule : vous pouvez vous arrêter là.',
+      'Faire émerger ce que votre activité sait déjà sans l’avoir formalisé, puis la ' +
+      'gouvernance et le droit. Elle se livre seule : vous pouvez vous arrêter là.',
   },
   {
     id: 'ia',
@@ -45,7 +45,7 @@ export const POLES_NAV: IPole[] = [
     promesse: 'La réponse n’est pas toujours un modèle, et je le dis avant d’en construire un.',
     accroche:
       'Souvent une règle métier intégrée à l’existant suffit ; sinon un modèle, ou un LLM ' +
-      'arbitré sur le coût d’inférence, la latence et la confidentialité.',
+      'arbitré sur le coût et la confidentialité.',
   },
   {
     id: 'sea-ux',
@@ -56,6 +56,6 @@ export const POLES_NAV: IPole[] = [
     promesse: 'Je ne dessine pas vos maquettes, je tranche vos parcours.',
     accroche:
       'Mesure construite dans le code, consentement conforme, rentabilité à long terme plutôt ' +
-      'que coût par clic, et des arbitrages décidés sur la donnée puis implémentés.',
+      'que coût par clic — puis les arbitrages implémentés.',
   },
 ]

--- a/src/@vitrine/contenu/renforts.ts
+++ b/src/@vitrine/contenu/renforts.ts
@@ -27,7 +27,7 @@ export const SECTION_RENFORTS: IEditorialSection = {
       titre: 'C’est rare, et la rareté se dit',
       texte:
         'La très grande majorité des projets tient sur une personne du cadrage au run. Le ' +
-        'renfort se déclenche quand le volume dépasserait ce que je peux tenir.',
+        'renfort se déclenche quand le volume dépasse ce que je peux tenir.',
       decision:
         'À quel moment vous préférez un renfort plutôt qu’un délai — l’arbitrage est le vôtre.',
     },
@@ -35,16 +35,14 @@ export const SECTION_RENFORTS: IEditorialSection = {
       titre: 'Choisis, cadrés, et sous ma responsabilité',
       texte:
         'Un renfort travaille sur mes spécifications, dans mon dépôt, avec les mêmes tests. Je ' +
-        'réponds de ce qui est livré, y compris de ce que je n’ai pas tapé moi-même.',
+        'réponds de ce qui est livré, y compris de ce que je n’ai pas tapé.',
       preuve:
         'AMOA de la startup biotech Artedrone : spécifications écrites pour des tiers ' +
         'extérieurs au domaine, BPMN 2.0 et cartographie du système d’information.',
     },
     {
       titre: 'Vous ne gérez personne d’autre que moi',
-      texte:
-        'Pas de chef de projet intermédiaire, pas de second contrat. Je porte le planning, le ' +
-        'budget et la qualité du renfort.',
+      texte: 'Je porte le planning, le budget et la qualité du renfort.',
       preuve:
         'Environ 25 000 € d’encadrement de prestataires SEA, SEO et SMA chez Verhoeven ' +
         'Joaillier : périmètre, budget et qualité sont restés de mon côté.',

--- a/src/@vitrine/contenu/sea-ux-sections.ts
+++ b/src/@vitrine/contenu/sea-ux-sections.ts
@@ -19,9 +19,7 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     pole: 'sea-ux',
     kicker: 'Disons-le tout de suite',
     titre: 'Je ne dessine pas vos maquettes',
-    chapo:
-      'Ce pôle ne vend pas de création graphique. Il vend des arbitrages — quelle étape ' +
-      'supprimée, quel formulaire raccourci — pris sur des chiffres, puis implémentés.',
+    chapo: 'Pas de création graphique : des arbitrages pris sur des chiffres, puis implémentés.',
     blocs: [
       {
         titre: 'Ce que je fais',
@@ -33,14 +31,14 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
       {
         titre: 'Ce que je ne fais pas',
         texte:
-          'Pas d’identité visuelle, pas de direction artistique. Si c’est ce dont vous avez ' +
-          'besoin, il vous faut un designer — je travaille volontiers avec le vôtre.',
+          'Pas d’identité visuelle, pas de direction artistique. S’il vous faut un designer, ' +
+          'je travaille volontiers avec le vôtre.',
       },
       {
         titre: 'Pourquoi ça marche',
         texte:
-          'Les chiffres viennent du pôle Data, le code de l’ingénierie web : toute la ' +
-          'chaîne est tenue par la même personne.',
+          'Les chiffres viennent de la data, le code de l’ingénierie web : la chaîne entière ' +
+          'tient sur la même personne.',
       },
     ],
   },
@@ -51,21 +49,18 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'La mesure',
     titre: 'Construite dans le code, pas déclarée dans une interface',
     chapo:
-      'Je lis le code à l’endroit exact où l’événement doit être posé, au lieu de le deviner ' +
-      'depuis un tableau de bord.',
+      'Je lis le code là où l’événement doit être posé, au lieu de le deviner depuis un ' +
+      'tableau de bord.',
     blocs: [
       {
         titre: 'Plan de taggage opposable',
-        texte:
-          'Conventions de nommage, propriétés attendues, cycle de vie de chaque événement, ' +
-          'documentation opposable aux équipes.',
         decision: 'Quels événements existent, ce qu’ils portent, et qui répond de leur exactitude.',
       },
       {
         titre: 'Collecte web et server-side',
         texte:
-          'GTM en conteneur web et server-side, dataLayer, Measurement Protocol : les ' +
-          'événements partent de serveur à serveur. Google Analytics, Matomo, Search Console.',
+          'GTM en conteneur web et server-side, dataLayer, Measurement Protocol. Google ' +
+          'Analytics, Matomo, Search Console.',
       },
       {
         titre: 'Mobile',
@@ -75,9 +70,6 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
       },
       {
         titre: 'Recette de la donnée',
-        texte:
-          'Le tracking est recetté événement par événement, avec contrôles d’intégrité et ' +
-          'dédoublonnage dès l’ingestion.',
         preuve: 'Méthode de recette adossée à la certification ISTQB Foundation.',
       },
     ],
@@ -90,13 +82,10 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     titre: 'Par construction, pas en rattrapage',
     chapo:
       'Le consentement ne se rajoute pas sur une collecte existante : il conditionne son ' +
-      'architecture. Conçue sans lui, elle devra être refaite.',
+      'architecture.',
     blocs: [
       {
         titre: 'RGPD et gestion du consentement',
-        texte:
-          'Plateforme de gestion du consentement, déclenchement conditionnel des tags par ' +
-          'catégorie, cadrage des traitements avec le juridique.',
         decision:
           'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
       },
@@ -115,14 +104,10 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'Le pilotage',
     titre: 'Arbitrer sur la rentabilité réelle, pas sur les métriques des régies',
     chapo:
-      'Une régie mesure ce qu’elle a servi, pas ce que le client vous rapportera sur deux ans. ' +
-      'Le budget suit alors son intérêt, pas le vôtre.',
+      'Une régie mesure ce qu’elle a servi, pas ce que le client vous rapportera sur deux ans.',
     blocs: [
       {
         titre: 'Valeur client à long terme',
-        texte:
-          'Agrégation des sources d’acquisition, réconciliation et dédoublonnage des ' +
-          'identités, mesure de la rentabilité dans la durée.',
         decision: 'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre.',
       },
       {
@@ -141,9 +126,6 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
       },
       {
         titre: 'Référencement technique',
-        texte:
-          'Le SEO traité comme une propriété du produit : stratégie de rendu, Core Web Vitals, ' +
-          'Lighthouse, accessibilité.',
         preuve: 'Lighthouse 98/100 sur la plateforme SaaS livrée.',
       },
     ],
@@ -154,8 +136,8 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'La boucle',
     titre: 'Ce que la mesure révèle repart en construction',
     chapo:
-      'Le dernier maillon renvoie au premier : un arbitrage décidé le lundi est implémenté ' +
-      'dans la semaine, sans devis d’agence.',
+      'Le dernier maillon renvoie au premier : l’arbitrage décidé le lundi est implémenté dans ' +
+      'la semaine.',
     blocs: [
       {
         titre: 'Aucun transfert de dossier',

--- a/src/interfaces/IEditorialBlock.ts
+++ b/src/interfaces/IEditorialBlock.ts
@@ -8,12 +8,26 @@
  * reformule, et un bloc de service se termine sur ce que le client peut **trancher**,
  * jamais sur une liste d'outils. Les deux champs correspondants sont donc optionnels
  * dans le type mais leur absence est un signal de relecture, pas un défaut de forme.
+ *
+ * `texte` est optionnel pour la raison inverse : quand un bloc porte déjà un titre, une
+ * preuve chiffrée et une décision, le paragraphe est le seul des quatre champs qui
+ * n'apporte rien à un dirigeant pressé — il redit en prose ce que les trois autres
+ * établissent. Dans ce cas précis, il s'omet (issue #45).
+ *
+ * La réciproque est une règle, pas une préférence : **un bloc dépourvu de `preuve` et
+ * de `decision` garde son `texte`**, sinon il ne reste qu'un titre orphelin. Les repères
+ * des charnières sont exactement ce cas.
  */
 export interface IEditorialBlock {
   /** Intitulé court du point d'expertise. */
   titre: string
-  /** Corps du bloc, 2 à 5 phrases. Texte fini, publiable tel quel. */
-  texte: string
+  /**
+   * Corps du bloc, une à trois phrases. Texte fini, publiable tel quel.
+   *
+   * S'omet quand `preuve` et `decision` sont tous deux présents ; obligatoire de fait
+   * quand ils sont tous deux absents.
+   */
+  texte?: string
   /** Preuve chiffrée réelle (montant, pourcentage, durée, contrainte tenue). */
   preuve?: string
   /** Ce que le client peut trancher grâce à ce point d'expertise. */


### PR DESCRIPTION
## Type

feature

## Description

Suite directe de #69, sur l'arbitrage rendu par Jérôme MARICHEZ : `IEditorialBlock.texte`
devient optionnel, et le paragraphe disparaît partout où le bloc porte déjà un titre, une
preuve chiffrée et une décision.

### Le changement de modèle

`texte` passe de `string` à `string | undefined`. Trois champs sur quatre sont désormais
facultatifs, mais pas pour la même raison, et c'est écrit dans le type :

- `preuve` et `decision` sont optionnels parce que le compilateur ne peut pas garantir
  qu'une preuve existe. Leur absence est un **signal de relecture**.
- `texte` l'est pour la raison inverse. Quand les trois autres champs sont là, le
  paragraphe redit en prose ce qu'ils établissent — c'est le seul des quatre qui
  n'apporte rien à un dirigeant pressé.

**La réciproque est une règle, pas une préférence : un bloc dépourvu de `preuve` et de
`decision` garde son `texte`**, sinon il ne reste qu'un titre orphelin. Les 26 repères de
charnière sont exactement ce cas. Vérifié : sur les **76 blocs** du site, **0 titre
orphelin**.

### Aucun paragraphe vide

`ExpertiseBlock`, `HingeSection` et `ThreadSection` conditionnent l'élément à la présence
de la valeur. Vérifié sur le **HTML généré**, pas seulement dans le code :

```
$ find out -name '*.html' -exec cat {} \; | grep -coE '<p[^>]*>\s*</p>'
0
```

(Les quatre `<span>` vides restants sont les glyphes décoratifs `aria-hidden` du
sélecteur d'animation et des flèches du schéma de chaîne, antérieurs à cette PR.)

Rendu réel d'un bloc sans paragraphe — le titre enchaîne directement sur la preuve :

```html
<h3 class="…titre">Site internet</h3>
<p class="…preuve"><span class="…etiquette">Preuve</span>Sites du fonds Truffle Capital…
```

Les trois conteneurs sont en `display:flex` + `gap`, donc la suppression se referme sans
espace résiduel.

### Volume

Mesuré sur les mêmes champs éditoriaux que #69, hors `contenu/blog/`, depuis la même
base de 7 132 mots :

| | Base | Après #69 | Après cette PR | Δ total |
|---|---:|---:|---:|---:|
| `src/@vitrine/contenu/` | **7 132** | 4 809 | **3 984** | **−44,1 %** |
| dont `texte` | 2 966 | 1 361 | **702** | −76,3 % |
| dont `chapo` | 1 177 | 626 | **511** | −56,6 % |
| `preuve` + `decision` + `titre` + `contexte` | 2 293 | 2 318 | 2 318 | intacts |

**34 paragraphes supprimés, 30 resserrés.**

La cible de −50 % (3 566) n'est pas tout à fait atteinte, à 418 mots près. Le plancher
est atteint et il est constitué : 2 265 mots dans des champs protégés, ~340 dans les
paragraphes qui empêchent un titre orphelin (règle 5), ~360 dans les paragraphes qui
portent une borne de véracité (règle 4), et 511 de `chapo` — champ obligatoire du type.
Descendre sous ce plancher demanderait de raboter une borne ou un `chapô` jusqu'à la
phrase unique. **La règle de véracité prime, donc je m'arrête ici et je donne le
chiffre.**

### Affirmations reformulées dont le sens pouvait bouger

| # | Avant | Après | Pourquoi c'est sûr |
|---|---|---|---|
| 1 | Bloc « ISTQB Foundation », paragraphe : « Un vocabulaire de recette commun et opposable : critères d'entrée et d'arrêt écrits avant la livraison. C'est le seul niveau que je détiens, et c'est donc le seul que j'affiche. » | « Critères d'entrée et d'arrêt écrits avant la livraison. C'est le seul niveau que je détiens, et c'est donc le seul que j'affiche. » | **Paragraphe conservé** alors que le bloc a une décision : il porte la borne. La phrase qui limite le niveau est intacte. |
| 2 | Bloc « Architecture et exploitation » (titre + preuve + décision → candidat à la suppression) | Paragraphe **conservé et resserré** : « Docker, CI/CD GitHub Actions, Cloud Run, VM Compute Engine auto-scalées, Pub/Sub, Vercel, Apache, Nginx et Linux. Pas de cluster Kubernetes administré en propre. » | Le `CLAUDE.md` demande que l'absence de K8s « se dise telle quelle ». La décision (« Où tourne votre produit… ») ne la dit pas : le paragraphe reste. |
| 3 | Bloc « Un LLM, quand le problème est du langage » (titre + preuve + décision) | Paragraphe **conservé et resserré** : « Claude sur Vertex AI, OpenAI, Gemini, Llama. Fine-tuning de Llama 3 pour l'application mobile Prézage, RAG documentaire fait maison, aucun framework tiers. » | « fait maison » et « aucun framework tiers » sont des bornes. Prézage et Llama 3 restent nommés (autorisé) ; rien du corpus ni des chiffres du projet. |
| 4 | Bloc « Vous ne gérez personne d'autre que moi » : « Pas de chef de projet intermédiaire, pas de second contrat. Je porte le planning, le budget et la qualité du renfort. » | « Je porte le planning, le budget et la qualité du renfort. » | La nuance de la promesse survit. Rien ne se rapproche d'une absence totale de tiers. |
| 5 | Bloc « Découvrir ce que votre métier sait déjà » : « Insights métier, profils de clients par clustering (KNN), règles formalisées. Vous pouvez vous arrêter là. » | « C'est une prestation à part entière : vous pouvez vous arrêter là. » | **« Vous pouvez vous arrêter là » est conservé** : c'est l'argument d'inclusivité, pas du remplissage. KNN survit sur la page Data (bloc « Découvrir vos profils de clients »). |
| 6 | Bloc « Coordination » : « Encadrement d'équipes marketing et SEO/SEA de 5 à 10 personnes, de prestataires externes, d'alternants et de stagiaires. Côté technique, le titre est Lead Tech dans une équipe de deux développeurs et un product owner. » | **Inchangé, mot pour mot** (bloc sans preuve ni décision → règle 5). Idem dans `limites.ts`. | Le périmètre d'encadrement est le point le plus exposé de la table de véracité. Il n'a jamais été touché. |
| 7 | Bloc « Application mobile », « Campagnes et référencement », « Mobile » | Paragraphes **conservés** malgré la présence d'une preuve. | Ils portent des bornes d'exclusivité : Firebase Analytics/Crashlytics et rien d'autre côté mobile, Google Ads et Bing Ads et pas d'autre régie. Les supprimer aurait laissé le site muet sur ce qu'il ne fait pas. |
| 8 | Bloc « Un modèle, quand la règle ne tient plus » : « Apprentissage supervisé ou non supervisé, selon ce que la donnée permet. La méthode d'extraction… publiée sur arXiv ; je l'ai implémentée moi-même, puis industrialisée. TensorFlow… » | « La méthode d'extraction des caractéristiques du signal audio est publiée sur arXiv ; je l'ai implémentée moi-même, puis industrialisée. TensorFlow, inférence en cloud functions. » | « publiée sur arXiv » + « implémentée moi-même » conservés : aucune collaboration institutionnelle suggérée. |
| 9 | `limites.ts` : « Le run tourne, il est mesuré, et il ne repose sur aucune compétence que je ne tiens pas. » | « Le run est mesuré, et il tient sur les seules compétences que je maîtrise. » | **Arbitrage de la relecture précédente.** Double négation supprimée dans un bloc de lucidité, portée identique. |
| 10 | `limites.ts` : « RAG fait maison : … réponses ancrées sur votre documentation interne. » | « …ancrées sur votre documentation interne, **pas sur la mémoire du modèle**. » | **Arbitrage de la relecture précédente.** `IBoundary` n'a pas de champ décision : aucune décision ne portait ce bénéfice, la queue est donc restaurée. |
| 11 | Chapô renforts, chapô d'accueil, jointures | **Clauses protégées intactes** : « Sur un projet dont la taille le demande », « c'est rare », « vous ne gérez personne d'autre que moi », « L'une, l'autre, ou les deux », « les deux suites se prennent séparément ou ensemble », « le pôle data ne se rachète pas pour accéder à l'IA », « l'ingénierie web n'est pas un préalable à vous facturer ». | Narration du modèle : arguments de vente, jamais du remplissage. |
| 12 | Bloc « Le relais, je l'ai déjà passé » | Paragraphe supprimé ; la `preuve` ajoutée en #69 (Truffle Capital, Verhoeven Joaillier) **porte désormais seule** les chiffres d'encadrement. | C'est le déplacement fait au lot précédent qui rend cette suppression possible sans perte de fait. |

Aucun fait n'a été jeté avec son paragraphe. Aucune `preuve` ni `decision` n'a été
élargie pour absorber ce que le paragraphe disait.

### Ce qui descend dans `/realisations/`

Détail retiré des pages de pôle, à reprendre dans l'espace en cours de création :

- Le récit des trois migrations (PHP 5 → 7, jQuery → React, Ionic 6 → 8, Angular 15 → 19).
- « Sms En Masse » : remplacement d'une solution tierce exploitée en marque blanche.
- L'AMOA Artedrone en détail : BPMN 2.0, cartographie du SI, matrice de risques, recette et tests d'acceptation.
- L'intégration ERP M3 Soft et la synchronisation boutique / e-commerce.
- La stack front détaillée (Redux, Zustand, React Query, Tailwind, Material UI) et le catalogue Storybook.
- Le plan de taggage opposable : conventions de nommage, propriétés attendues, cycle de vie d'un événement.
- La réconciliation d'identités et les contrôles d'intégrité à l'ingestion.
- Le procédé maison d'augmentation de contexte proche du RAG sur Prézage.

### Test — intention exposée, fichier non posé

Le test précède le code et c'est Jérôme MARICHEZ qui l'écrit. Niveau **unitaire**,
`tests/unitaire/bloc-editorial.spec.tsx`. Jeu de données : les tableaux réels de
`src/@vitrine/contenu/` — le contenu publié *est* la donnée sous test, pas de fixture.

1. **Aucun paragraphe vide.** Rendre un `IEditorialBlock` sans `texte` via
   `ExpertiseBlock`, `HingeSection` et `ThreadSection` : le titre, la preuve et la
   décision sont présents, et le conteneur ne produit aucun `<p>` ni `<span>` vide.
   Cas limite : `texte: ''` doit se comporter comme `texte` absent.
2. **Aucun titre orphelin.** Parcourir les 76 blocs de toutes les sections publiées : un
   bloc dépourvu à la fois de `texte`, de `preuve` et de `decision` échoue le test.
   C'est le garde-fou qui empêche une future coupe de vider une page.
3. **Verrou de véracité sur le contenu publié.** Concaténer les valeurs textuelles de
   `src/@vitrine/contenu/` et vérifier l'absence de : `/aucune sous-traitance/i`,
   `/0 sous-traitant/i`, `/istqb/i` non suivi de `Foundation`, `LangChain`, `LlamaIndex`,
   `AppsFlyer`, `Adjust`, `Amplitude`, `Tealium`, `Adobe (Launch|Analytics)`, `Meta Ads`,
   `LinkedIn Ads`, `GraphQL`, `NestJS`, `Prisma`, `Cucumber`, `Gherkin`, `PyTorch`, et
   `/management (d'|de )?(l')?équipes? (de )?dév/i`. Vérifier aussi la **présence** des
   bornes : « seul niveau que je détiens », « Pas de cluster Kubernetes administré en
   propre », « aucun framework tiers », « Pas d'autre outillage mobile revendiqué ».
   Cas limite : le test doit lire les **valeurs**, jamais les commentaires — la table du
   `CLAUDE.md` est recopiée en en-tête de plusieurs fichiers et produirait des faux
   positifs.

## Critères d'acceptation

- [x] `IEditorialBlock.texte` optionnel, avec le commentaire qui dit quand il se justifie.
- [x] Les trois composants ne produisent jamais de `<p>` vide — vérifié sur le HTML généré.
- [x] Aucun bloc n'est un titre orphelin (76 blocs, 0 orphelin).
- [x] Aucune reformulation n'élargit une affirmation ; aucun fait n'est jeté avec son paragraphe.
- [x] `make lint`, `make type-check`, `make test`, `make build` verts.
- [x] `docs/data-model.md` documente le contrat des quatre champs.
- [ ] Volume réduit de moitié — atteint à **−44,1 %** (3 984 mots). Plancher motivé ci-dessus.

## Impacts

`src/interfaces/IEditorialBlock.ts` ;
`src/@vitrine/components/{ExpertiseBlock,HingeSection,ThreadSection}/index.tsx` ;
`src/@vitrine/contenu/` : `accueil.ts`, `accueil-sections.ts`, `accueil-data.ts`,
`fil-ia.ts`, `renforts.ts`, `limites.ts`, `jointures.ts`, `poles-nav.ts`,
`data-sections.ts`, `ia-sections.ts`, `ingenierie-web-sections.ts`,
`sea-ux-sections.ts` ; `docs/data-model.md`.

Aucun style, aucune route, aucun composant hors des trois rendus.

Closes #45

https://claude.ai/code/session_01Vz8szo5e81R85kUGnwNftH
