### PR TITLE
autre: rendre executables les budgets de performance et d'accessibilite

### DIFF
--- a/.github/workflows/ci-dev-a11y.yml
+++ b/.github/workflows/ci-dev-a11y.yml
@@ -1,0 +1,35 @@
+name: ci-dev-a11y
+# Check rapide (PR -> dev) : contrôle d'accessibilité automatisé (axe-core) sur les
+# pages représentatives — accueil, page de pôle, page d'article.
+#
+# Pourquoi ici et pas sur `main` : une régression d'accessibilité vient presque toujours
+# d'un changement de balisage, et le corriger coûte cent fois moins cher le jour où il
+# est écrit que trois semaines plus tard au moment de la mise en production. axe est
+# rapide (build + un Chrome, ~2 min), donc le prix est payable à chaque PR.
+#
+# La mesure Lighthouse, elle, est lente : elle vit dans `ci-main-budgets`.
+#
+# Ce contrôle ne vaut PAS un audit RGAA — il couvre la part mécanisable de WCAG AA.
+# Voir docs/accessibility.md.
+on:
+  pull_request:
+    branches: [dev]
+jobs:
+  a11y:
+    name: Accessibilité (axe-core)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Installation
+        run: make install
+      # `npm install` déclenche déjà le postinstall de puppeteer, mais un cache npm
+      # restauré peut le sauter : on s'assure explicitement d'avoir un Chrome.
+      - name: Navigateur de mesure
+        run: npx puppeteer browsers install chrome
+      # make budget-a11y construit l'export, le sert, analyse chaque page et échoue si
+      # une violation d'impact critical/serious est trouvée (scripts/budgets.mjs).
+      - name: Budget accessibilité
+        run: make budget-a11y

--- a/.github/workflows/ci-main-budgets.yml
+++ b/.github/workflows/ci-main-budgets.yml
@@ -1,0 +1,39 @@
+name: ci-main-budgets
+# Check complet (PR -> main) : budgets de performance ET d'accessibilité mesurés sur les
+# pages représentatives — accueil, page de pôle, page d'article.
+#
+# Pourquoi ici : une mesure Lighthouse coûte trois passes par page (médiane) sur un
+# mobile émulé et un réseau bridé. C'est plusieurs minutes, et la variance impose la
+# répétition. La payer à chaque PR vers `dev` taxerait tout le monde pour une métrique
+# qui bouge rarement d'un commit à l'autre ; la placer sur la PR de mise en production
+# la met exactement là où la question se pose — « est-ce que ce qu'on publie tient les
+# chiffres qu'on vend ? ». C'est la convention du dépôt : `ci-dev-*` = rapide et à
+# chaque PR, `ci-main-*` = complet avant production (e2e, système, build).
+#
+# `workflow_dispatch` permet de lancer la mesure à la demande depuis `dev`, sans
+# attendre la PR de production.
+#
+# Seuils : `scripts/budgets/pages.mjs`, repris du CLAUDE.md — Lighthouse >= 95 sur les
+# quatre catégories. Règle 8 du CLAUDE.md : ce job n'a ni `continue-on-error`, ni
+# condition, ni exemption. S'il est rouge, c'est la page qu'on corrige.
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  budgets:
+    name: Budgets performance + accessibilité
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Installation
+        run: make install
+      - name: Navigateur de mesure
+        run: npx puppeteer browsers install chrome
+      # make budgets construit l'export, le sert, mesure axe puis Lighthouse, et sort en
+      # échec en nommant la page et la catégorie fautives (scripts/budgets.mjs).
+      - name: Budgets
+        run: make budgets

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 .PHONY: test-e2e
 .PHONY: test-system
 .PHONY: test-acceptance
+.PHONY: budgets budget-perf budget-a11y
 .PHONY: storybook storybook-build
 .PHONY: docker-up docker-down logs
 
@@ -46,6 +47,20 @@ test-system: ## Tests système (vrai serveur HTTP via listen(0))
 	@echo "Collection Postman rejouable : npx newman run tests/systeme/postman_collection.json (stack démarrée)"
 test-acceptance: ## Tests d'acceptation / UAT (runner Node natif)
 	node --test tests/acceptance/
+
+# Budgets exécutables — Lighthouse >= 95 sur les 4 categories et accessibilite WCAG AA.
+# Construisent l'export statique s'il manque, le servent, mesurent, et sortent en echec
+# en nommant la page et la categorie fautives. Seuils : scripts/budgets/pages.mjs.
+# Prerequis local : npx puppeteer browsers install chrome (une fois).
+budgets: ## Budgets perf + accessibilite sur les pages representatives
+	node scripts/budgets.mjs
+
+budget-perf: ## Budget de performance seul (Lighthouse, mobile bride)
+	node scripts/budgets.mjs perf
+
+budget-a11y: ## Budget d'accessibilite seul (axe-core) — rapide
+	node scripts/budgets.mjs a11y
+
 storybook: ## Storybook en local (http://localhost:6006) — après npx storybook@latest init
 	@if [ -d front ]; then cd front && npm run storybook; else npm run storybook; fi
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -36,9 +36,50 @@ Conformité **WCAG 2.1 AA** sur les parcours principaux.
 
 ## Vérification
 
-- Lint accessibilité (règles a11y de Biome).
-- Audit manuel clavier + lecteur d'écran sur les parcours critiques.
+Trois niveaux, et il est important de ne pas les confondre :
+
+1. **Lint** — règles a11y de Biome, à l'écriture. Attrape les fautes de balisage
+   évidentes (`div` cliquable, `alt` manquant) avant même le build.
+2. **Contrôle automatisé** — `make budget-a11y` : axe-core (Deque) sur les pages
+   représentatives, dans un vrai navigateur. Une violation d'impact `critical` ou
+   `serious` fait **échouer** le contrôle, et il tourne sur **chaque PR vers `dev`**
+   (`ci-dev-a11y`).
+3. **Audit manuel** — clavier et lecteur d'écran sur les parcours critiques. **Rien ne
+   le remplace.**
+
+### Ce que le contrôle automatique ne dit pas
+
+axe-core ne détecte que la part **mécanisable** de WCAG : Deque annonce environ 57 % des
+problèmes sur ses propres jeux de mesure, la pratique retient plutôt un tiers. Un
+`make budget-a11y` vert ne signifie **pas** que le site est conforme RGAA, et le site ne
+doit nulle part le laisser entendre — ce serait exactement le genre d'affirmation sans
+preuve que le `CLAUDE.md` s'interdit.
+
+Restent hors de portée d'axe, et donc à la charge de l'audit manuel :
+
+- la **pertinence** d'une alternative textuelle, d'un intitulé de lien, d'un titre ;
+- l'**ordre de lecture** et la cohérence de la hiérarchie de titres ;
+- l'utilisabilité réelle **au clavier** d'un composant riche (piège de focus, raccourci) ;
+- le **focus visible** en conditions réelles — axe ne juge pas la visibilité d'un
+  contour ;
+- `prefers-reduced-motion` : axe ne le teste pas. Le respect de la préférence est vérifié
+  à la main sur la scène d'accueil ;
+- **WCAG 2.2.2 (Pause, Stop, Hide)** — le mécanisme de mise en pause des animations. Un
+  contrôle automatique ne sait pas dire si l'utilisateur peut réellement arrêter le
+  mouvement ; c'est un point d'audit manuel explicite sur ce site ;
+- les **contrastes** au-delà du cas simple texte sur fond uni : les seize valeurs de la
+  palette des pôles sont mesurées à la main dans [`design.md`](./design.md), et
+  `--accent-vif` y est déclaré **non-texte uniquement**. axe ne peut pas connaître cette
+  intention.
+
+### Pages contrôlées
+
+Les mêmes que les budgets de performance — accueil, page de pôle, page d'article — parce
+qu'un gabarit non mesuré est un gabarit non protégé. La liste vit dans
+`scripts/budgets/pages.mjs`.
 
 | Parcours | Audit | État |
 |----------|-------|------|
-| _TODO_ | | |
+| Accueil, pôle, article | axe-core (`ci-dev-a11y`) | **0 violation** — première exécution, 2026-08-22 |
+| Clavier + lecteur d'écran | manuel | _à réaliser_ |
+| WCAG 2.2.2 — pause des animations | manuel | _à réaliser_ |

