### PR TITLE
feat: la scene du seuil dit quatre poles et un interlocuteur

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -3,14 +3,10 @@
 Direction retenue : **« L'Établi »**. Le site est un plan de travail vu à travers des
 panneaux de verre — on voit littéralement au travers parce qu'il n'y a rien à cacher,
 ni chaîne de prestataires ni couche commerciale. Les quatre pôles ne sont pas quatre
-offres côte à côte : ce sont des plaques alignées dans le même axe, chacune tenue par
-le liseré de sa propre teinte.
-
-> **Décor à reprendre.** La scène SVG du seuil (`ChainCanvas` / `SlabScene`) dessine
-> encore **trois** dalles en file, héritées du modèle à trois pôles linéaires. Elle est
-> purement décorative — `aria-hidden`, `role="presentation"`, et son texte de substitution
-> ne compte plus les pôles — mais elle ne dit pas encore l'embranchement. À reprendre avec
-> le lot de réécriture éditoriale.
+offres côte à côte au catalogue, et ce n'est pas non plus une file de quatre maillons :
+ce sont des plaques teintées chacune par sa propre teinte, dont les deux dernières —
+l'IA et le SEA & UX — sont écartées **côte à côte**, à égalité. Un seul filet vertical
+les traverse toutes : l'interlocuteur unique.
 
 Le verre ne réfracte **jamais du texte**, seulement le fond d'atelier (dégradé + trame
 technique). La transparence reste visible, la lisibilité reste intacte : c'est
@@ -22,7 +18,7 @@ exactement l'arbitrage que le site vend, appliqué à lui-même.
   [`src/app/globals.css`](../src/app/globals.css). Aucune couleur, aucun espacement,
   aucune taille en dur dans un composant.
 - **Responsive** : mobile-first. Le verre réfractant est un **enrichissement desktop**,
-  jamais un prérequis de lecture. La scène des trois dalles, elle, est du SVG : elle
+  jamais un prérequis de lecture. La scène des quatre dalles, elle, est du SVG : elle
   s'affiche partout, au même coût sur un téléphone et sur un poste de travail.
 - **Thème** : clair et sombre, via `prefers-color-scheme`. Les deux palettes sont
   complètes et vérifiées en contraste — aucune couleur n'est définie dans un seul thème.
@@ -305,7 +301,7 @@ personnalisé.
 | **Poser** | toute section qui entre dans l'écran | `opacity: 0` → `1` et `translateY(24px)` → `none`, `--duree-poser`. Porté par [`Reveal`](../src/@shared/components/Reveal/index.tsx), qui s'appuie sur `useInViewport` — voir « La révélation » ci-dessous |
 | **Tracer** | les deux charnières | filet cuivre 2px, `scaleY(0)` → `scaleY(1)`, `--duree-tracer`. Seul mouvement porteur de sens : la chaîne se trace. Déclenché à l'entrée de la charnière dans l'écran, et non au chargement de la page |
 | **Traverser** | le fil IA | filets cuivre **horizontaux**, `scaleX(0)` → `scaleX(1)`, même durée, même déclenchement. Perpendiculaires à ceux des charnières : la chaîne descend, le fil la coupe — la géométrie dit « ceci n'est pas une quatrième offre » |
-| **Dériver** | la scène des trois dalles | deux fréquences lentes qui ne se referment jamais ensemble, en `transform` seul — assez pour faire lire du volume, jamais assez pour appeler le regard |
+| **Dériver** | la scène des quatre dalles | deux fréquences lentes qui ne se referment jamais ensemble, en `transform` seul — assez pour faire lire du volume, jamais assez pour appeler le regard. Le filet de tenue en est **exclu** : ce qui tient ne dérive pas |
 | **Aimanter** | les boutons d'action | le bouton suit le pointeur, borné à **6 px** ([`utils/aimant.ts`](../src/utils/aimant.ts)), en `transform` seul. Souris uniquement : au doigt il n'y a pas de survol, l'attraction n'arriverait qu'après l'appui. `MagneticAction` est le **seul** module autorisé à poser un `transform` sur un bouton — deux règles concurrentes se départageraient à l'ordre du paquet CSS |
 | **Micro-états** | liens et boutons | épaisseur de soulignement, `--aimant-appui: -1px` au survol, `--duree-micro` — aucun déplacement de mise en page |
 
