### PR TITLE
fix: compresser le HTML en production, le budget de performance passe

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -9,6 +9,63 @@ server {
   # `trailingSlash: true` : chaque route est un dossier portant un `index.html`.
   index index.html;
 
+  # --- Compression -----------------------------------------------------------
+  #
+  # `nginx:alpine` livre `gzip` **commenté** : sans ce bloc, le site part en clair.
+  # C'est ce qui coûtait 15 points de performance mobile (LCP à 5,3 s pour un FCP à
+  # 1,7 s : du transfert, pas du calcul). L'accueil pèse 120 Kio de HTML et tombe à
+  # 22 Kio compressé — 81 % de moins sur le chemin critique.
+  #
+  # `gzip` et pas `brotli` : le module `ngx_brotli` n'est pas dans l'image officielle,
+  # l'ajouter imposerait de compiler nginx nous-mêmes. L'écart brotli/gzip sur du HTML
+  # est de l'ordre de 15 % — il ne justifie pas, aujourd'hui, une image maison à
+  # maintenir. Le jour où elle existe pour une autre raison, brotli s'y ajoute.
+  gzip on;
+
+  # Niveau 6, mesuré et non repris d'un billet de blog : sur l'`index.html` de
+  # l'accueil, le niveau 6 rend 22 226 octets et le niveau 9 en rend 22 092 — 134
+  # octets de mieux (0,6 %) pour environ deux fois le temps CPU. Le gain se joue entre
+  # 1 et 6 ; au-delà on paie de la latence serveur pour rien.
+  gzip_comp_level 6;
+
+  # En deçà de 1 Kio, compresser ne rapporte plus : l'en-tête gzip et les tables de
+  # Huffman coûtent quelques dizaines d'octets, et une réponse aussi petite tient de
+  # toute façon dans la première fenêtre de congestion — elle arrive dans le même
+  # aller-retour, compressée ou non. Le défaut de nginx (20 octets) fait le contraire.
+  gzip_min_length 1024;
+
+  # Une même URL peut désormais répondre en clair ou compressé selon
+  # `Accept-Encoding` : sans `Vary`, un cache intermédiaire servirait du gzip à un
+  # client qui ne l'a pas demandé.
+  gzip_vary on;
+
+  # Par défaut nginx refuse de compresser une réponse relayée à un proxy. Le site est
+  # destiné à vivre derrière un reverse proxy / CDN : sans cette ligne, la compression
+  # s'éteindrait justement en production.
+  gzip_proxied any;
+
+  # `text/html` est **toujours** compressé par nginx et ne se déclare pas ici (le
+  # répéter ne ferait qu'émettre un avertissement au démarrage).
+  #
+  # La liste ne retient que ce qui se comprime vraiment : texte et formats textuels.
+  # Les `woff2`, PNG, WebP et AVIF en sont **volontairement absents** — ils sont déjà
+  # compressés à la source, les repasser au gzip brûle du CPU pour gagner ~0 % et
+  # parfois grossir la réponse. Les deux polices du chemin critique (67 et 49 Kio)
+  # relèvent d'un autre levier, pas de celui-ci.
+  gzip_types
+    text/css
+    text/plain
+    text/xml
+    text/javascript
+    application/javascript
+    application/json
+    application/manifest+json
+    application/xml
+    application/rss+xml
+    application/atom+xml
+    image/svg+xml;
+  # ---------------------------------------------------------------------------
+
   # Les assets versionnés par Next sont immuables : leur nom change à chaque build.
   location /_next/static/ {
     add_header Cache-Control "public, max-age=31536000, immutable";

--- a/docs/ameliorations.md
+++ b/docs/ameliorations.md
@@ -5,8 +5,8 @@ le bénéfice attendu et l'effort estimé.
 
 | # | Amélioration | Bénéfice | Effort | Statut |
 |---|--------------|----------|--------|--------|
-| 1 | Compression du HTML et des polices en production (`gzip`/`brotli` dans `docker/nginx.conf`) | Budget de performance mobile : premier levier, de loin | faible | **identifié, non fait** |
-| 2 | Stratégie de chargement des polices (sous-ensemble, `preload`, `size-adjust`) | LCP mobile | moyen | proposé |
+| 1 | Compression du HTML en production (`gzip` dans `docker/nginx.conf`) | Budget de performance mobile : premier levier, de loin | faible | **fait** (issue #76) — 80/81/82 → 96/97/97 |
+| 2 | Stratégie de chargement des polices (sous-ensemble, `preload`, `size-adjust`) | LCP mobile | moyen | proposé — **c'est là que se joue désormais la marge** (voir plus bas) |
 | 3 | Réduction du JavaScript inutilisé (~153 Kio) et du JavaScript hérité (~43 Kio) | Budget de performance mobile | moyen | proposé |
 | 4 | Préchargement RSC de toutes les routes de pôle depuis l'accueil | Bande passante mobile après le LCP | faible | proposé |
 
@@ -51,3 +51,34 @@ c'est justement le budget qui l'a mis au jour, le jour de sa mise en service.
 En profil **desktop** non bridé, les mêmes pages sortent à **99 / 100 / 100 / 100** : le
 site n'est pas lent dans l'absolu, il l'est sur un mobile en 4G médiocre. C'est le cas
 qui compte, et c'est celui que le budget mesure.
+
+## Résultat — compression activée le 2026-08-22 (issue #76)
+
+Le diagnostic ci-dessus est confirmé jusqu'au bout : c'était bien du transfert, et rien
+d'autre. `gzip` déclaré dans `docker/nginx.conf` — réglages et justifications dans
+[docker](./docker.md#compression) — suffit à faire passer les trois pages.
+
+| Page | Perf avant | Perf après | A11y | Bonnes prat. | SEO |
+|------|-----------|-----------|------|--------------|-----|
+| accueil | 80 | **96** | 100 | 100 | 100 |
+| `/services/ingenierie-web/` | 81 | **97** | 100 | 100 | 100 |
+| article de blog | 82 | **97** | 100 | 100 | 100 |
+
+L'`index.html` de l'accueil passe de **119 998 à 22 215 octets sur le fil — 81 % de
+moins**. Aucune ligne de code applicatif n'a bougé, aucun composant n'a été supprimé,
+aucune police n'a été touchée : le site était correctement construit, il était mal
+servi. C'est le genre de défaut qu'aucune revue de code ne trouve et qu'une mesure
+trouve le premier jour.
+
+**Ce que la mesure ne dit pas encore.** Le budget est tenu, mais la marge de l'accueil
+est d'**un point**. Les deux `woff2` du chemin critique (67 et 49 Kio) n'ont pas bougé —
+ils sont déjà compressés à la source et le gzip ne les touche pas, à dessein. Ils
+restent donc le premier poste du chemin critique, et c'est la piste 2 qui porte la
+marge suivante, pas la piste 3.
+
+Les polices n'ont **pas** été retouchées ici, et c'est délibéré : Fraunces et Inter sont
+un choix de design documenté dans [design](./design.md#typographie), déjà réduit au
+strict nécessaire (variable, sous-ensemble latin, axe `opsz` seul depuis le retrait de
+`SOFT` et `WONK`, registre monospace confié à la pile système). Alléger davantage
+suppose d'arbitrer sur le dessin — `preload` sélectif, `size-adjust`, sous-ensemble de
+glyphes — et cet arbitrage revient à Jérôme MARICHEZ, pas à un lot de performance.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,13 +33,49 @@ make docker-down        # arrêt
 |---------|-------|------|-------|
 | `app` | `./Dockerfile` | `${APP_PORT:-3000}` → `80` | `npm ci && npm run build`, puis `nginx:1.29-alpine` sert `out/` |
 
-Configuration nginx : [`docker/nginx.conf`](../docker/nginx.conf). Deux règles y comptent :
+Configuration nginx : [`docker/nginx.conf`](../docker/nginx.conf). Trois règles y comptent :
 
 - `trailingSlash: true` fait sortir chaque route en `<route>/index.html`, que la directive
   `index` résout nativement — **aucune règle de réécriture à tenir**.
 - Les assets de `/_next/static/` sont immuables (leur nom change à chaque build) et
   portent `max-age=31536000, immutable` ; le HTML porte `max-age=0, must-revalidate`,
   sans quoi une mise en production resterait invisible pour les visiteurs déjà venus.
+- **La compression est déclarée explicitement** — voir ci-dessous.
+
+## Compression
+
+`nginx:alpine` livre la directive `gzip` **commentée**. Tant qu'on ne la déclare pas,
+le site part en clair : l'accueil sortait en **120 Kio de HTML brut**, ce qui coûtait
+15 points de performance mobile aux budgets (LCP à 5,3 s pour un FCP à 1,7 s — du
+transfert, pas du calcul). Une configuration nginx qu'on ne complète pas est une
+configuration qui ne compresse pas ; ça ne se voit pas en desktop, et ça se paie
+intégralement en 4G.
+
+| Réglage | Valeur | Pourquoi cette valeur |
+|---------|--------|-----------------------|
+| `gzip_comp_level` | `6` | Mesuré, pas recopié : sur l'`index.html` de l'accueil, le niveau 6 rend 22 226 octets, le niveau 9 en rend 22 092 — **134 octets de mieux (0,6 %) pour environ deux fois le temps CPU**. Le gain se joue entre 1 et 6. |
+| `gzip_min_length` | `1024` | En deçà de 1 Kio, l'en-tête gzip et les tables de Huffman mangent le gain, et la réponse tient de toute façon dans la première fenêtre de congestion : elle arrive dans le même aller-retour, compressée ou non. Le défaut de nginx (20 octets) fait l'inverse. |
+| `gzip_vary` | `on` | Une même URL répond désormais en clair ou compressé selon `Accept-Encoding` : sans `Vary`, un cache intermédiaire servirait du gzip à un client qui ne l'a pas demandé. |
+| `gzip_proxied` | `any` | Par défaut nginx refuse de compresser une réponse relayée à un proxy. Le site est destiné à vivre derrière un reverse proxy / CDN : sans cette ligne, la compression s'éteindrait justement en production. |
+| `gzip_types` | texte + `image/svg+xml` | `text/html` est **toujours** compressé par nginx et ne se déclare pas. Les `woff2`, PNG, WebP et AVIF sont **volontairement absents** : déjà compressés à la source, les repasser au gzip brûle du CPU pour ~0 % de gain, parfois pour grossir la réponse. |
+
+**gzip et pas brotli** : le module `ngx_brotli` n'est pas dans l'image officielle, et
+l'ajouter imposerait de compiler nginx nous-mêmes. L'écart brotli/gzip sur du HTML est
+de l'ordre de 15 % — il ne justifie pas, aujourd'hui, une image maison à maintenir. Le
+jour où elle existe pour une autre raison, brotli s'y ajoute.
+
+### Le harnais de mesure reflète cette configuration
+
+[`scripts/serve-out.mjs`](../scripts/serve-out.mjs) — le serveur qu'utilisent les tests
+e2e et `make budgets` — reproduit ces réglages : mêmes types, même seuil, même niveau,
+même `Vary`.
+
+**Le sens de la dépendance est fixe et ne s'inverse jamais : `docker/nginx.conf`
+décide, le harnais reflète.** Un harnais qui compresserait sans que la production
+compresse annoncerait une performance que le visiteur ne reçoit pas — c'est un truquage
+de la mesure au sens de la règle 8 du `CLAUDE.md`. L'inverse (harnais en clair,
+production compressée) condamne un site qui va bien. Toute évolution des réglages
+commence donc par `docker/nginx.conf`.
 
 <!-- TODO : ajouter ici les services d'infrastructure (base de données, cache…)
      au fur et à mesure, avec leurs volumes. -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {

--- a/scripts/serve-out.mjs
+++ b/scripts/serve-out.mjs
@@ -4,12 +4,21 @@
 // règles de résolution que `docker/nginx.conf` en production :
 //
 //   try_files $uri $uri/ =404 ; index index.html ; error_page 404 /404.html
+//   gzip on ; gzip_comp_level 6 ; gzip_min_length 1024 ; gzip_vary on ; gzip_types …
 //
 // C'est indispensable : `trailingSlash: true` fait sortir chaque route en
 // `<route>/index.html`. Un serveur qui ne résout pas un dossier vers son `index.html`
 // renverrait une 404 trompeuse et ferait échouer les specs pour la mauvaise raison.
 //
-// Zéro dépendance : `node:http` suffit, l'export n'a ni back, ni route API.
+// La compression relève de la même exigence, en plus sensible : ce serveur est ce que
+// `make budgets` mesure. S'il compressait sans que nginx compresse, la mesure
+// annoncerait une performance que le visiteur ne reçoit pas ; s'il ne compresse pas
+// alors que nginx compresse, elle condamne un site qui va bien. Le sens de la
+// dépendance est fixe et ne s'inverse jamais : **`docker/nginx.conf` décide, ce
+// fichier le reflète.** Toute évolution des réglages commence là-bas.
+//
+// Zéro dépendance : `node:http` et `node:zlib` suffisent, l'export n'a ni back, ni
+// route API.
 //
 //   node scripts/serve-out.mjs [port]      (par défaut : E2E_PORT ou 4173)
 //
@@ -20,6 +29,7 @@ import { stat } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { dirname, extname, join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { createGzip } from 'node:zlib'
 
 export const PORT_PAR_DEFAUT = Number(process.env.E2E_PORT ?? 4173)
 
@@ -47,6 +57,55 @@ const TYPES = {
 
 const typeDe = (chemin) => TYPES[extname(chemin).toLowerCase()] ?? 'application/octet-stream'
 
+/**
+ * Types compressés à la volée. Miroir de `gzip_types` dans `docker/nginx.conf`, plus
+ * `text/html` que nginx compresse d'office sans qu'on ait à le déclarer.
+ *
+ * Les `woff2` et les images en sont absents des deux côtés : déjà compressés à la
+ * source, les repasser au gzip coûte du CPU pour ~0 % de gain.
+ */
+const TYPES_COMPRESSIBLES = new Set([
+  'text/html',
+  'text/css',
+  'text/plain',
+  'text/xml',
+  'text/javascript',
+  'application/javascript',
+  'application/json',
+  'application/manifest+json',
+  'application/xml',
+  'application/rss+xml',
+  'application/atom+xml',
+  'image/svg+xml',
+])
+
+/** `gzip_comp_level 6` — voir la justification mesurée dans `docker/nginx.conf`. */
+const NIVEAU_GZIP = 6
+
+/** `gzip_min_length 1024` — en deçà, l'en-tête gzip mange le gain. */
+const TAILLE_MINIMALE_GZIP = 1024
+
+/** Le type sans ses paramètres : `text/html; charset=utf-8` → `text/html`. */
+const typeNu = (type) => type.split(';')[0].trim().toLowerCase()
+
+/**
+ * Le client accepte-t-il gzip ? Lecture volontairement stricte de `Accept-Encoding` :
+ * un `gzip;q=0` est un refus explicite, et le prendre pour un accord servirait un
+ * corps illisible à un client qui avait pris la peine de le dire.
+ */
+function accepteGzip(enTeteAcceptEncoding) {
+  if (!enTeteAcceptEncoding) return false
+  return enTeteAcceptEncoding
+    .split(',')
+    .map((piece) => piece.trim().toLowerCase())
+    .some((piece) => {
+      const [codage, ...parametres] = piece.split(';').map((p) => p.trim())
+      if (codage !== 'gzip' && codage !== '*') return false
+      const q = parametres.find((p) => p.startsWith('q='))
+      return !q || Number(q.slice(2)) > 0
+    })
+}
+
 /** Chemin d'un fichier existant, ou `null`. */
 async function fichierExistant(chemin) {
   try {
@@ -69,9 +128,38 @@ async function resoudre(racine, cheminUrl) {
   return (await fichierExistant(cible)) ?? (await fichierExistant(join(cible, 'index.html')))
 }
 
-function envoyer(reponse, statut, fichier, enTetes = {}) {
-  reponse.writeHead(statut, { 'Content-Type': typeDe(fichier), ...enTetes })
-  createReadStream(fichier).pipe(reponse)
+/**
+ * Décide de la compression exactement comme nginx : le client doit l'accepter, le type
+ * doit figurer dans la liste, et la réponse doit peser au moins `gzip_min_length`.
+ */
+async function doitCompresser(requete, fichier, type) {
+  if (!accepteGzip(requete.headers['accept-encoding'])) return false
+  if (!TYPES_COMPRESSIBLES.has(typeNu(type))) return false
+  const { size } = await stat(fichier)
+  return size >= TAILLE_MINIMALE_GZIP
+}
+
+async function envoyer(requete, reponse, statut, fichier, enTetes = {}) {
+  const type = typeDe(fichier)
+  const flux = createReadStream(fichier)
+
+  if (await doitCompresser(requete, fichier, type)) {
+    // Pas de `Content-Length` : le corps est compressé au fil de l'eau, sa taille
+    // finale n'est pas connue au moment d'écrire les en-têtes. `Vary` accompagne la
+    // réponse compressée, comme le fait `gzip_vary on` — sans lui, un cache
+    // intermédiaire servirait du gzip à un client qui ne l'a pas demandé.
+    reponse.writeHead(statut, {
+      'Content-Type': type,
+      'Content-Encoding': 'gzip',
+      Vary: 'Accept-Encoding',
+      ...enTetes,
+    })
+    flux.pipe(createGzip({ level: NIVEAU_GZIP })).pipe(reponse)
+    return
+  }
+
+  reponse.writeHead(statut, { 'Content-Type': type, ...enTetes })
+  flux.pipe(reponse)
 }
 
 /**
@@ -86,12 +174,12 @@ export async function demarrerServeurStatique({ racine, port = PORT_PAR_DEFAUT }
     try {
       const fichier = await resoudre(dossier, requete.url ?? '/')
       if (fichier) {
-        envoyer(reponse, 200, fichier, { 'Cache-Control': 'no-store' })
+        await envoyer(requete, reponse, 200, fichier, { 'Cache-Control': 'no-store' })
         return
       }
       const page404 = await fichierExistant(join(dossier, '404.html'))
       if (page404) {
-        envoyer(reponse, 404, page404, { 'Cache-Control': 'no-store' })
+        await envoyer(requete, reponse, 404, page404, { 'Cache-Control': 'no-store' })
         return
       }
       reponse.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })


### PR DESCRIPTION
Closes #76

## Le defaut

`nginx:alpine` livre la directive `gzip` **commentee**. `docker/nginx.conf` ne la
declarait pas : la production servait le site **en clair**. L'accueil partait en
**120 Kio de HTML brut**, et les budgets de performance — rendus executables la veille
par la PR #75 — echouaient sur les trois pages mesurees.

Le profil ne laissait aucun doute : FCP 1,4-1,7 s, Speed Index 1,4-1,7 s, TBT 20 ms,
CLS 0 — et **LCP a 5,0-5,3 s**. Ni JavaScript bloquant, ni instabilite de mise en page :
du **transfert**, et rien d'autre.

## Avant / apres — `make budgets`, page par page

Mesure locale, profil mobile bride. **Deux passages complets, chiffres identiques** :
la marge de l'accueil etant d'un seul point, un passage unique n'aurait rien prouve.

| Page | Perf avant | Perf apres | A11y | Bonnes pratiques | SEO |
|------|-----------|-----------|------|------------------|-----|
| accueil | ✗ **80** | ✓ **96** | 100 | 100 | 100 |
| `/services/ingenierie-web/` | ✗ **81** | ✓ **97** | 100 | 100 | 100 |
| article de blog | ✗ **82** | ✓ **97** | 100 | 100 | 100 |

```
✓ Budget accessibilité (axe) : tenu
✓ Budget performance (Lighthouse) : tenu
```

Transfert de l'`index.html` de l'accueil : **119 998 → 22 215 octets, soit 81 % de
moins**. Aucune ligne de code applicatif n'a bouge, aucun composant n'a ete supprime,
aucune police n'a ete touchee. Le site etait correctement construit — il etait mal
servi.

## Les reglages, et pourquoi ces valeurs

| Reglage | Valeur | Justification |
|---------|--------|---------------|
| `gzip_comp_level` | `6` | **Mesure, pas recopie d'un billet de blog** : sur l'`index.html` de l'accueil, le niveau 6 rend 22 226 octets et le niveau 9 en rend 22 092 — 134 octets de mieux (0,6 %) pour environ deux fois le temps CPU. Le gain se joue entre 1 et 6 ; au-dela on achete de la latence serveur. |
| `gzip_min_length` | `1024` | En deca de 1 Kio, l'en-tete gzip et les tables de Huffman mangent le gain, et la reponse tient de toute facon dans la premiere fenetre de congestion : elle arrive dans le meme aller-retour, compressee ou non. Le defaut de nginx (20 octets) fait l'inverse. |
| `gzip_vary` | `on` | Une meme URL repond desormais en clair ou compressee selon `Accept-Encoding` : sans `Vary`, un cache intermediaire servirait du gzip a un client qui ne l'a pas demande. |
| `gzip_proxied` | `any` | Par defaut nginx refuse de compresser une reponse relayee a un proxy. Le site est destine a vivre derriere un reverse proxy / CDN : sans cette ligne, la compression s'eteindrait justement en production. |
| `gzip_types` | texte + `image/svg+xml` | `text/html` est **toujours** compresse par nginx et ne se declare pas (le repeter n'emet qu'un avertissement). Les `woff2`, PNG, WebP et AVIF sont **volontairement absents** : deja compresses a la source, les repasser au gzip brule du CPU pour ~0 % de gain, parfois pour grossir la reponse. |

**gzip et pas brotli** : `ngx_brotli` n'est pas dans l'image officielle, l'ajouter
imposerait de compiler nginx nous-memes. L'ecart brotli/gzip sur du HTML est de l'ordre
de 15 % — il ne justifie pas, aujourd'hui, une image maison a maintenir. Le jour ou elle
existe pour une autre raison, brotli s'y ajoute.

## Integrite de la mesure

C'est le point sensible du ticket, alors il est dit explicitement.

`scripts/serve-out.mjs` est **ce que `make budgets` mesure**. Il a ete ecrit pour
reproduire `docker/nginx.conf` (`try_files`, `index index.html`, `error_page 404`), et
il reproduit maintenant aussi la compression : memes types, meme seuil, meme niveau,
meme `Vary`.

**Le sens de la dependance est fixe et ne s'inverse jamais : la production decide, le
harnais reflete.** Compresser dans le harnais sans corriger nginx aurait annonce une
performance que le visiteur ne recoit pas — un truquage de la mesure au sens de la
regle 8 du `CLAUDE.md`. C'est `docker/nginx.conf` qui a ete corrige d'abord ; le vert
vient d'un site reellement plus rapide.

Aucun seuil abaisse, aucune categorie ni page exemptee, aucun `continue-on-error`,
`allow_failure` ou `|| true`, aucun workflow desactive ou conditionne. `pages.mjs` n'est
pas touche.

## Ce que la mesure ne dit pas encore — a lire avant de fermer le sujet

Le budget est tenu, mais **la marge de l'accueil est d'un point** (96 contre 95).

Les deux `woff2` du chemin critique (67 et 49 Kio) n'ont pas bouge : ils sont deja
compresses a la source, et le gzip ne les touche pas — a dessein. **Ils sont desormais
le premier poste du chemin critique**, et c'est la piste 2 de `docs/ameliorations.md`
(strategie de chargement des polices) qui porte la marge suivante, pas la piste 3
(JavaScript inutilise).

Les polices n'ont **pas** ete retouchees ici, et c'est un choix assume plutot qu'un
oubli. Fraunces et Inter sont un choix de design documente dans `docs/design.md`, deja
reduit au strict necessaire : variable, sous-ensemble latin, axe `opsz` seul depuis le
retrait de `SOFT` et `WONK` (commit 4f7bd94), registre monospace confie a la pile
systeme. Alleger davantage suppose d'arbitrer sur le dessin — `preload` selectif,
`size-adjust`, sous-ensemble de glyphes — et **cet arbitrage revient a Jerome MARICHEZ**,
pas a un lot de performance qui trancherait seul pour gagner des points.

## Tests — intention exposee, fichier non pose

Conformement au `CLAUDE.md`, l'assistant n'ecrit pas de test. L'intention utile ici est
de niveau **systeme** (`tests/systeme/`, `*.test.ts`, vrai serveur HTTP `listen(0)` +
`fetch`), a poser par Jerome MARICHEZ :

> **Intention** — le serveur statique compresse ce qui doit l'etre, et rien d'autre.
>
> Sur un `out/` reellement construit, servi par `demarrerServeurStatique` :
>
> - `GET /` avec `Accept-Encoding: gzip` repond `Content-Encoding: gzip` **et**
>   `Vary: Accept-Encoding` ; le corps, une fois decompresse, est le HTML integral
>   (119 998 octets aujourd'hui) et le transfert est nettement plus petit que lui.
> - `GET` d'un `.woff2` de `/_next/static/media/` avec le meme en-tete repond **sans**
>   `Content-Encoding` : un format deja compresse ne se recompresse pas.
> - `GET /` **sans** `Accept-Encoding` repond en clair — la negociation est respectee,
>   on n'impose jamais gzip.
> - Cas limite : `Accept-Encoding: gzip;q=0` est un **refus explicite** et doit etre
>   traite comme une absence, pas comme un accord.
> - Cas limite : une reponse compressible de moins de 1 Kio part en clair
>   (`gzip_min_length`).
>
> **Jeu de donnees** : l'export statique lui-meme, construit par le harnais — pas de
> fixture ad hoc, pas de doublure. C'est le vrai serveur et les vrais fichiers.

Les quatre premiers points ont ete verifies a la main au `curl` pendant le
developpement ; le test les fige.

## Documentation

- `docs/docker.md` : nouvelle section **Compression** — le tableau des reglages avec la
  justification de chaque valeur, le choix gzip/brotli, et la regle du sens de
  dependance entre production et harnais.
- `docs/ameliorations.md` : la piste 1 passe a **fait** avec ses chiffres ; une section
  **Resultat** porte le tableau avant/apres, la marge d'un point et le renvoi vers les
  polices comme facteur limitant suivant.
- `README.md` et `docs/ci-cd.md` : inchanges a dessein. Ce qui y est promis
  (« Lighthouse ≥ 95 sur les 4 categories ») ne change pas — c'est simplement, pour la
  premiere fois, tenu.

## Livraison

`make lint`, `npx tsc --noEmit` et `make build` verts. Version **0.3.0 → 0.3.1**
(correctif : defaut de production corrige, aucune rupture, aucune fonctionnalite).

Note : Docker n'etant pas disponible sur la machine de developpement, la configuration
nginx n'a pas pu etre validee par un `nginx -t` local. Les six directives employees sont
toutes du module standard `ngx_http_gzip_module` et valides en contexte `server` ; le
comportement, lui, a ete verifie de bout en bout sur le harnais qui les reproduit.