--- a/docs/ameliorations.md
+++ b/docs/ameliorations.md
@@ -5,4 +5,49 @@ le bénéfice attendu et l'effort estimé.
 
 | # | Amélioration | Bénéfice | Effort | Statut |
 |---|--------------|----------|--------|--------|
-| 1 | _TODO_ | | | proposé |
+| 1 | Compression du HTML et des polices en production (`gzip`/`brotli` dans `docker/nginx.conf`) | Budget de performance mobile : premier levier, de loin | faible | **identifié, non fait** |
+| 2 | Stratégie de chargement des polices (sous-ensemble, `preload`, `size-adjust`) | LCP mobile | moyen | proposé |
+| 3 | Réduction du JavaScript inutilisé (~153 Kio) et du JavaScript hérité (~43 Kio) | Budget de performance mobile | moyen | proposé |
+| 4 | Préchargement RSC de toutes les routes de pôle depuis l'accueil | Bande passante mobile après le LCP | faible | proposé |
+
+## Budget de performance — diagnostic du 2026-08-22
+
+Les budgets sont devenus exécutables (`make budgets`, voir [testing](./testing.md)). Leur
+première exécution rapporte **80 / 81 / 82** en performance mobile, contre un seuil de
+**95**. Le seuil n'a pas été touché : ce qui suit est ce qu'il faut corriger.
+
+Le profil des trois pages est identique et sans ambiguïté :
+
+| Métrique | Accueil | Pôle |
+|----------|---------|------|
+| First Contentful Paint | 1,7 s | 1,4 s |
+| Speed Index | 1,7 s | 1,4 s |
+| Total Blocking Time | 20 ms | 20 ms |
+| Cumulative Layout Shift | 0 | 0 |
+| **Largest Contentful Paint** | **5,3 s** | **5,0 s** |
+
+Tout est excellent sauf le LCP, et le LCP arrive **3,5 s après** un premier rendu déjà
+rapide. Ce n'est donc ni du JavaScript bloquant (TBT à 20 ms) ni de la mise en page
+(CLS à 0) : c'est du **transfert**.
+
+Le relevé réseau le confirme :
+
+- le document HTML de l'accueil pèse **120 Kio**, servi **sans compression** ;
+- deux polices `woff2` de **67 Kio** et **49 Kio** s'y ajoutent sur le chemin critique ;
+- sur le lien bridé (1638 kbps, soit environ 200 Kio/s), ces 236 Kio coûtent à eux seuls
+  plus d'une seconde et retardent le rendu du texte principal.
+
+**Ce n'est pas un artefact du harnais de mesure.** `docker/nginx.conf` ne déclare aucune
+directive `gzip`, et l'image `nginx:alpine` la laisse commentée par défaut. La production
+sert donc, elle aussi, 120 Kio de HTML non compressé. Un HTML de cette taille se comprime
+autour de 20 Kio : c'est le premier levier, et c'est une correction de configuration de
+service, pas de code applicatif.
+
+Ce correctif touche la configuration de production (`docker/nginx.conf`, et
+`scripts/serve-out.mjs` pour que la mesure reste fidèle à ce que sert nginx). Il sort du
+périmètre du lot qui a rendu les budgets exécutables, et fait l'objet d'un lot distinct —
+c'est justement le budget qui l'a mis au jour, le jour de sa mise en service.
+
+En profil **desktop** non bridé, les mêmes pages sortent à **99 / 100 / 100 / 100** : le
+site n'est pas lent dans l'absolu, il l'est sur un mobile en 4G médiocre. C'est le cas
+qui compte, et c'est celui que le budget mesure.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -6,8 +6,8 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
 
 | Déclencheur | Workflows | Objectif |
 |-------------|-----------|----------|
-| **PR → `dev`** | `ci-dev-lint`, `ci-dev-types`, `ci-dev-tests` | Checks **rapides** : lint (Biome + limite 300 lignes), vérification des types, tests unitaires et intégration. |
-| **PR → `main`** | `ci-main-e2e`, `ci-main-system`, `ci-main-build` | Checks **complets** avant production : e2e navigateur, tests système, build. |
+| **PR → `dev`** | `ci-dev-lint`, `ci-dev-types`, `ci-dev-tests`, `ci-dev-a11y` | Checks **rapides** : lint (Biome + limite 300 lignes), vérification des types, tests unitaires et intégration, contrôle d'accessibilité (axe). |
+| **PR → `main`** | `ci-main-e2e`, `ci-main-system`, `ci-main-build`, `ci-main-budgets` | Checks **complets** avant production : e2e navigateur, tests système, build, budgets Lighthouse + axe. |
 
 ## Jobs
 
@@ -29,6 +29,22 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
   HTTP, pas de `sleep`), lance Cypress headless, puis arrête le serveur — y compris en
   cas d'échec, sans processus orphelin. Le code de sortie du harnais est celui de
   Cypress : aucun échec n'est absorbé. Détail : [testing](./testing.md).
+- **a11y (dev)** : `make budget-a11y` — axe-core sur l'accueil, une page de pôle et une
+  page d'article ; une violation d'impact `critical` ou `serious` fait échouer la PR.
+  Placé sur `dev` **parce qu'il est rapide** (~2 min) et qu'une régression
+  d'accessibilité vient presque toujours d'un changement de balisage : elle se corrige
+  cent fois moins cher le jour où elle est écrite. Ce contrôle ne vaut **pas** un audit
+  RGAA — il couvre la part mécanisable de WCAG AA, voir
+  [accessibility](./accessibility.md).
+- **budgets (main)** : `make budgets` — axe **et** Lighthouse (≥ 95 sur les quatre
+  catégories, mobile émulé + réseau bridé, médiane de trois passes) sur les mêmes pages.
+  Placé sur `main` **parce qu'il est lent** : trois passes par page, et la variance de
+  Lighthouse impose la répétition. Le payer à chaque PR vers `dev` taxerait tout le monde
+  pour une métrique qui bouge rarement d'un commit à l'autre ; le placer sur la PR de
+  mise en production le met là où la question se pose — *est-ce que ce qu'on publie tient
+  les chiffres qu'on vend ?* Un `workflow_dispatch` permet de le lancer à la demande
+  depuis `dev` sans attendre la PR de production. Seuils : `scripts/budgets/pages.mjs`,
+  repris du `CLAUDE.md`. Détail : [testing](./testing.md).
 - **système (main)** : vrai serveur HTTP + client réel.
 - **build (main)** : build de production (front et back), artefacts vérifiés.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,12 +99,16 @@ sous le seuil `break`). Lancer : `make test-mutation`.
 - **Couverture** : seuil défini dans la config de test — la CI échoue en dessous.
   <!-- TODO : fixer le seuil (ex. 90 %). -->
 
-## Harnais e2e — l'export statique servi en local
+## Harnais statique — l'export servi en local
 
 Le site est en **export statique** (`output: 'export'`) : il n'y a ni back, ni route
-API, ni serveur applicatif. La « stack » des tests e2e se réduit donc à **servir le
-dossier `out/`**. Tout est piloté par `scripts/e2e.mjs`, appelé par `make test-e2e` —
-en local comme dans le workflow `ci-main-e2e` :
+API, ni serveur applicatif. La « stack » se réduit donc à **servir le dossier `out/`**.
+`scripts/harnais-statique.mjs` porte cette mécanique **une seule fois**, pour les tests
+e2e (`scripts/e2e.mjs`) comme pour les budgets (`scripts/budgets.mjs`) : deux harnais
+concurrents finiraient par diverger sur le port, la sonde ou le nettoyage, et c'est
+toujours le second qui laisse un serveur orphelin en CI.
+
+`make test-e2e`, en local comme dans le workflow `ci-main-e2e` :
 
 1. **build si nécessaire** : `npm run build` si `out/index.html` manque ;
 2. **serveur statique** : `scripts/serve-out.mjs` sert `out/` sur `127.0.0.1:E2E_PORT`
@@ -128,6 +132,65 @@ chaque route en `<route>/index.html`. `serve-out.mjs` applique exactement les r�
 statique qui ignorerait cette règle ferait échouer les specs pour la mauvaise raison.
 La traversée de répertoire hors de `out/` est refusée.
 