@@ -395,24 +391,54 @@ Trois contraintes de la bibliothèque sont tenues, et leur parade est explicite 
 Le fond translucide n'est pas un pis-aller : c'est le rendu **par défaut** sur mobile,
 sans WebGL et en mouvement réduit.
 
-## La scène des trois dalles
+## La scène des quatre dalles
 
-Trois dalles de verre décalées en profondeur, alignées dans le même axe : la thèse du
-site rendue en volume. Aucun texte, aucun logo, aucune particule.
+Quatre dalles de verre teintées et **un filet vertical qui les traverse toutes** : le
+modèle de l'offre rendu en volume. Aucun texte, aucun logo, aucune particule.
+
+La topologie est celle du `CLAUDE.md`, pas une composition libre :
+
+```
+  ┌───────────────┐      ingénierie web — temps 1, dans l'axe
+  └───────────────┘
+  ┌───────────────┐      data — temps 2, dans l'axe, décalée
+  └───────────────┘
+┌─────────┐ ┌─────────┐  IA  et  SEA & UX — temps 3, écartées côte à côte
+└─────────┘ └─────────┘
+        (un filet vertical descend derrière les quatre)
+```
+
+**Le point qui décide de tout** : les deux dalles du temps 3 sont des **sœurs**, jamais
+une quatrième puis une cinquième étape. Même largeur, même hauteur, même dégradé, même
+classe CSS, même durée d'animation ; seul un décalage vertical de 12 unités casse la
+symétrie mécanique, et un décalage n'a ni premier ni second. Toute retouche de la scène
+doit préserver cette égalité — c'est l'argument que le site vend.
+
+Le **filet de tenue** est l'interlocuteur unique. Il est le seul élément **non animé** de
+la scène, et le seul à ne porter aucun `data-pole` : il prend le cuivre de la racine, qui
+est la couleur de la maison et non celle d'un pôle. Il descend derrière les quatre dalles
+et ressort dans l'écart qui sépare les deux sœurs, là où on le lit le mieux.
 
 Elle a d'abord été une scène WebGL (`three` + `@react-three/fiber`, ~235 ko gzip). Elle
-est aujourd'hui **un SVG de 1,6 ko rendu au serveur**, et le compromis n'en est pas un :
-le site vend une performance tenue, il ne pouvait pas payer un moteur 3D pour un décor.
-Ce qui est perdu — la réfraction physique, la rotation pilotée par le défilement —
+est aujourd'hui **un SVG d'environ 1,7 ko rendu au serveur**, et le compromis n'en est pas
+un : le site vend une performance tenue, il ne pouvait pas payer un moteur 3D pour un
+décor. Ce qui est perdu — la réfraction physique, la rotation pilotée par le défilement —
 n'était lisible par personne. Ce qui est gagné se mesure au premier chargement, et la
 scène s'affiche désormais **aussi sous 1024px**, là où le WebGL n'était jamais monté.
 
-- **Forme** : trois rectangles arrondis décalés, liseré cuivre, un dégradé de lueur sur
-  la dalle de premier plan. [`ChainCanvas/SlabScene.tsx`](../src/@shared/components/ChainCanvas/SlabScene.tsx).
+- **Forme** : `viewBox="0 0 420 360"`, quatre rectangles arrondis et un filet de 2
+  unités. [`ChainCanvas/SlabScene.tsx`](../src/@shared/components/ChainCanvas/SlabScene.tsx).
+  Le rapport 7/6 se retrouve tel quel dans `chain-canvas.module.css` : les deux valeurs
+  se suivent, sinon la réservation d'espace cesse de réserver la bonne place.
+- **Teintes** : chaque dalle porte son `data-pole` dans le SVG, et `poles.css` lui pose
+  `--accent` et `--verre-arete` dessous. **Aucune teinte de pôle n'est nommée dans le
+  module CSS de la scène.** Un seul `<linearGradient>` sert les quatre dalles : son
+  `currentColor` se résout sur l'élément qui *référence* le dégradé, pas sur le `<defs>`,
+  donc chaque dalle le teinte avec son propre accent.
 - **Mouvement** : le groupe porte une dérive d'ensemble, chaque dalle la sienne. Deux
   fréquences qui ne se referment jamais au même moment suffisent à faire lire du volume,
   là où une seule donnerait un balancement de métronome. `transform` et `opacity`
