### PR TITLE
fix: ignorer les worktrees git imbriques au lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,7 @@
       "!dist",
       "!build",
       "!coverage",
+      "!.claude/worktrees",
       "!**/postman_collection.json",
       "!next-env.d.ts"
     ]


### PR DESCRIPTION
Closes #73

## Le defaut

`make lint` echouait **en local** des qu'un worktree git vivait sous `.claude/worktrees/` — ce qui est le cas des qu'un agent delegue travaille.

Un worktree est une **copie complete du depot** : il porte son propre `biome.json`. Biome, lance depuis la racine, y descendait et refusait de continuer :

```
× Found a nested root configuration, but there's already a root configuration.
```

Le message ne parlant que de configuration, le lint sortait rouge **sans avoir rien trouve dans le code**. Constate le 2026-08-22 avec quatre worktrees simultanes, alors que `dev` etait propre.

**La CI n'etait pas touchee** — elle travaille sur un clone frais. D'ou un defaut invisible en integration, et penible en local puisqu'il fait douter d'un code sain.

## Le correctif

Une ligne : `"!.claude/worktrees"` dans `files.includes`.

## Aucun controle affaibli

Les fichiers de `.claude/worktrees/` sont des **copies** de sources deja lintees a la racine. Les exclure ne retire rien du perimetre — cela evite de le parcourir deux fois.

**Verifie empiriquement**, en reproduisant le cas plutot qu'en le supposant :

```
$ git worktree add .claude/worktrees/essai-lint --detach HEAD
$ make lint
Checked 156 files in 76ms. No fixes applied.
✓ Aucun fichier source ne depasse 300 lignes.
code=0
```

**156 fichiers avec le worktree imbrique, 156 sans.** Le perimetre reel est identique ; seule la copie est ignoree.

Aucune regle desactivee, aucun seuil abaisse, aucun repertoire de source exclu.

## Intention de test

Aucun fichier de test pose. L'intention utile serait de niveau **acceptation** : *la cible `lint` sort en code 0 et verifie le meme nombre de fichiers, qu'un worktree existe ou non sous `.claude/worktrees/`*. Jeu de donnees : un worktree jetable cree puis retire par le test. A poser par Jerome MARICHEZ s'il la juge utile — la preuve ci-dessus est reproductible a la main en deux commandes.