+## Budgets exécutables — performance et accessibilité
+
+Le `CLAUDE.md` pose deux contraintes produit non négociables : **Lighthouse ≥ 95 sur les
+quatre catégories** et **accessibilité WCAG AA**. Elles étaient écrites, elles ne sont
+plus seulement écrites : `make budgets` échoue quand le site descend sous le seuil, et
+dit **quelle page** sur **quelle catégorie**.
+
+Ce ne sont pas des tests au sens des quatre niveaux ci-dessus : ils ne décrivent pas un
+comportement attendu du code, ils mesurent une propriété du site rendu. Ils vivent donc
+dans `scripts/budgets/`, pas dans `tests/`.
+
+```bash
+make budgets       # accessibilité + performance
+make budget-a11y   # axe-core seul — rapide (~2 min)
+make budget-perf   # Lighthouse seul — lent (3 passes x 3 pages)
+```
+
+Prérequis local, une fois : `npx puppeteer browsers install chrome`.
+
+### Ce qui est mesuré, et pourquoi
+
+**Trois pages, trois gabarits** (`scripts/budgets/pages.mjs`) : l'accueil (scène animée,
+verre — le gabarit le plus lourd), une page de pôle (sections, preuves, palette dédiée)
+et une page d'article (corps long, typographie, fil d'Ariane, JSON-LD). Mesurer le seul
+accueil ne dit rien des deux autres, et c'est là que les régressions se logent.
+
+**Profil de mesure : mobile émulé, réseau bridé « slow 4G », CPU ×4.** C'est le profil
+par défaut de PageSpeed Insights, et le cas sur lequel un prospect jugera le site. Un
+profil desktop sans bridage donnerait des scores flatteurs qui ne protègent de rien — sur
+ce site, l'écart entre les deux profils est de **dix-sept points** (voir plus bas).
+
+**Médiane de trois passes.** Lighthouse varie de quelques points d'une exécution à
+l'autre. Un budget qui échoue au hasard une fois sur cinq se fait désactiver en une
+semaine ; la médiane le rend crédible. `BUDGET_PASSES` permet de réduire le nombre de
+passes en local pour itérer vite — jamais en CI.
+
+**Un seul Chrome pour toute la campagne** : Lighthouse s'y connecte par le port de
+débogage, axe par l'API puppeteer. Deux navigateurs mesureraient deux sites.
+
+### Première exécution — 2026-08-22
+
+Mesuré sur l'export de `dev` (commit `596aafd`), médiane de 3 passes, profil mobile.
+
+| Page | Perf | A11y | Bonnes prat. | SEO |
+|------|------|------|--------------|-----|
+| accueil | **80** ✗ | 100 ✓ | 100 ✓ | 100 ✓ |
+| pôle `ingenierie-web` | **81** ✗ | 100 ✓ | 100 ✓ | 100 ✓ |
+| article | **82** ✗ | 100 ✓ | 100 ✓ | 100 ✓ |
+
+axe-core : **0 violation** sur les trois pages, à tous les impacts.
+
+**Le budget de performance n'est pas tenu.** Il n'a pas été abaissé pour autant : c'est
+la page qu'on corrige, jamais le seuil (règle 8 du `CLAUDE.md`). Le diagnostic est
+consigné dans [`ameliorations.md`](./ameliorations.md).
+
+Pour situer : en profil **desktop** non bridé, les mêmes pages sortent à **99 / 100 / 100
+/ 100**. Le site n'est donc pas lent dans l'absolu — il l'est sur un mobile en 4G
+médiocre, ce qui est précisément le cas qui compte.
+
 ## Vérification des types
 
 `make type-check` exécute `tsc --noEmit` : le compilateur vérifie tout le dépôt sans
@@ -149,4 +212,7 @@ make test-e2e         # build + export statique servi + Cypress headless + arrê
 make test-system      # système (Jest + fetch ; collection Postman rejouable)
 make test-mutation    # Stryker (score de mutation)
 make test-acceptance  # acceptation / UAT
+make budgets          # budgets perf (Lighthouse) + accessibilité (axe) sur 3 gabarits
+make budget-perf      # budget de performance seul
+make budget-a11y      # budget d'accessibilité seul
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeromemarichez-fr",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "liquid-gl": "^2.0.1",
         "next": "^16.0.0",
@@ -15,6 +15,7 @@
         "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@axe-core/puppeteer": "^4.13.0",
         "@biomejs/biome": "^2.0.0",
         "@stryker-mutator/core": "^9.0.0",
         "@stryker-mutator/jest-runner": "^9.0.0",
@@ -27,8 +28,66 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
+        "lighthouse": "^13.4.1",
+        "puppeteer": "^25.8.0",
         "ts-jest": "^29.4.0",
         "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -51,6 +110,22 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/puppeteer": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.13.0.tgz",
+      "integrity": "sha512-y43krMJveVzxIZckPxo/2cHG5x4NBNF8fuwNcCYlTWV9cVtm5bagKZ6EmJO6EcKj37hsIL+nWUHGhTCvz4GNNg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">=1.10.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -1178,6 +1253,62 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@img/colour": {
@@ -3022,6 +3153,138 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@paulirish/trace_engine": {
+      "version": "0.0.65",
+      "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.65.tgz",
+      "integrity": "sha512-Qsm6F5C8xf6ZzQXbQc2+wcpe6sggfs/gvc/ytqSurdvYg3kyW0ECHCqE0CWBKZpqgjVfPNX9c7SCS3r2nEIRGg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "legacy-javascript": "latest",
+        "third-party-web": "latest"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3046,12 +3309,288 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.70.0.tgz",
+      "integrity": "sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node-core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.70.0.tgz",
+      "integrity": "sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.70.0.tgz",
+      "integrity": "sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.52",
@@ -3347,6 +3886,13 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -3894,6 +4440,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -4035,6 +4591,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4050,6 +4616,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/aws-sign2": {
@@ -4068,6 +4645,16 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/babel-jest": {
       "version": "30.4.1",
@@ -4501,6 +5088,65 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -4764,6 +5410,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4792,6 +5457,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.8.tgz",
+      "integrity": "sha512-EwOnfYuNbTytvbMKsLixTrRgnjOa0WZCxGy8A9nnSYAicrdwn+T/epU/yjgymmOxlgKnvH+8wXt+7p/8ak5Feg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -5117,6 +5789,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5169,6 +5851,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1663043",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1663043.tgz",
+      "integrity": "sha512-33aOY3ZnBP1dgZsshgaL+/XlsQleiFZgyUaDtdZkEa1nbZhVY1MoDeWjk+wxg25fU924l1ZJfoGNmjjeA/5s1w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/diff-match-patch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
@@ -5183,6 +5872,35 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5254,6 +5972,33 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -5309,6 +6054,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -5371,6 +6123,29 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eventemitter2": {
@@ -6003,6 +6778,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-link-header": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.4.tgz",
+      "integrity": "sha512-xT3GPW6/ZbGuw4UvwHqErSCEjNUlwbQJuZn9/q5U4WEKfp2kENVCAlousG1zLxHeaQ/ffOHUNpWamvkbBW0eNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6107,6 +6892,28 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -6166,12 +6973,41 @@
         "node": ">=10"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
@@ -6277,6 +7113,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isexe": {
@@ -7874,6 +8723,23 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-md4": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
@@ -8039,6 +8905,13 @@
         "verror": "1.10.0"
       }
     },
+    "node_modules/legacy-javascript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+      "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8047,6 +8920,102 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lighthouse": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.4.1.tgz",
+      "integrity": "sha512-fDu8lt3QLK/lTqIxtp1HkzQNJ32rsFHhbadYOepcMZFLgA8oINhxutMbMv8XXnpTOvZ0TXCo4JCk1LDTWaRLnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paulirish/trace_engine": "0.0.65",
+        "@sentry/node": "^10.0.0",
+        "axe-core": "^4.12.1",
+        "chrome-launcher": "^1.2.1",
+        "configstore": "^7.0.0",
+        "csp_evaluator": "1.1.8",
+        "devtools-protocol": "0.0.1663043",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.2",
+        "lighthouse-stack-packs": "1.12.3",
+        "lodash-es": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "open": "^8.4.0",
+        "puppeteer-core": "^25.3.0",
+        "robots-parser": "^3.0.1",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.29.2",
+        "tldts-icann": "^7.4.9",
+        "web-features": "^3.34.0",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=22.19"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.3.tgz",
+      "integrity": "sha512-d8IsOpE83kbANgnM+Tp8+x6HcMpX9o2ITBiUERssgzAIFdZCQzs/f4k6D0DLQTE59enml9mbAOU52Wu35exWtg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lighthouse/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -8146,6 +9115,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8348,6 +9324,13 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8367,6 +9350,16 @@
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -8402,6 +9395,13 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8418,6 +9418,16 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -8507,6 +9517,30 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8761,6 +9795,24 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9121,6 +10173,60 @@
         "node": ">=6"
       }
     },