-  uniquement.
+  uniquement. Le filet de tenue est hors du groupe animé et n'a pas d'animation propre.
 - **Rendu** : entièrement serveur. Le seul motif restant de rendre `ChainCanvas` côté
   client est de lire le choix « animation figée » et de le passer à la scène. Plus de
   chargement différé à orchestrer, plus de détection de WebGL, plus de seuil de largeur.

--- a/src/@shared/components/ChainCanvas/SlabScene.tsx
+++ b/src/@shared/components/ChainCanvas/SlabScene.tsx
@@ -1,16 +1,32 @@
 // SlabScene.tsx — jeromemarichez-fr
-// Trois dalles de verre alignées dans le même axe : la thèse du site, en SVG.
+// Quatre dalles de verre et un filet de tenue : le modèle de l'offre, en SVG.
 //
-// Cette scène a remplacé une scène WebGL (`three` + `@react-three/fiber`, 235 ko gzip)
-// qui disait exactement la même chose. Le compromis n'en est pas un : le site vend une
-// perf tenue, il ne pouvait pas payer un moteur 3D pour un décor. Ce qui est perdu — la
-// réfraction physique, la rotation pilotée par le défilement — n'était lisible par
-// personne ; ce qui est gagné se mesure au premier chargement.
+// Ce que la scène dessine, c'est la topologie du CLAUDE.md — ingénierie web, puis la
+// donnée en passage obligé, puis DEUX suites côte à côte — et le filet vertical qui les
+// traverse toutes : l'interlocuteur unique. Le filet est le seul élément immobile de la
+// scène. C'est délibéré : ce qui tient ne dérive pas.
+//
+// Les deux dalles du temps 3 sont des SŒURS, jamais une quatrième puis une cinquième
+// étape. Même taille, même facture, même classe CSS ; seul un décalage vertical de
+// quelques pixels casse la symétrie mécanique, et il ne se lit pas comme un ordre.
+// Toute évolution de cette scène doit préserver cette égalité — c'est l'argument que le
+// site vend, pas un détail de composition.
+//
+// Cette scène a remplacé une scène WebGL (`three` + `@react-three/fiber`, 235 ko gzip).
+// Le compromis n'en est pas un : le site vend une perf tenue, il ne pouvait pas payer un
+// moteur 3D pour un décor. Ce qui est perdu — la réfraction physique, la rotation pilotée
+// par le défilement — n'était lisible par personne.
 //
 // Règle de tenue : **rien d'autre que `transform` et `opacity` n'est animé ici**. Ce sont
 // les deux seules propriétés que le compositeur traite sans repasser par la mise en page
 // ni par le peintre, donc les deux seules qui tiennent 60 images par seconde sur un
 // téléphone — la scène s'affiche désormais aussi sous 1024 px.
+//
+// Les teintes ne sont pas écrites ici : chaque dalle porte `data-pole`, et `poles.css`
+// mappe `--accent` dessous. L'accueil n'est sous aucune racine de pôle — les quatre y
+// coexistent — donc chaque dalle pose la sienne. Le filet, lui, reste hors de tout
+// `data-pole` : il hérite du cuivre de la racine, la couleur de la maison — celle de
+// l'interlocuteur, qui n'appartient à aucun pôle parce qu'il les porte tous.
 
 import styles from './slab-scene.module.css'
 
@@ -19,7 +35,7 @@ interface SlabSceneProps {
   fige?: boolean
 }
 