+    "node_modules/puppeteer": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.8.0.tgz",
+      "integrity": "sha512-3gcUJ+Jfodb5zNa/lWLZukBUwYiRIwAc8WRICoqfi+ZYmNWqpsPFyanTU3Gw/lhgII9aotVbAmhT6/NKHWgyUA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.8.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
+      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -9230,6 +10336,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -9276,6 +10396,16 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
@@ -9340,6 +10470,13 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -9596,6 +10733,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9839,6 +10991,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -9996,6 +11165,13 @@
         "node": "*"
       }
     },
+    "node_modules/third-party-web": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.29.2.tgz",
+      "integrity": "sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/throttleit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
@@ -10023,6 +11199,23 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts-icann": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.10.tgz",
+      "integrity": "sha512-JrzJnTNDURpnyPCf/b0bq/mAiQhPcNwkwpfO67M0nECzVzSIuCFN+EYjqnEjnmO60nPRabS3zIFChbwPp/Q+Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      }
+    },
+    "node_modules/tldts-icann/node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10210,6 +11403,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typed-rest-client": {
       "version": "2.3.1",
@@ -10448,6 +11648,20 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/web-features": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.35.1.tgz",
+      "integrity": "sha512-c9R1duLo60camLUu7JWP6nP/ALu1YI+bF7Pmyzo4tJM8lDzI/Uwlo++9DSfgoP3ziO/QtK+iBzaDAfp62rjBRA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -10508,6 +11722,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10677,6 +11898,19 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {
@@ -17,6 +17,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@axe-core/puppeteer": "^4.13.0",
     "@biomejs/biome": "^2.0.0",
     "@stryker-mutator/core": "^9.0.0",
     "@stryker-mutator/jest-runner": "^9.0.0",
@@ -29,6 +30,8 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
+    "lighthouse": "^13.4.1",
+    "puppeteer": "^25.8.0",
     "ts-jest": "^29.4.0",
     "typescript": "^5.9.0"
   }

--- a/scripts/budgets.mjs
+++ b/scripts/budgets.mjs
@@ -1,0 +1,108 @@
+// budgets.mjs — jeromemarichez-fr
+//
+// Rend **exécutables** les deux promesses que le site affiche : Lighthouse ≥ 95 sur les
+// quatre catégories, et accessibilité WCAG AA. Une commande, un code de sortie, et le
+// nom de ce qui ne passe pas.
+//
+//   node scripts/budgets.mjs            (ou : make budgets)
+//   node scripts/budgets.mjs perf       (ou : make budget-perf)
+//   node scripts/budgets.mjs a11y       (ou : make budget-a11y)
+//
+// Le site est un export statique : le harnais commun (`scripts/harnais-statique.mjs`,
+// partagé avec `make test-e2e`) construit `out/` si besoin, le sert et l'arrête. Ici, il
+// ne reste que la mesure.
+//
+// Règle 8 du `CLAUDE.md` : le vert s'obtient par un site qui tient ses budgets, jamais
+// par un seuil qu'on abaisse. Aucun `|| true`, aucune catégorie exemptée, aucune page
+// retirée de la liste pour faire passer la CI.
+
+import puppeteer from 'puppeteer'
+import { analyserPage } from './budgets/mesure-axe.mjs'
+import { mesurerPage } from './budgets/mesure-lighthouse.mjs'
+import { PAGES } from './budgets/pages.mjs'
+import {
+  afficherAxe,
+  afficherEchecsLighthouse,
+  afficherTableauLighthouse,
+} from './budgets/rapport.mjs'
+import { avecSiteServi, lancer } from './harnais-statique.mjs'
+
+const PORT_DEBOGAGE = Number(process.env.BUDGET_PORT_CDP ?? 9222)
+
+const MODES = new Set(['perf', 'a11y', 'tout'])
+
+function lireMode() {
+  const argument = process.argv[2] ?? 'tout'
+  if (!MODES.has(argument)) {
+    throw new Error(`Mode inconnu « ${argument} » — attendu : ${[...MODES].join(', ')}`)
+  }
+  return argument
+}
+
+/**
+ * Un seul Chrome pour toute la campagne : Lighthouse s'y connecte par le port de
+ * débogage, axe par l'API puppeteer. Deux navigateurs mesureraient deux sites.
+ */
+function ouvrirNavigateur() {
+  return puppeteer.launch({
+    headless: true,
+    args: [
+      `--remote-debugging-port=${PORT_DEBOGAGE}`,
+      // Indispensable en CI (conteneur sans namespaces utilisateur). N'affaiblit rien
+      // ici : le seul contenu chargé est l'export statique servi en local.
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+    ],
+  })
+}
+
+async function mesurerPerformance({ url }) {
+  const resultats = []
+  for (const page of PAGES) {
+    const cible = `${url}${page.chemin}`
+    console.log(`Lighthouse — ${page.id} (${page.pourquoi})…`)
+    // Lighthouse pilote lui-même l'onglet via CDP : on lui passe le port, pas un onglet.
+    resultats.push(await mesurerPage({ page, url: cible, portDebogage: PORT_DEBOGAGE }))
+  }
+  afficherTableauLighthouse(resultats)
+  afficherEchecsLighthouse(resultats)
+  return resultats.every((resultat) => resultat.echecs.length === 0)
+}
+
+async function mesurerAccessibilite({ navigateur, url }) {
+  const resultats = []
+  for (const page of PAGES) {
+    const cible = `${url}${page.chemin}`
+    console.log(`axe-core — ${page.id}…`)
+    resultats.push(await analyserPage({ navigateur, url: cible }))
+  }
+  afficherAxe(resultats)
+  return resultats.every((resultat) => resultat.bloquantes.length === 0)
+}
+
+async function main() {
+  const mode = lireMode()
+
+  return avecSiteServi(async ({ url }) => {
+    const navigateur = await ouvrirNavigateur()
+    try {
+      const verdicts = []
+      if (mode === 'a11y' || mode === 'tout') {
+        verdicts.push(['accessibilité (axe)', await mesurerAccessibilite({ navigateur, url })])
+      }
+      if (mode === 'perf' || mode === 'tout') {
+        verdicts.push(['performance (Lighthouse)', await mesurerPerformance({ url })])
+      }
+
+      console.log('')
+      for (const [nom, tenu] of verdicts) {
+        console.log(`${tenu ? '✓' : '✗'} Budget ${nom} : ${tenu ? 'tenu' : 'DÉPASSÉ'}`)
+      }
+      return verdicts.every(([, tenu]) => tenu) ? 0 : 1
+    } finally {
+      await navigateur.close()
+    }
+  })
+}
+
+lancer('budgets', main)

--- a/scripts/budgets/mesure-axe.mjs
+++ b/scripts/budgets/mesure-axe.mjs
@@ -1,0 +1,54 @@
+// mesure-axe.mjs — jeromemarichez-fr
+//
+// Contrôle d'accessibilité automatisé (axe-core, Deque) sur une page servie.
+//
+// **Ce contrôle ne vaut pas un audit RGAA.** axe-core ne détecte mécaniquement qu'une
+// partie des critères — Deque annonce environ 57 % des problèmes WCAG sur ses propres
+// mesures, et la littérature du domaine retient plutôt un tiers en pratique. Tout ce
+// qui demande un jugement — pertinence d'une alternative textuelle, ordre de lecture,
+// cohérence d'un intitulé de lien, utilisabilité au clavier d'un composant riche — reste
+// hors de portée. Le détail et la part manuelle sont dans `docs/accessibility.md`.
+//
+// Ce que ce contrôle garantit, précisément : aucune régression sur la part mécanisable.
+// C'est un filet, pas un certificat.
+
+import { AxePuppeteer } from '@axe-core/puppeteer'
+import { ETIQUETTES_AXE, IMPACTS_BLOQUANTS } from './pages.mjs'
+
+/**
+ * Analyse une page et rend `{ url, bloquantes, mineures }`.
+ * Une violation bloquante (`critical` ou `serious`) fait échouer le budget.
+ *
+ * @param {{ navigateur: object, url: string }} contexte
+ */
+export async function analyserPage({ navigateur, url }) {
+  const onglet = await navigateur.newPage()
+  try {
+    // `networkidle0` : les polices et la scène animée doivent être en place, sinon on
+    // audite un état intermédiaire que personne ne voit jamais.
+    await onglet.goto(url, { waitUntil: 'networkidle0', timeout: 60_000 })
+
+    const resultat = await new AxePuppeteer(onglet).withTags(ETIQUETTES_AXE).analyze()
+
+    const decrire = (violation) => ({
+      regle: violation.id,
+      impact: violation.impact,
+      description: violation.help,
+      occurrences: violation.nodes.length,
+      exemple: violation.nodes[0]?.target?.join(' ') ?? '',
+      aide: violation.helpUrl,
+    })
+
+    return {
+      url,
+      bloquantes: resultat.violations
+        .filter((v) => IMPACTS_BLOQUANTS.includes(v.impact))
+        .map(decrire),
+      mineures: resultat.violations
+        .filter((v) => !IMPACTS_BLOQUANTS.includes(v.impact))
+        .map(decrire),
+    }
+  } finally {
+    await onglet.close()
+  }
+}

--- a/scripts/budgets/mesure-lighthouse.mjs
+++ b/scripts/budgets/mesure-lighthouse.mjs
@@ -1,0 +1,87 @@
+// mesure-lighthouse.mjs — jeromemarichez-fr
+//
+// Mesure Lighthouse d'une page servie, et verdict par rapport aux seuils du
+// `CLAUDE.md` (voir `scripts/budgets/pages.mjs`).
+//
+// Le navigateur est fourni par l'appelant : lancer un Chrome par page coûterait plus
+// cher que la mesure elle-même, et ferait diverger les conditions d'exécution entre
+// deux pages du même rapport.
+
+import lighthouse from 'lighthouse'
+import { SEUILS_LIGHTHOUSE } from './pages.mjs'
+
+/**
+ * Profil de mesure. Mobile émulé et réseau bridé : c'est le cas défavorable, celui que
+ * PageSpeed Insights applique par défaut et celui sur lequel un prospect jugera le site.
+ * Mesurer en desktop sans bridage donnerait des scores flatteurs qui ne protègent de rien.
+ */
+const CONFIGURATION = {
+  extends: 'lighthouse:default',
+  settings: {
+    formFactor: 'mobile',
+    screenEmulation: {
+      mobile: true,
+      width: 412,
+      height: 823,
+      deviceScaleFactor: 1.75,
+      disabled: false,
+    },
+    throttlingMethod: 'simulate',
+    // Le site est servi en local : la latence réseau mesurée n'a aucun sens, seule la
+    // simulation en a. Les valeurs sont celles du préréglage « slow 4G » de Lighthouse.
+    throttling: { rttMs: 150, throughputKbps: 1638.4, cpuSlowdownMultiplier: 4 },
+  },
+}
+
+/**
+ * Lighthouse est instable de quelques points d'une exécution à l'autre. On garde la
+ * **médiane** de plusieurs passes plutôt qu'une mesure unique : un budget qui échoue au
+ * hasard une fois sur cinq se fait désactiver en une semaine.
+ */
+const PASSES = Number(process.env.BUDGET_PASSES ?? 3)
+
+const mediane = (valeurs) => {
+  const triees = [...valeurs].sort((a, b) => a - b)
+  return triees[Math.floor(triees.length / 2)]
+}
+
+/**
+ * Mesure une page et rend `{ id, url, scores, echecs }`.
+ * `echecs` liste les catégories sous leur seuil — vide signifie budget tenu.
+ *
+ * @param {{ page: object, url: string, portDebogage: number }} contexte
+ */
+export async function mesurerPage({ page, url, portDebogage }) {
+  const passes = []
+  for (let index = 0; index < PASSES; index += 1) {
+    const resultat = await lighthouse(
+      url,
+      { port: portDebogage, output: 'json', logLevel: 'error' },
+      CONFIGURATION,
+    )
+    if (!resultat?.lhr) throw new Error(`Lighthouse n'a rien rendu pour ${url}`)
+    passes.push(resultat.lhr)
+  }
+
+  const scores = {}
+  for (const categorie of Object.keys(SEUILS_LIGHTHOUSE)) {
+    const brut = passes.map((lhr) => Math.round((lhr.categories[categorie]?.score ?? 0) * 100))
+    scores[categorie] = mediane(brut)
+  }
+
+  const echecs = Object.entries(SEUILS_LIGHTHOUSE)
+    .filter(([categorie, seuil]) => scores[categorie] < seuil)
+    .map(([categorie, seuil]) => ({ categorie, obtenu: scores[categorie], seuil }))
+
+  // Les audits en échec de la catégorie performance : sans eux, un budget rouge dit
+  // « c'est trop lent » sans jamais dire pourquoi, et personne ne le corrige.
+  const dernier = passes[passes.length - 1]
+  const coupables = Object.values(dernier.audits)
+    .filter(
+      (audit) => audit.score !== null && audit.score < 0.9 && audit.details?.type !== 'debugdata',
+    )
+    .map((audit) => ({ id: audit.id, titre: audit.title, valeur: audit.displayValue ?? '' }))
+    .slice(0, 8)
+
+  return { url, scores, echecs, coupables, page }
+}

--- a/scripts/budgets/pages.mjs
+++ b/scripts/budgets/pages.mjs
@@ -1,0 +1,67 @@
+// pages.mjs — jeromemarichez-fr
+//
+// Ce que les budgets mesurent, et à partir de quel chiffre ils échouent.
+// Source unique : `scripts/budgets.mjs`, la doc et la CI lisent ces valeurs, personne
+// ne les recopie.
+//
+// **Les seuils viennent du `CLAUDE.md`** (« Lighthouse ≥ 95 sur les 4 catégories »),
+// pas d'un arbitrage de confort. Les abaisser pour faire passer un contrôle est
+// explicitement interdit par la règle 8 du `CLAUDE.md` : c'est la page qu'on corrige,
+// jamais le budget. Un budget qu'on rabote ne protège plus de rien.
+
+/**
+ * Seuil minimal, par catégorie Lighthouse. Les quatre catégories sont contrôlées :
+ * une accessibilité à 100 n'excuse pas une performance à 80.
+ */
+export const SEUILS_LIGHTHOUSE = {
+  performance: 95,
+  accessibility: 95,
+  'best-practices': 95,
+  seo: 95,
+}
+
+/**
+ * Niveaux d'impact axe qui font échouer le contrôle. `minor` et `moderate` sont
+ * rapportés mais ne bloquent pas : ce sont souvent des recommandations contextuelles,
+ * et un contrôle qui crie à tout propos finit par être ignoré.
+ */
+export const IMPACTS_BLOQUANTS = ['critical', 'serious']
+
+/**
+ * Règles axe activées : les référentiels WCAG 2.x niveaux A et AA, plus les bonnes
+ * pratiques d'axe. Le RGAA s'appuie sur WCAG AA — mais axe n'en couvre qu'une part
+ * (voir `docs/accessibility.md`) : ce contrôle ne vaut pas audit RGAA.
+ */
+export const ETIQUETTES_AXE = [
+  'wcag2a',
+  'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
+  'wcag22aa',
+  'best-practice',
+]
+
+/**
+ * Les pages mesurées. Trois familles, parce qu'un site ne se juge pas sur son accueil :
+ * les gabarits diffèrent (scène animée, sections de pôle, corps d'article long), et
+ * c'est justement là que les régressions se logent.
+ *
+ * Ajouter un gabarit ici suffit à l'inclure partout — budgets locaux comme CI.
+ */
+export const PAGES = [
+  {
+    id: 'accueil',
+    chemin: '/',
+    pourquoi: 'la scène animée et le verre — le gabarit le plus lourd du site',
+  },
+  {
+    id: 'pole-ingenierie-web',
+    chemin: '/services/ingenierie-web/',
+    pourquoi: 'gabarit de pôle : sections, preuves chiffrées, palette dédiée',
+  },
+  {
+    id: 'article',
+    chemin: '/blog/pourquoi-ce-site-est-un-export-statique/',
+    pourquoi: "gabarit d'article : corps long, typographie, fil d'Ariane, JSON-LD",
+  },
+]