-/** Trois dalles décalées dans le même axe, liseré cuivre. Environ 1,6 ko, zéro JS. */
+/** Quatre dalles teintées, un filet de tenue immobile. Environ 1,7 ko, zéro JS. */
 export function SlabScene({ fige = false }: SlabSceneProps) {
   return (
     <svg
@@ -28,32 +44,72 @@ export function SlabScene({ fige = false }: SlabSceneProps) {
       fill="none"
       focusable="false"
       role="presentation"
-      viewBox="0 0 340 420"
+      viewBox="0 0 420 360"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title>Trois dalles de verre alignées dans le même axe</title>
+      <title>Quatre dalles de verre traversées par un même filet vertical</title>
       <defs>
+        {/* `currentColor` se résout sur l'élément qui RÉFÉRENCE le dégradé, pas sur le
+            `<defs>` : un seul dégradé suffit aux quatre teintes, chaque dalle posant son
+            propre `color: var(--accent)`. */}
         <linearGradient id="dalle-lueur" x1="0" x2="1" y1="0" y2="1">
-          <stop offset="0" stopColor="currentColor" stopOpacity="0.16" />
-          <stop offset="0.55" stopColor="currentColor" stopOpacity="0.04" />
-          <stop offset="1" stopColor="currentColor" stopOpacity="0.14" />
+          <stop offset="0" stopColor="currentColor" stopOpacity="0.24" />
+          <stop offset="0.55" stopColor="currentColor" stopOpacity="0.07" />
+          <stop offset="1" stopColor="currentColor" stopOpacity="0.2" />
         </linearGradient>
       </defs>
 
-      {/* Le groupe porte la dérive d'ensemble, chaque dalle sa propre dérive : deux
-          fréquences qui ne se referment jamais au même moment suffisent à faire lire
-          du volume, là où une seule donnerait un balancement de métronome. */}
+      {/* Hors du groupe animé, et sans animation propre : le filet descend derrière les
+          quatre dalles et ressort dans l'écart qui sépare les deux sœurs — c'est là qu'on
+          le lit le mieux, et c'est là qu'il compte le plus. */}
+      <rect className={styles.tenue} height="344" rx="1" width="2" x="209" y="8" />
+
+      {/* Le groupe porte la dérive d'ensemble, chaque dalle la sienne : deux fréquences
+          qui ne se referment jamais au même moment suffisent à faire lire du volume, là
+          où une seule donnerait un balancement de métronome. */}
       <g className={styles.groupe}>
-        <rect className={styles.arriere} height="290" rx="14" width="190" x="132" y="94" />
-        <rect className={styles.milieu} height="300" rx="15" width="200" x="76" y="66" />
         <rect
-          className={styles.avant}
+          className={styles.socle}
+          data-pole="ingenierie-web"
           fill="url(#dalle-lueur)"
-          height="312"
-          rx="16"
-          width="210"
-          x="18"
-          y="38"
+          height="92"
+          rx="14"
+          width="168"
+          x="126"
+          y="18"
+        />
+        <rect
+          className={styles.passage}
+          data-pole="data"
+          fill="url(#dalle-lueur)"
+          height="92"
+          rx="14"
+          width="168"
+          x="106"
+          y="130"
+        />
+        {/* Les deux suites : même largeur, même hauteur, même classe, même dégradé. Seuls
+            `x`, `y` et le déphasage de la dérive les distinguent — rien qui se lise
+            comme un ordre. */}
+        <rect
+          className={styles.suite}
+          data-pole="ia"
+          fill="url(#dalle-lueur)"
+          height="96"
+          rx="14"
+          width="150"
+          x="26"
+          y="250"
+        />
+        <rect
+          className={`${styles.suite} ${styles.suiteDecalee}`}
+          data-pole="sea-ux"
+          fill="url(#dalle-lueur)"
+          height="96"
+          rx="14"
+          width="150"
+          x="244"
+          y="262"
         />
       </g>
     </svg>

--- a/src/@shared/components/ChainCanvas/chain-canvas.module.css
+++ b/src/@shared/components/ChainCanvas/chain-canvas.module.css
@@ -1,4 +1,4 @@
-/* chain-canvas.module.css — réservation d'espace pour la scène des trois dalles.
+/* chain-canvas.module.css — réservation d'espace pour la scène des quatre dalles.
  * L'aspect-ratio est posé en CSS et non déduit du contenu : c'est lui qui tient la place
  * exacte de la scène dès la première image, avant même que le SVG ne soit peint. La
  * réservation date de l'époque où la scène arrivait en différé ; elle reste ici pour la
@@ -15,8 +15,13 @@
   position: relative;
   z-index: 3;
   width: 100%;
-  aspect-ratio: 4 / 5;
-  max-height: 34rem;
+  /* 7/6 depuis que la composition s'élargit au temps 3 : les deux suites sont écartées
+     côte à côte, elles ne tiennent plus dans un portrait 4/5. Le rapport est celui du
+     `viewBox` (420 × 360) — toute retouche de l'un doit suivre dans l'autre, sinon la
+     scène se retrouve centrée dans une boîte trop haute et la réservation ne réserve
+     plus la bonne place. */
+  aspect-ratio: 7 / 6;
+  max-height: 26rem;
 }
 
 /* Le substitut n'est jamais montré : le conteneur est déjà `aria-hidden`. Il ne sert

--- a/src/@shared/components/ChainCanvas/index.tsx
+++ b/src/@shared/components/ChainCanvas/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 // ChainCanvas/index.tsx — jeromemarichez-fr
-// L'enveloppe de la scène des trois dalles : sa place réservée, et sa mise en pause.
+// L'enveloppe de la scène des quatre dalles : sa place réservée, et sa mise en pause.
 
 import { useMotionPaused } from '../../hooks/use-motion-paused'
 import styles from './chain-canvas.module.css'

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -1,11 +1,13 @@
-/* slab-scene.module.css — les trois dalles de verre.
+/* slab-scene.module.css — les quatre dalles de verre et leur filet de tenue.
  * Les couleurs viennent des jetons : la scène suit le thème clair et sombre comme le
- * reste, elle n'a pas de palette à elle.
+ * reste, elle n'a pas de palette à elle. Chaque dalle porte `data-pole` dans le SVG, donc
+ * `poles.css` lui pose son propre `--accent` et son propre `--verre-arete` : aucune
+ * teinte de pôle n'est nommée ici.
  *
  * Seuls `transform` et `opacity` sont animés — voir l'en-tête de `SlabScene.tsx`. Aucune
  * de ces règles ne déclenche de mise en page ni de repeinture, ce qui est la condition
  * pour que la scène puisse s'afficher sur téléphone sans coûter une image perdue. Pas de
- * `will-change` non plus : trois rectangles animés en transform sont déjà promus par le
+ * `will-change` non plus : quatre rectangles animés en transform sont déjà promus par le
  * compositeur, l'indice ne ferait que réserver de la mémoire GPU en double. */
 
 .scene {
@@ -16,27 +18,45 @@
 
 .groupe rect {
   stroke-width: 1;
+  /* `currentColor` du dégradé se résout ICI, sur la dalle qui le référence : poser la
+     couleur du pôle sur le rect suffit à teinter sa lueur. */
+  color: var(--accent);
+  /* `--accent` plein, et non `--verre-arete` : l'arête de verre est un mélange à 28% de
+     transparent, calibré pour un liseré cuivre posé sur du verre. Appliqué aux quatre
+     teintes, il les ramène toutes au même gris — et une scène dont les quatre dalles ont
+     la même couleur ne dit plus rien du modèle. Le liseré fait 1 unité de large sur 420 :
+     il reste un trait, pas un aplat. */
+  stroke: var(--accent);
   /* Sans `fill-box`, l'origine des transformations d'un `rect` SVG est le coin du
      viewBox : chaque dalle pivoterait autour d'un point situé hors d'elle-même. */
   transform-box: fill-box;
   transform-origin: center;
 }
 
-.arriere {
-  fill: color-mix(in srgb, var(--encre) 3%, transparent);
-  stroke: color-mix(in srgb, var(--encre) 14%, transparent);
+/* L'interlocuteur unique : hors du groupe, et sans `animation` du tout. Il n'a pas de
+   `data-pole` — il prend le cuivre de la racine, qui est la couleur de la maison et non
+   celle d'un pôle. C'est la seule chose fixe de la scène, et c'est tout le propos. */
+.tenue {
+  fill: color-mix(in srgb, var(--accent-vif) 70%, transparent);
+}
+
+.socle {
   animation: deriver-dalle 19s var(--courbe-poser) infinite alternate;
 }
 
-.milieu {
-  fill: color-mix(in srgb, var(--encre) 4%, transparent);
-  stroke: color-mix(in srgb, var(--encre) 18%, transparent);
+.passage {
   animation: deriver-dalle 15s var(--courbe-poser) -5s infinite alternate;
 }
 
-.avant {
-  stroke: var(--verre-arete);
-  animation: deriver-dalle 12s var(--courbe-poser) -9s infinite alternate;
+/* Les deux sœurs partagent CETTE règle, entièrement. Même durée, même courbe, même
+   amplitude : rien dans leur mouvement ne peut se lire comme un ordre. Seul le déphasage
+   ci-dessous les désynchronise, et un déphasage n'a ni premier ni second. */
+.suite {
+  animation: deriver-dalle 13s var(--courbe-poser) infinite alternate;
+}
+
+.suiteDecalee {
+  animation-delay: -7s;
 }
 
 .groupe {

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -131,7 +131,9 @@
    contexte WebGL, donc plus rien ne justifie de la retirer aux petits écrans. Elle passe
    sous le discours, centrée et bornée en largeur pour ne pas manger l'écran, et le
    contrôle de mise en pause la suit — c'est lui qui doit rester atteignable partout où
-   la scène bouge. */
+   la scène bouge. La borne de largeur a suivi le passage de la scène au format 7/6 :
+   la composition s'élargit au temps 3, et une borne de 20rem écrasait les deux suites
+   au point qu'on ne les distinguait plus l'une de l'autre. */
 @media (max-width: 1023px) {
   .seuil {
     grid-template-columns: minmax(0, 1fr);
@@ -142,7 +144,7 @@
   .volume {
     align-items: center;
     width: 100%;
-    max-width: 20rem;
+    max-width: 26rem;
     margin-inline: auto;
   }
 }

--- a/src/@vitrine/components/HomeHero/index.tsx
+++ b/src/@vitrine/components/HomeHero/index.tsx
@@ -10,8 +10,9 @@ import { HERO_ACCUEIL } from '../../contenu/accueil'
 import styles from './home-hero.module.css'
 
 /**
- * Le `h1` est le seul de la page et il est rendu statiquement : c'est lui le LCP, pas
- * la scène WebGL, qui n'arrive qu'après et ne bloque rien.
+ * Le `h1` est le seul de la page et il est rendu statiquement : c'est lui le LCP. La
+ * scène voisine est du SVG rendu au serveur — elle arrive dans le même document et ne
+ * dispute rien au titre.
  *
  * Les trois jetons de preuve sont posés dès le seuil parce que la promesse
  * d'interlocuteur unique est invérifiable telle quelle : sans chiffre à côté, elle se
@@ -54,7 +55,7 @@ export function HomeHero() {
       </div>
 
       <div className={styles.volume}>
-        <ChainCanvas description="Des plaques de verre alignées dans le même axe : une seule chaîne, tenue par une seule personne." />
+        <ChainCanvas description="Quatre dalles de verre — ingénierie web, donnée, puis IA et SEA & UX côte à côte — traversées par un même filet vertical : un seul interlocuteur, du cadrage au run." />
         {/* Le contrôle est posé au pied de la scène, là où le mouvement se voit.
             WCAG 2.2.2 demande un mécanisme de mise en pause : la préférence système
             n'en est pas un, elle ne se change pas depuis la page. */}


### PR DESCRIPTION
Closes #48

## Ce que ça change

La scène SVG du seuil rendait encore **trois dalles en file**, héritées du modèle à trois
pôles linéaires. Elle dessine maintenant la topologie réelle du `CLAUDE.md` :

```
  ┌───────────────┐      ingénierie web — temps 1, dans l'axe
  └───────────────┘
  ┌───────────────┐      data — temps 2, dans l'axe, décalée
  └───────────────┘
┌─────────┐ ┌─────────┐  IA  et  SEA & UX — temps 3, écartées côte à côte
└─────────┘ └─────────┘
        (un filet vertical descend derrière les quatre)
```

**Les deux dalles du temps 3 sont des sœurs**, jamais une quatrième puis une cinquième
étape : même largeur, même hauteur, même dégradé, **même classe CSS**, même durée
d'animation. Seul un décalage vertical de 12 unités casse la symétrie mécanique, et un
décalage n'a ni premier ni second.

**Le filet vertical est l'interlocuteur unique.** C'est le seul élément **non animé** de
la scène, et le seul sans `data-pole` : il prend le cuivre de la racine, la couleur de la
maison et non celle d'un pôle.

## Comment les teintes arrivent

Aucune teinte de pôle n'est nommée dans le module CSS. Chaque dalle porte `data-pole` dans
le SVG, `poles.css` lui pose `--accent` dessous, et **un seul `<linearGradient>` sert les
quatre** : son `currentColor` se résout sur l'élément qui *référence* le dégradé, pas sur
le `<defs>`.

Le liséré passe de `--verre-arete` à `--accent` plein. Justification : `--verre-arete` est
un mélange à 28 % de transparent, calibré pour un liséré cuivre sur du verre ; appliqué aux
quatre teintes il les ramenait toutes au même gris, et une scène dont les quatre dalles ont
la même couleur ne dit plus rien du modèle. Le trait fait 1 unité sur 420 — il reste un
trait, pas un aplat.

## Ce qui ne change pas

- **Aucune dépendance ajoutée.** Toujours du SVG rendu au serveur ; pas de retour à WebGL.
- `transform` et `opacity` uniquement.
- Les **deux** mécanismes de figeage, tels quels : `animation-play-state: paused` pour le
  `MotionToggle` (garde la pose), `animation: none` sous `prefers-reduced-motion` (retour à
  l'image de départ).
- `role="presentation"`, conteneur `aria-hidden`, `data-liquid-ignore`.
- **Le poids baisse** : le SVG inline mesuré dans l'export statique pèse **1,3 ko**, contre
  ~1,6 ko avant.

## Mise en page

Le format passe de `4/5` portrait à **`7/6`** : la composition s'élargit au temps 3 et ne
tenait plus dans un portrait. `viewBox="0 0 420 360"`, `chain-canvas.module.css`
(`aspect-ratio: 7 / 6`, `max-height: 26rem`) et la borne de largeur du bloc
`@media (max-width: 1023px)` de `home-hero.module.css` (20rem → 26rem) suivent ensemble.

## Chaînes corrigées

Les trois chaînes qui mentaient : le `<title>` du SVG, la `description` passée à
`ChainCanvas`, et les en-têtes de `chain-canvas.module.css`, `slab-scene.module.css` et
`ChainCanvas/index.tsx`. Au passage, le commentaire de `HomeHero` qui parlait encore d'une
« scène WebGL qui n'arrive qu'après ».

`docs/design.md` : la thèse d'ouverture, la ligne « Dériver » du tableau Mouvement, et la
section — renommée « La scène des quatre dalles », qui porte désormais le schéma de la
topologie, la règle d'égalité des deux sœurs et le mécanisme des teintes.

## Vérification

Pas de test dans ce lot : ce n'est pas ce qui juge un décor. Rendu contrôlé en pose
**figée** (animation coupée) sur l'export statique, en clair et en sombre :

- **1400 px** : les deux dalles de l'axe, puis les deux sœurs écartées, le filet cuivre
  descendant derrière et ressortant dans l'écart qui les sépare. Les quatre teintes se
  distinguent — cuivre, bleu-canard, violet, olive.
- **320 px** (rendu dans une iframe de 320 px, Chrome headless ne descendant pas sous sa
  largeur de fenêtre minimale) : la composition tient, les deux sœurs restent côte à côte
  et lisibles comme égales, aucun débordement horizontal.

`make lint`, `make type-check`, `make build` verts.

https://claude.ai/code/session_01Vz8szo5e81R85kUGnwNftH