--- a/scripts/budgets/rapport.mjs
+++ b/scripts/budgets/rapport.mjs
@@ -1,0 +1,68 @@
+// rapport.mjs — jeromemarichez-fr
+//
+// Mise en forme des résultats de budget. Un budget qui échoue doit dire **lequel** et
+// **sur quelle page** : un « échec » sans chiffre se contourne, un chiffre se corrige.
+
+import { SEUILS_LIGHTHOUSE } from './pages.mjs'
+
+const CATEGORIES = Object.keys(SEUILS_LIGHTHOUSE)
+const ETIQUETTES = {
+  performance: 'Perf',
+  accessibility: 'A11y',
+  'best-practices': 'Bonnes prat.',
+  seo: 'SEO',
+}
+
+const cadrer = (texte, largeur) => String(texte).padEnd(largeur)
+
+export function afficherTableauLighthouse(resultats) {
+  const largeurId = Math.max(12, ...resultats.map((r) => r.page.id.length))
+  const entete = [cadrer('Page', largeurId), ...CATEGORIES.map((c) => cadrer(ETIQUETTES[c], 12))]
+  console.log(`\n${entete.join(' │ ')}`)
+  console.log('─'.repeat(entete.join(' │ ').length))
+  for (const resultat of resultats) {
+    const cellules = CATEGORIES.map((categorie) => {
+      const score = resultat.scores[categorie]
+      const marque = score < SEUILS_LIGHTHOUSE[categorie] ? '✗' : '✓'
+      return cadrer(`${marque} ${score}`, 12)
+    })
+    console.log([cadrer(resultat.page.id, largeurId), ...cellules].join(' │ '))
+  }
+  console.log(
+    `\nSeuils (CLAUDE.md) : ${CATEGORIES.map((c) => `${ETIQUETTES[c]} ≥ ${SEUILS_LIGHTHOUSE[c]}`).join(', ')}`,
+  )
+}
+
+export function afficherEchecsLighthouse(resultats) {
+  for (const resultat of resultats.filter((r) => r.echecs.length > 0)) {
+    console.log(`\nBudget dépassé — ${resultat.page.id} (${resultat.url})`)
+    for (const echec of resultat.echecs) {
+      console.log(`  ✗ ${ETIQUETTES[echec.categorie]} : ${echec.obtenu} < ${echec.seuil}`)
+    }
+    if (resultat.coupables.length > 0) {
+      console.log('  Audits en échec :')
+      for (const audit of resultat.coupables) {
+        console.log(`    · ${audit.titre}${audit.valeur ? ` — ${audit.valeur}` : ''} (${audit.id})`)
+      }
+    }
+  }
+}
+
+export function afficherAxe(resultats) {
+  console.log('\nAccessibilité — axe-core (part mécanisable de WCAG AA, pas un audit RGAA)')
+  for (const resultat of resultats) {
+    const bloquantes = resultat.bloquantes.length
+    const mineures = resultat.mineures.length
+    const marque = bloquantes === 0 ? '✓' : '✗'
+    console.log(
+      `  ${marque} ${resultat.url} — ${bloquantes} bloquante(s), ${mineures} mineure(s)/modérée(s)`,
+    )
+    for (const violation of [...resultat.bloquantes, ...resultat.mineures]) {
+      const gravite = resultat.bloquantes.includes(violation) ? '✗' : '·'
+      console.log(
+        `      ${gravite} [${violation.impact}] ${violation.regle} : ${violation.description}` +
+          ` — ${violation.occurrences} occurrence(s), ex. ${violation.exemple}`,
+      )
+    }
+  }
+}

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -1,109 +1,25 @@
 // e2e.mjs — jeromemarichez-fr
 //
 // Harnais des tests e2e (cible `make test-e2e`), en local comme dans `ci-main-e2e`.
-// Le site étant en export statique (`output: 'export'`), la « stack » se réduit à
-// servir `out/` : ni back, ni route API, ni serveur applicatif.
+// Toute la mécanique — construire l'export si besoin, servir `out/`, sonder le port,
+// arrêter proprement sur signal — vit dans `scripts/harnais-statique.mjs`, partagé avec
+// les budgets de performance et d'accessibilité (`scripts/budgets.mjs`).
 //
-//   1. construit l'export statique s'il manque (`npm run build`) ;
-//   2. sert `out/` sur E2E_PORT (4173 par défaut), avec les règles de `docker/nginx.conf` ;
-//   3. attend que le port RÉPONDE vraiment (sonde HTTP, pas un `sleep`) ;
-//   4. lance `cypress run` ;
-//   5. arrête le serveur quoi qu'il arrive — succès, échec ou interruption — et sort
-//      avec le code de Cypress, jamais un autre.
+// Ici, il ne reste que ce qui est propre à Cypress.
 //
 //   node scripts/e2e.mjs      (ou : make test-e2e)
+//   node scripts/e2e.mjs --spec tests/e2e/fumee.cy.ts
 
-import { spawn } from 'node:child_process'
-import { access } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { demarrerServeurStatique, PORT_PAR_DEFAUT } from './serve-out.mjs'
-
-const RACINE = join(dirname(fileURLToPath(import.meta.url)), '..')
-const DOSSIER_EXPORT = join(RACINE, 'out')
-const PORT = Number(process.env.E2E_PORT ?? PORT_PAR_DEFAUT)
-const DELAI_SONDE_MS = 30_000
-
-const existe = (chemin) =>
-  access(chemin).then(
-    () => true,
-    () => false,
-  )
-
-/** Exécute une commande en héritant des flux, et résout son code de sortie. */
-function executer(commande, arguments_, env = {}) {
-  return new Promise((ok, ko) => {
-    const enfant = spawn(commande, arguments_, {
-      cwd: RACINE,
-      stdio: 'inherit',
-      env: { ...process.env, ...env },
-      shell: process.platform === 'win32',
-    })
-    enfant.once('error', ko)
-    enfant.once('close', (code, signal) => ok(signal ? 1 : (code ?? 1)))
-  })
-}
-
-/**
- * Attend que le serveur réponde réellement sur `/`. Un port en écoute ne suffit pas :
- * on veut une réponse HTTP, sinon Cypress démarre sur un serveur qui n'est pas prêt.
- */
-async function attendreReponse(url) {
-  const limite = Date.now() + DELAI_SONDE_MS
-  let derniereErreur
-  while (Date.now() < limite) {
-    try {
-      const reponse = await fetch(url, { redirect: 'manual' })
-      if (reponse.status < 500) return reponse.status
-    } catch (erreur) {
-      derniereErreur = erreur
-    }
-    await new Promise((ok) => setTimeout(ok, 200))
-  }
-  throw new Error(
-    `Le serveur statique n'a pas répondu sur ${url} en ${DELAI_SONDE_MS} ms` +
-      (derniereErreur ? ` (${derniereErreur.message})` : ''),
-  )
-}
-
-async function main() {
-  if (!(await existe(join(DOSSIER_EXPORT, 'index.html')))) {
-    console.log('Export statique absent : construction (`npm run build`)…')
-    const code = await executer('npm', ['run', 'build'])
-    if (code !== 0) throw new Error(`Le build a échoué (code ${code})`)
-  }
-
-  const { serveur, url } = await demarrerServeurStatique({ racine: DOSSIER_EXPORT, port: PORT })
-  const arreter = () => {
-    serveur.closeAllConnections?.()
-    return new Promise((ok) => serveur.close(ok))
-  }
-  // Interruption clavier ou signal CI : on ne laisse jamais le serveur orphelin.
-  const surSignal = () => {
-    arreter().then(() => process.exit(130))
-  }
-  process.once('SIGINT', surSignal)
-  process.once('SIGTERM', surSignal)
-
-  try {
-    const statut = await attendreReponse(`${url}/`)
-    console.log(`Export statique servi sur ${url} (GET / → ${statut}) — lancement de Cypress.`)
-    // Les arguments supplémentaires sont transmis tels quels à Cypress
-    // (ex. `node scripts/e2e.mjs --spec tests/e2e/fumee.cy.ts`).
-    return await executer('npx', ['cypress', 'run', ...process.argv.slice(2)], {
-      E2E_PORT: String(PORT),
-    })
-  } finally {
-    await arreter()
-    console.log('Serveur statique arrêté.')
-  }
-}
+import { avecSiteServi, executer, lancer } from './harnais-statique.mjs'
 
 // Le code de sortie du harnais est celui de Cypress : aucun échec n'est absorbé.
-main().then(
-  (code) => process.exit(code),
-  (erreur) => {
-    console.error(`Harnais e2e : ${erreur instanceof Error ? erreur.message : erreur}`)
-    process.exit(1)
-  },
+lancer('e2e', () =>
+  avecSiteServi(({ url, port }) => {
+    console.log(`Lancement de Cypress contre ${url}.`)
+    // Les arguments supplémentaires sont transmis tels quels à Cypress
+    // (ex. `node scripts/e2e.mjs --spec tests/e2e/fumee.cy.ts`).
+    return executer('npx', ['cypress', 'run', ...process.argv.slice(2)], {
+      E2E_PORT: String(port),
+    })
+  }),
 )

--- a/scripts/harnais-statique.mjs
+++ b/scripts/harnais-statique.mjs
@@ -1,0 +1,137 @@
+// harnais-statique.mjs — jeromemarichez-fr
+//
+// Socle commun à tout contrôle qui a besoin du site **réellement servi** : tests e2e
+// (`scripts/e2e.mjs`) et budgets de performance / accessibilité (`scripts/budgets.mjs`).
+//
+// Le site étant en export statique (`output: 'export'`), la « stack » se réduit à servir
+// `out/`. Le harnais :
+//
+//   1. construit l'export statique s'il manque (`npm run build`) ;
+//   2. sert `out/` avec les règles de résolution de `docker/nginx.conf` (serve-out.mjs) ;
+//   3. attend que le port RÉPONDE vraiment (sonde HTTP, jamais un `sleep`) ;
+//   4. exécute le travail demandé ;
+//   5. arrête le serveur quoi qu'il arrive — succès, échec ou signal — et laisse
+//      remonter le code de sortie du travail, jamais un autre.
+//
+// Un seul endroit sait démarrer et arrêter le site : deux harnais concurrents finiraient
+// par diverger sur le port, la sonde ou le nettoyage, et c'est toujours le second qui
+// laisse un serveur orphelin en CI.
+
+import { spawn } from 'node:child_process'
+import { access } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { demarrerServeurStatique, PORT_PAR_DEFAUT } from './serve-out.mjs'
+
+export const RACINE = join(dirname(fileURLToPath(import.meta.url)), '..')
+export const DOSSIER_EXPORT = join(RACINE, 'out')
+
+const DELAI_SONDE_MS = 30_000
+
+const existe = (chemin) =>
+  access(chemin).then(
+    () => true,
+    () => false,
+  )
+
+/** Exécute une commande en héritant des flux, et résout son code de sortie. */
+export function executer(commande, arguments_, env = {}) {
+  return new Promise((ok, ko) => {
+    const enfant = spawn(commande, arguments_, {
+      cwd: RACINE,
+      stdio: 'inherit',
+      env: { ...process.env, ...env },
+      shell: process.platform === 'win32',
+    })
+    enfant.once('error', ko)
+    enfant.once('close', (code, signal) => ok(signal ? 1 : (code ?? 1)))
+  })
+}
+
+/**
+ * Attend que le serveur réponde réellement sur `/`. Un port en écoute ne suffit pas :
+ * on veut une réponse HTTP, sinon le contrôle démarre sur un serveur qui n'est pas prêt
+ * et échoue pour la mauvaise raison.
+ */
+async function attendreReponse(url) {
+  const limite = Date.now() + DELAI_SONDE_MS
+  let derniereErreur
+  while (Date.now() < limite) {
+    try {
+      const reponse = await fetch(url, { redirect: 'manual' })
+      if (reponse.status < 500) return reponse.status
+    } catch (erreur) {
+      derniereErreur = erreur
+    }
+    await new Promise((ok) => setTimeout(ok, 200))
+  }
+  throw new Error(
+    `Le serveur statique n'a pas répondu sur ${url} en ${DELAI_SONDE_MS} ms` +
+      (derniereErreur ? ` (${derniereErreur.message})` : ''),
+  )
+}
+
+/** Construit l'export statique s'il manque. Lève si le build échoue. */
+export async function construireSiNecessaire() {
+  if (await existe(join(DOSSIER_EXPORT, 'index.html'))) return
+  console.log('Export statique absent : construction (`npm run build`)…')
+  const code = await executer('npm', ['run', 'build'])
+  if (code !== 0) throw new Error(`Le build a échoué (code ${code})`)
+}
+
+/**
+ * Construit si besoin, sert `out/`, attend une vraie réponse HTTP, puis exécute
+ * `travail({ url, port })`. Le serveur est arrêté dans tous les cas.
+ *
+ * @param {(contexte: { url: string, port: number }) => Promise<number>} travail
+ * @param {{ port?: number }} options
+ * @returns {Promise<number>} le code de sortie rendu par `travail`
+ */
+export async function avecSiteServi(
+  travail,
+  { port = Number(process.env.E2E_PORT ?? PORT_PAR_DEFAUT) } = {},
+) {
+  await construireSiNecessaire()
+
+  const {
+    serveur,
+    url,
+    port: attribue,
+  } = await demarrerServeurStatique({
+    racine: DOSSIER_EXPORT,
+    port,
+  })
+  const arreter = () => {
+    serveur.closeAllConnections?.()
+    return new Promise((ok) => serveur.close(ok))
+  }
+  // Interruption clavier ou signal CI : on ne laisse jamais le serveur orphelin.
+  const surSignal = () => {
+    arreter().then(() => process.exit(130))
+  }
+  process.once('SIGINT', surSignal)
+  process.once('SIGTERM', surSignal)
+
+  try {
+    const statut = await attendreReponse(`${url}/`)
+    console.log(`Export statique servi sur ${url} (GET / → ${statut}).`)
+    return await travail({ url, port: attribue })
+  } finally {
+    await arreter()
+    console.log('Serveur statique arrêté.')
+  }
+}
+
+/**
+ * Point d'entrée commun d'un script de contrôle : exécute `main`, sort avec son code,
+ * et transforme toute exception en code 1 avec un message préfixé.
+ */
+export function lancer(nom, main) {
+  main().then(
+    (code) => process.exit(code),
+    (erreur) => {
+      console.error(`Harnais ${nom} : ${erreur instanceof Error ? erreur.message : erreur}`)
+      process.exit(1)
+    },
+  )
+}


### PR DESCRIPTION
Closes #25

Les deux promesses que le site affiche — **Lighthouse ≥ 95 sur les quatre catégories** et
**accessibilité WCAG AA** — étaient écrites dans le `CLAUDE.md` et le `README`, mais rien
ne les mesurait. `make budgets` échoue désormais quand le site descend sous le seuil, et
dit **quelle page** sur **quelle catégorie**.

## Chiffres réellement mesurés

Export de `dev` (`596aafd`), médiane de 3 passes Lighthouse, profil mobile émulé + réseau
bridé « slow 4G » + CPU ×4 (le profil par défaut de PageSpeed Insights).

| Page | Perf | A11y | Bonnes prat. | SEO |
|------|------|------|--------------|-----|
| accueil | **80** ✗ | 100 ✓ | 100 ✓ | 100 ✓ |
| pôle `ingenierie-web` | **81** ✗ | 100 ✓ | 100 ✓ | 100 ✓ |
| article | **82** ✗ | 100 ✓ | 100 ✓ | 100 ✓ |

axe-core : **0 violation** sur les trois pages, à tous les niveaux d'impact.

### Ce qui ne passe pas : la performance mobile

Le seuil n'a pas été abaissé et aucune page n'a été retirée de la liste. Le budget est
rouge, et c'est son travail.

Le profil est identique sur les trois pages et sans ambiguïté :

| Métrique | Accueil | Pôle |
|----------|---------|------|
| First Contentful Paint | 1,7 s | 1,4 s |
| Speed Index | 1,7 s | 1,4 s |
| Total Blocking Time | 20 ms | 20 ms |
| Cumulative Layout Shift | 0 | 0 |
| **Largest Contentful Paint** | **5,3 s** | **5,0 s** |

Tout est excellent sauf le LCP, qui arrive **3,5 s après** un premier rendu déjà rapide.
Ce n'est ni du JS bloquant (TBT à 20 ms) ni de la mise en page (CLS à 0) : c'est du
**transfert**. Le relevé réseau le confirme — le HTML de l'accueil pèse **120 Kio servis
sans compression**, plus deux `woff2` de 67 et 49 Kio sur le chemin critique. Sur un lien
à 200 Kio/s, ces 236 Kio coûtent à eux seuls plus d'une seconde.

**Ce n'est pas un artefact du harnais.** `docker/nginx.conf` ne déclare aucune directive
`gzip`, et `nginx:alpine` la laisse commentée par défaut : **la production sert elle aussi
120 Kio de HTML non compressé**. C'est le premier levier, et c'est une correction de
configuration de service.

Pour situer : en profil **desktop** non bridé, les mêmes pages sortent à
**99 / 100 / 100 / 100**. Le site n'est pas lent dans l'absolu — il l'est sur un mobile en
4G médiocre, ce qui est précisément le cas qui compte.

Diagnostic complet et backlog : `docs/ameliorations.md`. **Le correctif n'est pas dans
cette PR** : il touche la configuration de production et sort du périmètre du lot qui rend
les budgets exécutables. C'est le budget qui l'a mis au jour, le jour de sa mise en
service.

## Arbitrage à trancher — `ci-main-budgets` sera rouge

Conséquence directe : le job `ci-main-budgets` échouera sur la prochaine PR `dev → main`
tant que la performance mobile n'est pas corrigée. C'est le comportement attendu d'un
garde-fou, mais c'est un blocage de production sur une condition préexistante, donc une
décision qui revient à Jérôme MARICHEZ :

1. corriger la compression avant la prochaine mise en production (lot dédié, effort
   faible) — recommandé ;
2. ou faire précéder cette PR du lot compression.

Aucune troisième option n'a été retenue : abaisser le seuil, exempter une catégorie ou
conditionner le job sont interdits par la règle 8.

## Ce qui a été fait

- **`scripts/harnais-statique.mjs`** — la mécanique commune (construire l'export s'il
  manque, servir `out/` via `serve-out.mjs`, sonder le port par une vraie requête HTTP,
  arrêter proprement sur `SIGINT`/`SIGTERM`) est **extraite de `scripts/e2e.mjs`** et
  partagée. Aucun second harnais n'a été écrit : `e2e.mjs` se réduit désormais à ce qui
  est propre à Cypress, et le comportement e2e est inchangé.
- **`scripts/budgets/pages.mjs`** — source unique des pages mesurées et des seuils, repris
  du `CLAUDE.md`.
- **`scripts/budgets/mesure-lighthouse.mjs`** — mobile bridé, médiane de 3 passes (la
  variance de Lighthouse rendrait un budget mono-passe non crédible), et la liste des
  audits fautifs pour qu'un rouge soit actionnable.
- **`scripts/budgets/mesure-axe.mjs`** — axe-core, étiquettes WCAG 2.0/2.1/2.2 A + AA ;
  échec sur impact `critical` ou `serious`.
- **`scripts/budgets/rapport.mjs`** — tableau et détail des échecs.
- **Cibles Make** : `make budgets`, `make budget-perf`, `make budget-a11y`.
- **Docs** : `docs/testing.md`, `docs/ci-cd.md`, `docs/accessibility.md`,
  `docs/ameliorations.md`.
- **Version** : `0.2.0` → `0.3.0` (SemVer, fonctionnalité).

### Trois gabarits, pas seulement l'accueil

Accueil (scène animée, verre — le gabarit le plus lourd), page de pôle (sections, preuves,
palette dédiée), page d'article (corps long, typographie, fil d'Ariane, JSON-LD). Un
gabarit non mesuré est un gabarit non protégé.

## CI — où le contrôle tourne, et pourquoi

La convention du dépôt est `ci-dev-*` = rapide et à chaque PR, `ci-main-*` = complet avant
production. Elle est suivie, en **séparant les deux contrôles selon leur coût** :

- **`ci-dev-a11y`** (PR → `dev`) — axe seul, ~2 min. Une régression d'accessibilité vient
  presque toujours d'un changement de balisage : elle se corrige cent fois moins cher le
  jour où elle est écrite qu'à la mise en production. Le prix est payable à chaque PR.
- **`ci-main-budgets`** (PR → `main` + `workflow_dispatch`) — axe **et** Lighthouse. Trois
  passes par page, et la variance impose la répétition. Le payer à chaque PR vers `dev`
  taxerait tout le monde pour une métrique qui bouge rarement d'un commit à l'autre ; le
  placer sur la PR de production le met là où la question se pose. Le
  `workflow_dispatch` évite qu'il soit *tardif* : la mesure se lance à la demande depuis
  `dev`, sans attendre la PR de production.

Aucun `continue-on-error`, aucun `allow_failure`, aucun `|| true`, aucun `if:` de
contournement.

## Accessibilité — ce que ce contrôle ne dit pas

Écrit noir sur blanc dans `docs/accessibility.md` : **axe ne vaut pas un audit RGAA.** Il
couvre la part mécanisable de WCAG — Deque annonce ~57 %, la pratique retient plutôt un
tiers. Un `make budget-a11y` vert ne signifie pas que le site est conforme, et le site ne
doit nulle part le laisser entendre.

Restent explicitement à la charge de l'audit manuel : pertinence des alternatives
textuelles et des intitulés de liens, ordre de lecture, utilisabilité clavier réelle,
**focus visible**, **`prefers-reduced-motion`**, **WCAG 2.2.2 (pause des animations)** —
axe ne teste aucun des trois — et les **contrastes de la palette à quatre pôles**, dont
les seize valeurs sont mesurées à la main dans `design.md` (`--accent-vif` y est déclaré
non-texte uniquement ; axe ne peut pas connaître cette intention).

## Dépendances ajoutées

`lighthouse@13.4.1` (GoogleChrome), `puppeteer@25.8.0` (puppeteer), `@axe-core/puppeteer@4.13.0`
(dequelabs) — toutes en `devDependencies`. Les trois passent le hook
`check-new-dependency.sh` : SemVer conforme, dépôt GitHub déclaré, publication de moins de
six mois, plus de trois contributeurs. `chrome-launcher` a été **écarté** volontairement
(dernière publication en septembre 2025, > 6 mois) : Chrome est lancé par puppeteer, et
Lighthouse s'y connecte par le port de débogage.

Prérequis local, une fois : `npx puppeteer browsers install chrome`. Les workflows le font
explicitement, un cache npm restauré pouvant sauter le postinstall.

## Tests — aucun fichier de test écrit

Conformément à la règle, aucun fichier de `tests/` n'a été créé. Les scripts de mesure ne
sont pas des tests au sens du projet : ils ne décrivent pas un comportement du code, ils
mesurent une propriété du site rendu. Ils vivent donc dans `scripts/budgets/`.

Deux intentions de test utiles ont été identifiées, **à poser par Jérôme MARICHEZ** :

**1. Unitaire — `tests/unitaire/budgets-verdict.spec.ts`**
Intention : le verdict d'un budget ne se relâche jamais silencieusement.
Comportement : une fonction pure de verdict, extraite de `mesure-lighthouse.mjs`, qui
prend `(scores, seuils)` et rend la liste des catégories en échec.
Cas limites : score **exactement égal** au seuil → tenu (`<` et non `<=`) ; score à
`seuil - 1` → échec nommé ; catégorie absente des scores → traitée comme 0, pas comme
tenue (un audit qui n'a pas tourné ne vaut pas un succès) ; les **quatre** catégories sont
évaluées, pas seulement la performance.
Jeu de données : `tests/fixtures/budget-scores.fixture.json`, que je peux préparer — un
jeu de données n'est pas un test.
*Ce test demande d'extraire d'abord la fonction de verdict ; l'extraction n'a pas été
faite dans cette PR pour ne pas poser du code qu'aucun test ne couvre encore.*

**2. Système — `tests/systeme/budgets-pages.test.ts`**
Intention : toute page listée dans `scripts/budgets/pages.mjs` existe réellement dans
l'export. Un chemin mal orthographié ferait mesurer une 404, qui score très bien.
Comportement : pour chaque entrée de `PAGES`, un `GET` sur l'export servi rend **200** et
un HTML non vide.
Cas limite : le slug d'article référencé disparaît d'une publication → le test échoue et
désigne la page à mettre à jour, au lieu d'un budget vert sur une page d'erreur.

## Vérifications

`make lint`, `make type-check` et `make build` verts. `make budgets` reproduit les chiffres
ci-dessus.

⚠️ `package.json` / `package-lock.json` sont touchés (ajout des trois devDependencies +
bump de version) : conflit possible avec le lot « verre » en cours, résolution triviale.
