### PR TITLE
feat: creer l espace realisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ ce qu'il faut réunir pour les quatre logos manquants.
 | `/services/data` | Le passage obligé en détail |
 | `/services/ia` | Une des deux suites en détail |
 | `/services/sea-ux` | L'autre suite en détail |
+| `/realisations` | Liste des réalisations, groupées par cadre d'emploi (employeur, intitulé de poste exact, période, équipe) |
+| `/realisations/<slug>` | Une réalisation. Une page statique par fiche, générée au build par `generateStaticParams` |
 | `/blog` | Liste des articles, du plus récent au plus ancien |
 | `/blog/<slug>` | Un article. Une page statique par article, générée au build par `generateStaticParams` |
 | `/parcours` | *(pas encore construite)* Parcours d'ingénieur et de chef de projet, formation |
@@ -329,6 +331,45 @@ ce qu'il faut réunir pour les quatre logos manquants.
 
 Chaque page de service porte ses propres métadonnées SEO, ses données structurées
 (`schema.org/Service` et `ProfessionalService`) et un appel à contact contextualisé.
+
+### L'espace `/realisations/` — le nom est un arbitrage de véracité
+
+**Aucune des entreprises citées sur le site n'est un client** : ce sont trois postes
+salariés — Lead Tech chez Acetelecom / MailingVox (2023-2026), Développeur Full Stack chez
+Verhoeven Joaillier (2019-2022, poste unique), Développeur web & Chef de projet digital
+chez Truffle Capital (2017-2019). Artedrone est une **participation du fonds** Truffle, pas
+un client. Nommer l'espace « cas clients » affirmerait une relation commerciale qui n'a
+jamais existé, et réécrirait des intitulés de poste que le [`CLAUDE.md`](./CLAUDE.md)
+impose de reprendre à l'identique des CV.
+
+L'espace s'appelle donc **`/realisations/`**, et **chaque fiche porte son cadre d'emploi** —
+intitulé exact, période, taille d'équipe. Le cadre est **obligatoire dans le type**
+(`IRealisationCadre`, aucun champ optionnel) : c'est le compilateur, et non la relecture,
+qui interdit qu'une fiche paraisse sans dire d'où elle vient.
+
+**Deux gabarits, et c'est structurant.** Trois fiches seulement portent un chiffre : ce
+sont les trois du mur de preuves — +50 % de panier moyen, 98/100 Lighthouse, 100 000 € de
+budget ADS/SEO **piloté**. Le mur de preuves les **lit sur la fiche** au lieu de les
+recopier (`IProof.fiche` n'accepte qu'une `IRealisationChiffree`), donc le nombre n'est
+écrit qu'une fois dans le dépôt. Les dix autres fiches sont **sans chiffre** et portent au
+mieux un résultat directionnel — « fraude en baisse », « routes vocales coûteuses
+évitées » — jamais quantifié ; deux d'entre elles n'ont aucun résultat et l'écrivent noir
+sur blanc. Même doctrine que les certifications publiées sans lien plutôt qu'avec un lien
+mort.
+
+Le rattachement aux pôles est un `readonly PoleId[]` **non contraint**. Le modèle décrit
+l'offre d'aujourd'hui, pas un historique : un type qui exigerait `data` partout forcerait à
+réétiqueter des travaux de 2017 pour satisfaire le compilateur. Deux formes portent
+l'argument — `['ingenierie-web', 'data', 'sea-ux']` **sans IA** montre qu'on n'est pas
+obligé d'acheter de l'IA, `['data']` seul que la donnée se livre pour elle-même.
+
+Une **réalisation n'est pas datée** : ce qui la situe dans le temps est la période du poste
+sous lequel elle a été menée, et cette période appartient au contenu de la fiche. Ses
+métadonnées passent donc par `buildPageMetadata`, pas par `buildArticleMetadata` qui
+exigerait une date de publication qu'il faudrait inventer. Les données structurées sont
+volontairement pauvres — `CollectionPage` + `ItemList` sur la liste, `WebPage` avec
+`isPartOf` sur la fiche : **ni `Service` ni `CreativeWork`**, aucun type qui affirmerait
+une prestation vendue ou une œuvre détenue.
 
 Le **blog** n'est pas un quatrième pôle et la navigation le sépare de la chaîne : ce sont
 des notes courtes sur des décisions techniques réelles. Chaque article porte ses propres

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,31 +28,49 @@ personne qui fera le travail*. Le jour où un formulaire s'impose, il faudra soi
 service tiers, soit un back séparé, soit renoncer à l'export : c'est un arbitrage à
 prendre en connaissance de cause, pas un détail de configuration.
 
-### Le blog : la seule route dynamique du site
+### Les deux routes dynamiques du site : le blog et les réalisations
 
-`/blog/[slug]` est le seul segment dynamique, et l'export statique en fixe les règles :
+`/blog/[slug]` et `/realisations/[slug]` sont les seuls segments dynamiques, et l'export
+statique leur impose les mêmes règles :
 
 - **`generateStaticParams()` est obligatoire.** Sans lui, `next build` n'a aucune page à
-  écrire pour ce segment et il échoue. La liste est dérivée des articles, jamais tenue à
-  la main : publier un article suffit à créer sa page. `dynamicParams = false` est écrit
-  noir sur blanc, pour qu'un futur passage au rendu serveur n'ouvre pas silencieusement
-  `/blog/<n-importe-quoi>`.
+  écrire pour ce segment et il échoue. La liste est dérivée du contenu, jamais tenue à
+  la main : publier un article ou une fiche suffit à créer sa page. `dynamicParams = false`
+  est écrit noir sur blanc, pour qu'un futur passage au rendu serveur n'ouvre pas
+  silencieusement `/blog/<n-importe-quoi>` ni `/realisations/<n-importe-quoi>`.
 - **Le sitemap devient composé.** `INDEXABLE_ROUTES` (`@shared/routes`) n'énumère que les
-  routes **fixes** ; les URL d'articles ne sont pas des routes mais des instances d'une
-  seule route, et leur nombre change à chaque publication. `@shared/seo/sitemap-entries`
-  les ajoute avec **une date par article** — et donne à `/blog` la date de son article le
-  plus récent, parce que c'est exactement ce qui la fait changer. C'est le seul module de
-  `@shared/seo` qui lit le contenu de `@vitrine` : un sitemap est par définition
-  l'inventaire du contenu publié, il n'y a pas d'autre source d'où tirer la liste.
-- **Une seule fonction compose une URL d'article** : `toArticleRoute(slug)`. Liste,
-  `canonical`, `og:url`, fil d'Ariane, JSON-LD et sitemap passent tous par elle. Dans un
-  export statique, une URL canonique fausse reste fausse jusqu'au prochain build.
+  routes **fixes** ; les URL d'articles et de fiches ne sont pas des routes mais des
+  instances de deux routes, et leur nombre change à chaque publication.
+  `@shared/seo/sitemap-entries` les ajoute avec **une date par article** — et donne à
+  `/blog` la date de son article le plus récent, parce que c'est exactement ce qui la fait
+  changer. C'est le seul module de `@shared/seo` qui lit le contenu de `@vitrine` : un
+  sitemap est par définition l'inventaire du contenu publié, il n'y a pas d'autre source
+  d'où tirer la liste.
+- **Une réalisation n'est pas datée**, et le sitemap le respecte : elle porte la révision
+  globale du site, comme les pages éditoriales. Ce qui la situe dans le temps, c'est la
+  période du poste sous lequel elle a été menée, et cette période appartient au **contenu**
+  de la fiche. Même raison côté métadonnées : `buildPageMetadata` et non
+  `buildArticleMetadata`, qui exigerait une `datePublished` qu'il faudrait inventer.
+- **Une seule fonction compose une URL** : `toArticleRoute(slug)`, `toRealisationRoute(slug)`.
+  Liste, `canonical`, `og:url`, fil d'Ariane, JSON-LD, sitemap et renvois depuis le mur de
+  preuves passent tous par elles. Dans un export statique, une URL canonique fausse reste
+  fausse jusqu'au prochain build.
 - **Un seul fil d'Ariane.** `buildBreadcrumbSchema` accepte les niveaux qui suivent
   l'accueil — celui-ci est un invariant du site, il est posé par la fonction et ne peut
   pas être oublié par un appelant. La même liste alimente le fil **visible**
   (`@shared/components/Breadcrumb`) : l'affiché et le déclaré ne peuvent pas diverger.
-- **Le blog n'est pas un pôle**, et la navigation le dit : il occupe un bloc distinct de
-  la liste numérotée de la chaîne, dans l'en-tête comme dans le pied de page.
+- **Ni le blog ni les réalisations ne sont des pôles**, et la navigation le dit : ils
+  occupent un bloc distinct de la liste numérotée de la chaîne, dans l'en-tête comme dans
+  le pied de page.
+
+#### Le JSON-LD des réalisations : le type le plus pauvre possible
+
+La liste déclare une `CollectionPage` dont le `mainEntity` est une `ItemList` ; chaque
+fiche déclare une `WebPage` rattachée par `isPartOf`. **Ni `Service`, ni `CreativeWork`,
+ni `Project`** : le premier affirmerait une prestation vendue, le deuxième une œuvre dont
+on détiendrait les droits, le troisième une entreprise autonome. Aucune de ces trois
+affirmations n'est vraie d'un travail mené sous contrat de travail — et le JSON-LD est
+d'autant plus tentant à gonfler qu'il n'est lu que par des moteurs.
 
 ### Métadonnées : la fusion de Next est **de surface**
 
@@ -101,7 +119,7 @@ Les règles qui en découlent :
 
 | Domaine | Contenu |
 |---------|---------|
-| `src/@vitrine/` | Sections éditoriales : offres, parcours, preuves, certifications, **articles du blog** |
+| `src/@vitrine/` | Sections éditoriales : offres, parcours, preuves, certifications, **articles du blog**, **fiches de réalisation** |
 | `src/@shared/` | Design system, layout, composants transverses, SEO/métadonnées |
 
 Le **contenu éditorial est de la donnée, pas du JSX** : offres, expériences,

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -10,7 +10,7 @@ TypeScript dans `src/@vitrine/contenu/`, et sa forme est tenue par des interface
 > manquant ou mal typé, et un schéma exécuté au build ne ferait que revérifier ce que
 > TypeScript a garanti. La seule vraie frontière du blog est le `slug` d'URL — il est
 > confronté à la liste close des articles par `generateStaticParams`, donc aucune URL
-> hors de cette liste n'est servie.
+> hors de cette liste n'est servie. Il en va de même pour les réalisations.
 
 ## Entités
 
@@ -21,7 +21,14 @@ TypeScript dans `src/@vitrine/contenu/`, et sa forme est tenue par des interface
 | `IEditorialPage` | `src/interfaces/IEditorialPage.ts` | Une page rédigée (accueil, page de pôle) | contient des `IEditorialSection` |
 | `IEditorialSection` | `src/interfaces/IEditorialSection.ts` | Une section de page | contient des `IEditorialBlock` ; `pole` référence un `PoleId` |
 | `IEditorialBlock` | `src/interfaces/IEditorialBlock.ts` | Un point d'expertise | — |
-| `IProof` | `src/interfaces/IProof.ts` | Une preuve chiffrée | — |
+| `IProof` | `src/interfaces/IProof.ts` | Une preuve chiffrée | `fiche` référence une `IRealisationChiffree` |
+| **`IRealisation`** | `src/interfaces/IRealisation.ts` | **Une réalisation** : un travail mené, son cadre, sa décision | contient un `IRealisationCadre` et des `IRealisationEtape` ; `poles` référence des `PoleId` |
+| `IRealisationChiffree` | `src/interfaces/IRealisationChiffree.ts` | Une `IRealisation` dont le `chiffre` est **obligatoire** | étend `IRealisation` |
+| `IRealisationCadre` | `src/interfaces/IRealisationCadre.ts` | Le cadre d'emploi : employeur, poste, période, équipe | — |
+| `IRealisationChiffre` | `src/interfaces/IRealisationChiffre.ts` | Un résultat chiffré, et ce qu'il ne dit pas | — |
+| `IRealisationEtape` | `src/interfaces/IRealisationEtape.ts` | Une étape du travail mené | — |
+| `IRealisationGroupe` | `src/interfaces/IRealisationGroupe.ts` | Vue dérivée : un cadre et ses fiches | calculée par `find-realisation`, jamais déclarée |
+| `IRealisationsIndex` | `src/interfaces/IRealisationsIndex.ts` | L'en-tête éditoriale de `/realisations` | — |
 | `ICertification` | `src/interfaces/ICertification.ts` | Une certification obtenue | `ICertificationLogo` |
 | `IBoundary` | `src/interfaces/IBoundary.ts` | Une limite assumée | — |
 | **`IArticle`** | `src/interfaces/IArticle.ts` | **Un article du blog** | contient des `IArticleSection` |
@@ -125,6 +132,63 @@ un composant :
   nulle part ailleurs : une seconde liste d'ordre finirait par contredire la première.
 - **Pas de statut `brouillon`.** Un article non publié n'est pas dans `articles.ts`.
 
+## La réalisation (`IRealisation`)
+
+C'est l'entité la plus exposée du site : le format « portfolio » dérive de lui-même vers
+« mon client X », et les entreprises citées sont des **employeurs**. Le modèle tient cette
+frontière par le **type**, pas par la relecture.
+
+| Champ | Type | Obligatoire | Rôle |
+|-------|------|-------------|------|
+| `slug` | `string` | oui | Identité durable. Dernier segment de l'URL, clé de recherche, ancre du JSON-LD |
+| `titre` | `string` | oui | `<h1>`, `name` du JSON-LD, dernier niveau du fil d'Ariane. À l'infinitif : un travail, pas une offre |
+| `chapo` | `string` | oui | Résumé. Teaser sur la liste, `description` du JSON-LD |
+| `meta` | `IPageMeta` | oui | `<title>` (60 car. max) et meta description (155 car. max) |
+| **`cadre`** | `IRealisationCadre` | **oui** | Employeur, intitulé de poste exact, période, équipe |
+| `poles` | `readonly PoleId[]` | oui | Pôles réellement mobilisés. **Non contraint** |
+| `probleme` | `string` | oui | Le problème posé au départ, dans les termes de l'époque |
+| `etapes` | `readonly IRealisationEtape[]` | oui | Ce qui a été fait, étape par étape |
+| `resultat` | `string` | oui | Résultat **directionnel**, jamais chiffré. Dit qu'il n'y en a pas quand il n'y en a pas |
+| `chiffre` | `IRealisationChiffre` | **non** | Le chiffre. **Trois fiches sur treize** en portent un |
+| `decision` | `string` | oui | Ce que le commanditaire pouvait trancher à l'arrivée |
+
+### Ce que le type interdit, et pourquoi
+
+- **`cadre` n'a aucun champ optionnel.** Une fiche ne peut pas paraître sans dire d'où
+  elle vient — et une fiche sans provenance se lit comme une prestation vendue. C'est le
+  compilateur qui ferme cette porte, parce que c'est le seul garde-fou qui ne s'oublie pas
+  en relecture. Le champ `equipe` existe pour la même raison : il empêche « j'ai managé N
+  développeurs », en obligeant à écrire ce qui a réellement été encadré.
+- **Le chiffre n'a qu'une porte d'entrée.** `IRealisationChiffre` est une entité à part,
+  avec une `portee` obligatoire — ce que le chiffre **ne** dit **pas**. Un chiffre publié
+  sans sa portée se fait élargir tout seul par celui qui le lit : « +50 % de panier moyen »
+  devient « +50 % de chiffre d'affaires ». Concentrer le nombre dans une entité dédiée le
+  rend aussi visible en revue : une quatrième fiche chiffrée ne peut pas apparaître au
+  détour d'un paragraphe.
+- **`IRealisationChiffree` porte les deux gabarits dans le type.** `IRealisation` laisse
+  `chiffre` optionnel — c'est le cas général ; l'interface dérivée le rend obligatoire.
+  `IProof.fiche` n'accepte qu'une `IRealisationChiffree`, donc le mur de preuves de
+  l'accueil **lit** le chiffre sur la fiche au lieu de le recopier. Le nombre n'est écrit
+  qu'une fois dans le dépôt : l'accueil et la fiche ne peuvent pas diverger.
+- **`resultat` est obligatoire même quand il n'y a rien à annoncer.** Deux fiches n'ont
+  aucun résultat mesuré et l'écrivent. Rendre le champ optionnel laisserait une fiche muette
+  sur son issue, ce qui se lit comme un résultat tu, pas comme un résultat absent.
+- **`poles` n'est pas contraint.** Le modèle de l'offre — ingénierie web → data → (IA
+  et/ou SEA & UX) — décrit ce qui se vend aujourd'hui, pas un historique. Un type qui
+  exigerait `data` partout forcerait à réétiqueter des travaux de 2017 pour satisfaire le
+  compilateur : ce serait le type qui écrirait le contenu.
+
+### Règles portées par le service
+
+Elles vivent dans `src/@vitrine/services/find-realisation.ts` :
+
+| Règle | Comportement |
+|-------|--------------|
+| `listRealisations()` | Rend la liste **dans l'ordre déclaré**. Aucun tri : une réalisation n'est pas datée, il n'existe pas de clé de tri qui ne soit pas inventée |
+| `groupRealisationsByCadre()` | Groupe par employeur, dans l'ordre de `CADRES` (du poste le plus récent au plus ancien). Un cadre sans fiche ne produit pas de groupe vide |
+| `findRealisation(slug)` | Rend la fiche et jusqu'à `MAX_REALISATIONS_LIEES` (2) autres, choisies sur les **pôles partagés** — la liste groupe déjà par employeur, proposer trois fois le même employeur en bas de page n'apprendrait rien. **Lève** sur un slug inconnu |
+| `listPoles(ids)` (`find-pole`) | Ordonne les pôles selon `POLES_NAV`, jamais selon l'ordre déclaré par la fiche |
+
 ## Où vivent les données
 
 ```
@@ -134,11 +198,20 @@ src/@vitrine/contenu/blog/
 ├── export-statique.ts   ← un fichier par article
 ├── test-avant-code.ts
 └── mesurer-avant-arbitrer.ts
+
+src/@vitrine/contenu/realisations/
+├── realisations.ts        ← la liste publiée : SOURCE UNIQUE de l'espace
+├── realisations-index.ts  ← l'en-tête éditoriale de /realisations
+├── cadres.ts              ← les trois cadres d'emploi, partagés par les fiches
+├── mailingvox-produits.ts ← les fiches, groupées par employeur
+├── mailingvox-donnee.ts   ←   (MailingVox est scindé en deux : limite de 300 lignes)
+├── verhoeven.ts
+└── truffle.ts
 ```
 
-`articles.ts` alimente **tout** : la liste, les pages générées au build
-(`generateStaticParams`), le sitemap (`@shared/seo/sitemap-entries`) et les données
-structurées. Retirer un article de ce tableau le fait disparaître partout — il n'y a pas
+`articles.ts` et `realisations.ts` alimentent **tout** : la liste, les pages générées au
+build (`generateStaticParams`), le sitemap (`@shared/seo/sitemap-entries`) et les données
+structurées. Retirer une entrée de ces tableaux la fait disparaître partout — il n'y a pas
 de second endroit à mettre à jour.
 
 ## Règles générales

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeromemarichez-fr",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
         "next": "^16.0.0",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {

--- a/scripts/budgets/pages.mjs
+++ b/scripts/budgets/pages.mjs
@@ -64,4 +64,18 @@ export const PAGES = [
     chemin: '/blog/pourquoi-ce-site-est-un-export-statique/',
     pourquoi: "gabarit d'article : corps long, typographie, fil d'Ariane, JSON-LD",
   },
+  {
+    id: 'realisations',
+    chemin: '/realisations/',
+    pourquoi:
+      "gabarit d'index de réalisations : groupes par cadre d'emploi, cartes, étiquettes de " +
+      'pôle et JSON-LD de collection',
+  },
+  {
+    id: 'realisation',
+    chemin: '/realisations/verhoeven-parcours-achat/',
+    pourquoi:
+      "gabarit de fiche : cadre d'emploi en liste de définitions, chiffre et sa portée, " +
+      'étapes numérotées, étiquettes de pôle',
+  },
 ]

--- a/src/@shared/components/SiteFooter/index.tsx
+++ b/src/@shared/components/SiteFooter/index.tsx
@@ -59,6 +59,9 @@ export function SiteFooter() {
               <Link href={ROUTES.accueil}>Accueil</Link>
             </li>
             <li>
+              <Link href={ROUTES.realisations}>Réalisations</Link>
+            </li>
+            <li>
               <Link href={ROUTES.blog}>Blog</Link>
             </li>
           </ul>

--- a/src/@shared/components/SiteHeader/index.tsx
+++ b/src/@shared/components/SiteHeader/index.tsx
@@ -52,12 +52,24 @@ export function SiteHeader() {
             </ul>
           </nav>
 
-          {/* Bloc distinct, et pas un élément de plus dans la liste des pôles : le blog
-              n'est pas une offre, et l'ajouter à la chaîne le ferait lire comme telle. */}
-          <nav aria-label="Le blog" className={styles.navigationSecondaire}>
-            <Link className={styles.lien} href={ROUTES.blog}>
-              Blog
-            </Link>
+          {/* Bloc distinct, et pas deux éléments de plus dans la liste des pôles : ni les
+              réalisations ni le blog ne sont des offres, et les ajouter à la chaîne les
+              ferait lire comme telles. Les réalisations passent devant le blog — elles
+              montrent ce qui a été fait, ce qui est la question que se pose un visiteur
+              qui vient de lire les quatre pôles. */}
+          <nav aria-label="Réalisations et blog" className={styles.navigationSecondaire}>
+            <ul className={styles.liste}>
+              <li>
+                <Link className={styles.lien} href={ROUTES.realisations}>
+                  Réalisations
+                </Link>
+              </li>
+              <li>
+                <Link className={styles.lien} href={ROUTES.blog}>
+                  Blog
+                </Link>
+              </li>
+            </ul>
           </nav>
         </div>
       </div>

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -84,10 +84,12 @@
   min-width: 0;
 }
 
-/* Le blog est séparé de la chaîne par un filet vertical : c'est le seul signal qui dit,
-   sans un mot, qu'il n'appartient pas à la liste des pôles d'à côté. */
+/* Les réalisations et le blog sont séparés de la chaîne par un filet vertical : c'est le
+   seul signal qui dit, sans un mot, qu'ils n'appartiennent pas à la liste des pôles d'à
+   côté. */
 .navigationSecondaire {
   display: flex;
+  min-width: 0;
   padding-left: var(--e-1);
   border-left: 1px solid color-mix(in srgb, var(--encre) 14%, transparent);
 }

--- a/src/@shared/routes.ts
+++ b/src/@shared/routes.ts
@@ -9,11 +9,12 @@ import type { PoleId } from '@/interfaces/types'
 export const ROUTES = {
   accueil: '/',
   blog: '/blog',
+  realisations: '/realisations',
   'ingenierie-web': '/services/ingenierie-web',
   data: '/services/data',
   ia: '/services/ia',
   'sea-ux': '/services/sea-ux',
-} as const satisfies Record<'accueil' | 'blog' | PoleId, string>
+} as const satisfies Record<'accueil' | 'blog' | 'realisations' | PoleId, string>
 
 /**
  * Toutes les routes **fixes** indexables.
@@ -22,9 +23,9 @@ export const ROUTES = {
  * suites parallèles de la donnée, et un sitemap ne porte aucun ordre — c'est un
  * inventaire. Toute lecture ordonnée de cette liste serait une erreur.
  *
- * Les URL d'articles n'y figurent pas : elles ne sont pas des routes du site mais des
- * instances d'une seule route dynamique, et leur nombre change à chaque publication.
- * C'est le sitemap qui les ajoute, à partir de la liste des articles
+ * Les URL d'articles et de réalisations n'y figurent pas : ce ne sont pas des routes du
+ * site mais des instances de deux routes dynamiques, et leur nombre change à chaque
+ * publication. C'est le sitemap qui les ajoute, à partir des listes de contenu
  * (`@shared/seo/sitemap-entries`).
  */
 export const INDEXABLE_ROUTES = [
@@ -33,6 +34,7 @@ export const INDEXABLE_ROUTES = [
   ROUTES.data,
   ROUTES.ia,
   ROUTES['sea-ux'],
+  ROUTES.realisations,
   ROUTES.blog,
 ] as const
 
@@ -46,4 +48,15 @@ export const INDEXABLE_ROUTES = [
  */
 export function toArticleRoute(slug: string): string {
   return `${ROUTES.blog}/${slug}`
+}
+
+/**
+ * Route d'une réalisation à partir de son slug.
+ *
+ * Même règle que pour un article, et pour la même raison : liste, métadonnées, fil
+ * d'Ariane, JSON-LD, sitemap et renvois depuis le mur de preuves passent tous par ici.
+ * Dans un export statique, une URL canonique fausse le reste jusqu'au prochain build.
+ */
+export function toRealisationRoute(slug: string): string {
+  return `${ROUTES.realisations}/${slug}`
 }

--- a/src/@shared/seo/sitemap-entries.ts
+++ b/src/@shared/seo/sitemap-entries.ts
@@ -1,16 +1,17 @@
 // sitemap-entries.ts — jeromemarichez-fr
-// Les entrées du sitemap : les routes fixes du site, plus un article par publication.
+// Les entrées du sitemap : les routes fixes du site, plus une URL par contenu publié.
 //
 // La logique vit ici et non dans `src/app/sitemap.ts` : `app/` ne fait que du routage
 // (docs/architecture.md), et cette liste-ci se vérifie sans démarrer Next.
 //
 // C'est le seul module de `@shared/seo` qui lit le contenu de `@vitrine`. C'est assumé :
 // un sitemap est par définition l'inventaire du contenu publié, il n'existe aucune autre
-// source d'où tirer la liste des articles.
+// source d'où tirer la liste des articles et des réalisations.
 
 import type { MetadataRoute } from 'next'
 import { articleRevisionDate, listArticles } from '@/@vitrine/services/find-article'
-import { INDEXABLE_ROUTES, ROUTES, toArticleRoute } from '../routes'
+import { listRealisations } from '@/@vitrine/services/find-realisation'
+import { INDEXABLE_ROUTES, ROUTES, toArticleRoute, toRealisationRoute } from '../routes'
 import { SITE_DERNIERE_REVISION } from './site'
 import { toAbsoluteUrl } from './urls'
 
@@ -24,6 +25,13 @@ import { toAbsoluteUrl } from './urls'
  *   exactement ce qui la fait changer. Lui laisser la date globale reviendrait à
  *   annoncer une page modifiée les jours où elle ne l'est pas, et inchangée le jour
  *   d'une publication — soit le contraire du signal attendu.
+ *
+ * **Les réalisations, elles, ne sont pas datées**, et elles portent donc la révision
+ * globale du site comme les autres pages éditoriales. C'est cohérent avec ce qu'elles
+ * sont : ce qui les situe dans le temps, c'est la période du poste sous lequel elles ont
+ * été menées, et cette période appartient au contenu de la fiche — pas à ses métadonnées.
+ * Leur inventer une date de publication reviendrait à publier une information fausse dans
+ * le seul champ du sitemap que Google lit encore.
  */
 export function buildSitemapEntries(): MetadataRoute.Sitemap {
   const articles = listArticles()
@@ -40,5 +48,10 @@ export function buildSitemapEntries(): MetadataRoute.Sitemap {
     lastModified: articleRevisionDate(article),
   }))
 
-  return [...routesFixes, ...pagesArticles]
+  const pagesRealisations = listRealisations().map((realisation) => ({
+    url: toAbsoluteUrl(toRealisationRoute(realisation.slug)),
+    lastModified: SITE_DERNIERE_REVISION,
+  }))
+
+  return [...routesFixes, ...pagesRealisations, ...pagesArticles]
 }

--- a/src/@shared/seo/structured-data.ts
+++ b/src/@shared/seo/structured-data.ts
@@ -126,6 +126,83 @@ export function buildArticleSchema(params: {
 }
 
 /**
+ * La liste des réalisations, avec l'inventaire de ses fiches.
+ *
+ * `CollectionPage` et non `Blog` : ces pages ne sont pas datées et ne forment pas une
+ * publication périodique. Surtout, **ni `Service` ni `CreativeWork`** — le premier
+ * affirmerait une prestation vendue, le second une œuvre dont on détiendrait les droits.
+ * Ce sont des travaux menés sous contrat de travail : la seule chose que le JSON-LD a le
+ * droit de dire, c'est qu'il existe une page qui en fait la liste.
+ *
+ * L'`ItemList` est en `mainEntity` : elle est le sujet de la page, pas un à-côté. Chaque
+ * élément n'y porte que son nom et son URL, le détail étant déclaré par la fiche
+ * elle-même — recopier ici le contenu des fiches donnerait deux descriptions du même
+ * objet, qui divergeraient à la première correction.
+ */
+export function buildCollectionPageSchema(params: {
+  nom: string
+  description: string
+  route: string
+  elements: readonly { titre: string; route: string }[]
+}): Record<string, unknown> {
+  const url = toAbsoluteUrl(params.route)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    '@id': `${url}#collection`,
+    name: params.nom,
+    description: params.description,
+    url,
+    inLanguage: 'fr-FR',
+    author: { '@id': `${SITE_URL}/#personne` },
+    publisher: { '@id': `${SITE_URL}/#activite` },
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: params.elements.length,
+      itemListElement: params.elements.map((element, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: element.titre,
+        url: toAbsoluteUrl(element.route),
+      })),
+    },
+  }
+}
+
+/**
+ * Une fiche de réalisation, rattachée à la collection qui la contient.
+ *
+ * `WebPage`, le type le plus pauvre qui soit — et c'est exactement ce qu'on veut. Toute
+ * montée en spécificité affirmerait quelque chose de plus : `Service` une prestation
+ * vendue, `CreativeWork` une œuvre, `Project` une entreprise autonome. Aucune de ces trois
+ * affirmations n'est vraie d'un travail mené sous contrat de travail.
+ *
+ * `isPartOf` pointe la collection par son `@id`, ce qui suffit à un moteur pour rattacher
+ * la fiche à la liste sans que celle-ci ait à redéclarer quoi que ce soit.
+ */
+export function buildRealisationSchema(params: {
+  titre: string
+  chapo: string
+  route: string
+  collectionRoute: string
+}): Record<string, unknown> {
+  const url = toAbsoluteUrl(params.route)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    '@id': `${url}#realisation`,
+    name: params.titre,
+    description: params.chapo,
+    url,
+    inLanguage: 'fr-FR',
+    isPartOf: { '@id': `${toAbsoluteUrl(params.collectionRoute)}#collection` },
+    author: { '@id': `${SITE_URL}/#personne` },
+  }
+}
+
+/**
  * Le blog lui-même, avec la liste de ses articles.
  *
  * Les articles n'y sont référencés que par leur `@id` et leur titre : le détail est

--- a/src/@vitrine/components/EmploymentFrame/employment-frame.module.css
+++ b/src/@vitrine/components/EmploymentFrame/employment-frame.module.css
@@ -1,0 +1,56 @@
+/* employment-frame.module.css — le cadre d'emploi d'une réalisation.
+ * Registre documentaire : monospace et capitales pour les termes, comme les étiquettes
+ * du reste du site. Ce bloc est un état civil, pas un argument. */
+
+.cadre {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+}
+
+.employeur {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-family: var(--police-titre-pile);
+  font-variation-settings: "opsz" 24;
+  font-weight: 600;
+  font-size: var(--t-2);
+  line-height: 1.2;
+  letter-spacing: var(--suivi-titre);
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-0);
+  margin: 0;
+  max-width: var(--mesure-texte);
+}
+
+/* Le terme et sa valeur partagent la ligne tant qu'elle est large, et se remettent l'un
+   sous l'autre sinon : l'intitulé de poste et la composition d'équipe sont des phrases
+   entières, elles ne tiennent pas dans une colonne étroite. */
+.ligne {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--e-1);
+}
+
+.terme {
+  flex: 0 0 auto;
+  min-width: 5rem;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: var(--suivi-etiquette);
+  color: var(--encre-douce);
+}
+
+.valeur {
+  flex: 1 1 18ch;
+  margin: 0;
+  font-size: var(--t-note);
+  line-height: 1.5;
+  color: var(--encre);
+}

--- a/src/@vitrine/components/EmploymentFrame/index.tsx
+++ b/src/@vitrine/components/EmploymentFrame/index.tsx
@@ -1,0 +1,55 @@
+// EmploymentFrame/index.tsx — jeromemarichez-fr
+// Le cadre d'emploi d'une réalisation : employeur, intitulé de poste, période, équipe.
+
+import type { IRealisationCadre } from '@/interfaces/IRealisationCadre'
+import styles from './employment-frame.module.css'
+
+interface EmploymentFrameProps {
+  cadre: IRealisationCadre
+  /**
+   * Balise portant l'employeur. `h2` sur la liste, où chaque cadre ouvre un groupe ;
+   * `p` sur une fiche, où le titre de niveau 2 appartient déjà aux sections du récit.
+   */
+  niveau?: 'h2' | 'p'
+  /** Identifiant du titre, pour le `aria-labelledby` de la section qui l'englobe. */
+  titreId?: string
+}
+
+/**
+ * Rendu en liste de définitions, et pas en suite de phrases.
+ *
+ * Trois informations de nature différente — un poste, une période, une équipe — dont
+ * chacune répond à une question précise. Une liste de définitions dit laquelle répond à
+ * quoi, pour un lecteur d'écran comme à l'œil, là où « Développeur Full Stack, 2019-2022,
+ * poste unique » demande de deviner.
+ *
+ * Ce bloc est le garde-fou éditorial de tout l'espace : c'est lui qui empêche une fiche de
+ * se lire comme une prestation vendue à un client. Il apparaît donc au-dessus du titre sur
+ * une fiche, pas en bas de page.
+ */
+export function EmploymentFrame({ cadre, niveau = 'p', titreId }: EmploymentFrameProps) {
+  const Employeur = niveau
+
+  return (
+    <div className={styles.cadre}>
+      <Employeur className={styles.employeur} id={titreId}>
+        {cadre.employeur}
+      </Employeur>
+
+      <dl className={styles.details}>
+        <div className={styles.ligne}>
+          <dt className={styles.terme}>Poste</dt>
+          <dd className={styles.valeur}>{cadre.poste}</dd>
+        </div>
+        <div className={styles.ligne}>
+          <dt className={styles.terme}>Période</dt>
+          <dd className={styles.valeur}>{cadre.periode}</dd>
+        </div>
+        <div className={styles.ligne}>
+          <dt className={styles.terme}>Équipe</dt>
+          <dd className={styles.valeur}>{cadre.equipe}</dd>
+        </div>
+      </dl>
+    </div>
+  )
+}

--- a/src/@vitrine/components/PoleTagList/index.tsx
+++ b/src/@vitrine/components/PoleTagList/index.tsx
@@ -1,0 +1,47 @@
+// PoleTagList/index.tsx — jeromemarichez-fr
+// Les pôles mobilisés par une réalisation, rendus navigables.
+
+import Link from 'next/link'
+import { listPoles } from '@/@vitrine/services/find-pole'
+import type { PoleId } from '@/interfaces/types'
+import styles from './pole-tag-list.module.css'
+
+interface PoleTagListProps {
+  poles: readonly PoleId[]
+  /** Intitulé de la liste. Il change selon qu'on est sur une carte ou sur une fiche. */
+  legende: string
+}
+
+/**
+ * Une liste **non ordonnée**, et c'est un choix de balisage autant que de sens : les
+ * pôles d'une réalisation ne se succèdent pas, ils ont été mobilisés ensemble. Un `<ol>`
+ * ferait lire un rang à voix haute là où il n'y en a aucun — même raison que dans
+ * l'en-tête du site.
+ *
+ * Chaque étiquette porte `data-pole` : `poles.css` mappe alors `--accent` sur la teinte du
+ * pôle, et l'étiquette prend sa couleur sans qu'aucune couleur ne soit nommée ici. La
+ * couleur n'est jamais seule à porter l'information — le nom du pôle est écrit (WCAG
+ * 1.4.1).
+ *
+ * L'ordre d'affichage vient de `listPoles`, donc de la chaîne, jamais de l'ordre dans
+ * lequel une fiche a déclaré ses pôles.
+ */
+export function PoleTagList({ poles, legende }: PoleTagListProps) {
+  const rattaches = listPoles(poles)
+
+  if (rattaches.length === 0) return null
+
+  return (
+    <nav aria-label={legende} className={styles.zone}>
+      <ul className={styles.liste}>
+        {rattaches.map((pole) => (
+          <li className={styles.item} data-pole={pole.id} key={pole.id}>
+            <Link className={styles.etiquette} href={pole.route}>
+              {pole.nom}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/src/@vitrine/components/PoleTagList/pole-tag-list.module.css
+++ b/src/@vitrine/components/PoleTagList/pole-tag-list.module.css
@@ -1,0 +1,43 @@
+/* pole-tag-list.module.css — les pôles mobilisés par une réalisation.
+ * Un filet à gauche plutôt qu'une pastille pleine : la teinte du pôle reste un repère,
+ * elle ne devient pas un bouton. Aucune couleur n'est nommée ici — `--accent` est mappé
+ * par `poles.css` à partir du `data-pole` posé sur chaque item. */
+
+.zone {
+  display: flex;
+}
+
+.liste {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--e-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item {
+  display: flex;
+}
+
+.etiquette {
+  display: inline-flex;
+  align-items: baseline;
+  padding: var(--e-0) var(--e-2);
+  border-left: 2px solid var(--accent-vif);
+  border-radius: 0 var(--rayon-petit) var(--rayon-petit) 0;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  color: var(--accent);
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  transition: background-color var(--duree-micro) ease-out;
+}
+
+.etiquette:hover,
+.etiquette:focus-visible {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}

--- a/src/@vitrine/components/ProofWall/index.tsx
+++ b/src/@vitrine/components/ProofWall/index.tsx
@@ -1,6 +1,8 @@
 // ProofWall/index.tsx — jeromemarichez-fr
 // Le mur de preuves : ce qui est vérifiable.
 
+import Link from 'next/link'
+import { toRealisationRoute } from '@/@shared/routes'
 import type { IProof } from '@/interfaces/IProof'
 import styles from './proof-wall.module.css'
 
@@ -14,6 +16,11 @@ interface ProofWallProps {
  * Un chiffre qui s'anime demande qu'on le regarde ; un chiffre posé demande qu'on le
  * vérifie. Le second registre est le seul tenable ici — et il évite au passage une
  * animation qui n'aurait rien apporté à la lecture.
+ *
+ * Trois tuiles sur six portent un lien vers la réalisation qui les déplie, et le libellé
+ * du lien est le **titre de la fiche** plutôt qu'un « en savoir plus ». Six liens de même
+ * intitulé sur une page sont un défaut d'accessibilité connu : sortis de leur contexte,
+ * ils ne disent plus où ils mènent.
  */
 export function ProofWall({ preuves }: ProofWallProps) {
   return (
@@ -23,6 +30,11 @@ export function ProofWall({ preuves }: ProofWallProps) {
           <p className={styles.chiffre}>{preuve.chiffre}</p>
           <p className={styles.libelle}>{preuve.libelle}</p>
           <p className={styles.contexte}>{preuve.contexte}</p>
+          {preuve.fiche ? (
+            <p className={styles.renvoi}>
+              <Link href={toRealisationRoute(preuve.fiche.slug)}>{preuve.fiche.titre}</Link>
+            </p>
+          ) : null}
         </li>
       ))}
     </ul>

--- a/src/@vitrine/components/ProofWall/proof-wall.module.css
+++ b/src/@vitrine/components/ProofWall/proof-wall.module.css
@@ -36,3 +36,14 @@
   line-height: 1.5;
   color: var(--encre-douce);
 }
+
+/* Le renvoi vers la fiche est poussé en bas de tuile par `margin-top: auto` : les six
+   tuiles n'ont pas la même hauteur de contexte, et trois seulement portent un lien —
+   sans cela, les liens se retrouveraient à trois hauteurs différentes sur la même
+   ligne de grille. */
+.renvoi {
+  margin-top: auto;
+  padding-top: var(--e-1);
+  font-size: var(--t--1);
+  line-height: 1.4;
+}

--- a/src/@vitrine/components/RealisationCard/index.tsx
+++ b/src/@vitrine/components/RealisationCard/index.tsx
@@ -1,0 +1,50 @@
+// RealisationCard/index.tsx — jeromemarichez-fr
+// Une réalisation vue depuis une liste : son chiffre s'il y en a un, son titre, son chapô.
+
+import Link from 'next/link'
+import { toRealisationRoute } from '@/@shared/routes'
+import type { IRealisation } from '@/interfaces/IRealisation'
+import { PoleTagList } from '../PoleTagList'
+import styles from './realisation-card.module.css'
+
+interface RealisationCardProps {
+  realisation: IRealisation
+}
+
+/**
+ * Le lien porte le titre, et rien d'autre — même raison que sur une carte d'article :
+ * rendre la carte entière cliquable demanderait un lien vide superposé ou du JavaScript,
+ * et un lecteur d'écran annoncerait un lien sans intitulé.
+ *
+ * Le titre est un `h3` sans réglage possible : la carte n'apparaît que sous un cadre
+ * d'emploi (liste) ou sous « Sur les mêmes pôles » (fiche), deux titres de niveau 2. Un
+ * niveau paramétrable serait une option que personne n'utilise, et qu'un appelant finirait
+ * par régler de travers.
+ *
+ * Le chiffre passe **avant** le titre quand il existe. Ce n'est pas un effet de mise en
+ * page : sur une liste où trois fiches sur treize en portent un, c'est le seul endroit où
+ * la différence entre les deux gabarits se voit d'un coup d'œil. Une carte sans chiffre
+ * n'a pas de trou à la place — elle commence simplement par son titre.
+ */
+export function RealisationCard({ realisation }: RealisationCardProps) {
+  return (
+    <article className={styles.carte}>
+      {realisation.chiffre ? (
+        <p className={styles.chiffre}>
+          <span className={styles.nombre}>{realisation.chiffre.chiffre}</span>
+          <span className={styles.mesure}>{realisation.chiffre.libelle}</span>
+        </p>
+      ) : null}
+
+      <h3 className={styles.titre}>
+        <Link className={styles.lien} href={toRealisationRoute(realisation.slug)}>
+          {realisation.titre}
+        </Link>
+      </h3>
+
+      <p className={styles.chapo}>{realisation.chapo}</p>
+
+      <PoleTagList legende={`Pôles mobilisés — ${realisation.titre}`} poles={realisation.poles} />
+    </article>
+  )
+}

--- a/src/@vitrine/components/RealisationCard/realisation-card.module.css
+++ b/src/@vitrine/components/RealisationCard/realisation-card.module.css
@@ -1,0 +1,61 @@
+/* realisation-card.module.css — une réalisation dans une liste.
+ * Pas de panneau ni de vignette : un filet supérieur suffit à séparer. Le verre est
+ * réservé aux offres (docs/design.md), et une réalisation n'en est pas une. */
+
+.carte {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+  padding-top: var(--e-3);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+}
+
+/* Le chiffre et sa mesure sur la même ligne tant qu'elle est large : séparés, ils se
+   liraient comme deux informations, alors que « +50 % » ne veut rien dire sans
+   « de panier moyen ». */
+.chiffre {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--e-1);
+}
+
+.nombre {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t-2);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: var(--encre);
+}
+
+.mesure {
+  font-size: var(--t-note);
+  color: var(--encre-douce);
+}
+
+.titre {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-2);
+  line-height: 1.25;
+}
+
+.lien {
+  color: var(--encre);
+  text-decoration: none;
+}
+
+.lien:hover,
+.lien:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-0);
+  line-height: 1.55;
+  color: var(--encre-douce);
+}

--- a/src/@vitrine/contenu/preuves.ts
+++ b/src/@vitrine/contenu/preuves.ts
@@ -3,30 +3,42 @@
 //
 // Source unique : les CV de référence de /Users/nicolasb/Documents/CV. Un chiffre qui
 // ne s'y trouve pas mot pour mot n'a rien à faire sur cette page.
+//
+// **Les trois premières tuiles ne portent plus leur chiffre en propre** : elles le lisent
+// sur la fiche de réalisation qui le déplie. C'est la seule façon de garantir que
+// l'accueil et `/realisations/` ne peuvent pas afficher deux valeurs différentes — le
+// nombre n'est écrit qu'une fois dans le dépôt. Le `contexte`, lui, reste écrit ici :
+// c'est la version courte, calibrée pour une tuile, pas le résumé de la fiche.
 
 import type { IProof } from '@/interfaces/IProof'
+import { REALISATION_SMS_EN_MASSE } from './realisations/mailingvox-produits'
+import { REALISATION_BUDGET_ADS } from './realisations/truffle'
+import { REALISATION_PARCOURS_ACHAT } from './realisations/verhoeven'
 
 export const PREUVES: IProof[] = [
   {
-    chiffre: '+50 %',
-    libelle: 'de panier moyen',
+    chiffre: REALISATION_PARCOURS_ACHAT.chiffre.chiffre,
+    libelle: REALISATION_PARCOURS_ACHAT.chiffre.libelle,
     contexte:
       'Verhoeven Joaillier, 2019-2022. Refonte des parcours d’achat pilotée par la mesure : ' +
       'A/B testing des pages et des designs, heatmaps, taux de rebond.',
+    fiche: REALISATION_PARCOURS_ACHAT,
   },
   {
-    chiffre: '98/100',
-    libelle: 'au score Lighthouse',
+    chiffre: REALISATION_SMS_EN_MASSE.chiffre.chiffre,
+    libelle: REALISATION_SMS_EN_MASSE.chiffre.libelle,
     contexte:
       'Plateforme SaaS « Sms En Masse », front React / Next.js avec stratégie de rendu ' +
       'différenciée par type de page. Conformité RGAA / WCAG tenue en parallèle.',
+    fiche: REALISATION_SMS_EN_MASSE,
   },
   {
-    chiffre: '100 000 €',
-    libelle: 'de budget ADS / SEO piloté',
+    chiffre: REALISATION_BUDGET_ADS.chiffre.chiffre,
+    libelle: REALISATION_BUDGET_ADS.chiffre.libelle,
     contexte:
       'Truffle Capital, 2017-2019. Budget mesuré et justifié auprès des dirigeants, ' +
       'coordination d’une équipe marketing de 5 à 10 personnes et de 3 prestataires.',
+    fiche: REALISATION_BUDGET_ADS,
   },
   {
     chiffre: '3',

--- a/src/@vitrine/contenu/realisations/cadres.ts
+++ b/src/@vitrine/contenu/realisations/cadres.ts
@@ -1,0 +1,46 @@
+// cadres.ts — jeromemarichez-fr
+// Les trois cadres d'emploi sous lesquels toutes les réalisations du site ont été menées.
+//
+// **Aucune de ces trois entreprises n'est un client.** Ce sont trois postes salariés, et
+// c'est la raison pour laquelle l'espace s'appelle « réalisations » et non « cas
+// clients » : nommer autrement affirmerait une relation commerciale qui n'a jamais
+// existé. Les intitulés de poste sont repris à l'identique des CV de référence
+// (`CLAUDE.md`), sans réécriture pour coller à une offre de service.
+//
+// L'ORDRE DE CE TABLEAU EST L'ORDRE D'AFFICHAGE de la liste : du poste le plus récent au
+// plus ancien. C'est le seul classement qui ne raconte rien d'autre que la chronologie.
+
+import type { IRealisationCadre } from '@/interfaces/IRealisationCadre'
+
+/** 2023-2026. Ni QA ni équipe data dédiées : la qualité et la donnée ont été outillées. */
+export const CADRE_MAILINGVOX: IRealisationCadre = {
+  employeur: 'Acetelecom / MailingVox',
+  poste: 'Lead Tech · Ingénieur full stack, mobile & IA',
+  periode: '2023-2026',
+  equipe:
+    'Équipe technique de trois — deux développeurs et un product owner. Ni QA ni équipe ' +
+    'data dédiées. Encadrement d’alternants et de stagiaires.',
+}
+
+/** 2019-2022. Poste unique : aucun développeur à encadrer, et rien qui le laisse croire. */
+export const CADRE_VERHOEVEN: IRealisationCadre = {
+  employeur: 'Verhoeven Joaillier',
+  poste: 'Développeur Full Stack · E-commerce de luxe',
+  periode: '2019-2022',
+  equipe:
+    'Poste unique, en autonomie complète sur le site marchand. Encadrement de prestataires ' +
+    'SEA, SEO et SMA.',
+}
+
+/** 2017-2019. L'équipe coordonnée est marketing, jamais technique. */
+export const CADRE_TRUFFLE: IRealisationCadre = {
+  employeur: 'Truffle Capital',
+  poste: 'Développeur web & Chef de projet digital',
+  periode: '2017-2019',
+  equipe:
+    'Coordination d’une équipe marketing et SEO/SEA de 5 à 10 personnes et de trois ' +
+    'prestataires externes.',
+}
+
+/** Les trois cadres, du plus récent au plus ancien. Source unique du regroupement. */
+export const CADRES: IRealisationCadre[] = [CADRE_MAILINGVOX, CADRE_VERHOEVEN, CADRE_TRUFFLE]

--- a/src/@vitrine/contenu/realisations/mailingvox-donnee.ts
+++ b/src/@vitrine/contenu/realisations/mailingvox-donnee.ts
@@ -1,0 +1,200 @@
+// mailingvox-donnee.ts — jeromemarichez-fr
+// Acetelecom / MailingVox, 2023-2026 : ce qui a été construit sur la donnée.
+//
+// Séparé de `mailingvox-produits.ts` pour la limite de 300 lignes par fichier, et
+// regroupé par ce sur quoi le travail s'appuie : la donnée et les modèles.
+//
+// Deux fiches d'ici n'ont **aucun résultat**, ni chiffré ni directionnel, et le disent.
+// C'est la même doctrine que les certifications, publiées sans lien plutôt qu'avec un
+// lien mort : une fiche qui décrit ce qui a été construit vaut mieux qu'une fiche qui
+// invente ce que ça a rapporté.
+//
+// Périmètre de confidentialité : Prézage et Llama 3 sont nommables ; le contenu du
+// corpus, les données et les chiffres du projet restent hors ligne.
+
+import type { IRealisation } from '@/interfaces/IRealisation'
+import { CADRE_MAILINGVOX } from './cadres'
+
+export const REALISATION_PREZAGE_LLAMA: IRealisation = {
+  slug: 'prezage-llama-3',
+  titre: 'Spécialiser un Llama 3 sur un métier, pour une application mobile',
+  chapo:
+    'Le problème posé était du langage, sur un métier précis : un modèle généraliste répondait ' +
+    'à côté. Llama 3 a été spécialisé sur un corpus métier, complété par un procédé maison ' +
+    'd’augmentation du contexte.',
+  meta: {
+    title: 'Prézage — un Llama 3 spécialisé sur un métier',
+    description:
+      'Fine-tuning de Llama 3 sur corpus métier pour l’application Prézage, complété par un ' +
+      'procédé maison d’augmentation du contexte. Aucun framework tiers.',
+  },
+  cadre: CADRE_MAILINGVOX,
+  poles: ['data', 'ia'],
+  probleme:
+    'L’application mobile Prézage avait besoin de réponses justes sur un métier précis. Un ' +
+    'modèle généraliste répond bien en général, et à côté en particulier.',
+  etapes: [
+    {
+      titre: 'Fine-tuning de Llama 3',
+      texte:
+        'Le modèle a été spécialisé sur un corpus métier. Ce que contient ce corpus, d’où il ' +
+        'vient et ce qu’il pèse ne sont pas publiés : ils sont couverts par un accord de ' +
+        'confidentialité.',
+    },
+    {
+      titre: 'Une augmentation de contexte faite maison',
+      texte:
+        'Un procédé maison, proche du RAG, complète le fine-tuning. Écrit à la main, sans ' +
+        'framework tiers.',
+    },
+    {
+      titre: 'L’arbitrage, refait à chaque cas d’usage',
+      texte:
+        'Coût, latence, qualité et confidentialité comparés en continu entre un modèle ' +
+        'open-weight hébergé et un service tiers. La réponse change selon le cas, pas selon ' +
+        'la mode.',
+    },
+  ],
+  resultat:
+    'Charge de travail des prestataires réduite. Le résultat n’est pas chiffré : les chiffres ' +
+    'du projet sont couverts par l’accord de confidentialité.',
+  decision:
+    'Modèle hébergé chez vous ou service tiers — et ce que chacun vous coûte par mois, une ' +
+    'fois la confidentialité mise dans la balance.',
+}
+
+export const REALISATION_DEPOT_VOCAL: IRealisation = {
+  slug: 'echecs-depot-vocal',
+  titre: 'Anticiper les échecs de dépôt vocal avec un modèle supervisé',
+  chapo:
+    'L’échec d’un dépôt vocal ne se constatait qu’après coup, une fois la route déjà empruntée. ' +
+    'Un modèle supervisé, entraîné sur les caractéristiques du signal audio, le voit venir.',
+  meta: {
+    title: 'Anticiper les échecs de dépôt vocal — modèle supervisé',
+    description:
+      'Modèle supervisé en production — TensorFlow, inférence en cloud functions — ' +
+      'anticipant les échecs de dépôt vocal. Extraction du signal publiée sur arXiv.',
+  },
+  cadre: CADRE_MAILINGVOX,
+  poles: ['data', 'ia'],
+  probleme:
+    'Certaines routes vocales échouaient au dépôt du message. L’échec ne se constatait qu’après ' +
+    'coup, une fois la route déjà empruntée — et facturée.',
+  etapes: [
+    {
+      titre: 'Extraire les caractéristiques du signal',
+      texte:
+        'La méthode d’extraction des caractéristiques du signal audio est publiée sur arXiv. ' +
+        'Je l’ai implémentée moi-même, puis adaptée aux données réelles.',
+    },
+    {
+      titre: 'Un modèle supervisé, mis en production',
+      texte:
+        'TensorFlow, inférence en cloud functions. Versioning et monitoring du modèle, comme ' +
+        'pour n’importe quel composant qui tourne.',
+    },
+    {
+      titre: 'Industrialisé, pas prototypé',
+      texte:
+        'CI/CD Docker et GitHub Actions, Vertex AI, Pub/Sub, Cloud Run, VM Compute Engine ' +
+        'auto-scalées. Pas de cluster Kubernetes administré en propre.',
+    },
+  ],
+  resultat:
+    'Routes vocales coûteuses évitées. Le gain n’est pas chiffré ici : je n’en publie pas de ' +
+    'mesure.',
+  decision:
+    'À partir de quel taux d’échec un modèle coûte moins cher que les routes qu’il évite — et ' +
+    'jusqu’où il faut le surveiller ensuite.',
+}
+
+export const REALISATION_RAG_SUPPORT: IRealisation = {
+  slug: 'rag-support-niveau-1',
+  titre: 'Répondre aux tickets de niveau 1 depuis la documentation interne',
+  chapo:
+    'Les questions du support de niveau 1 ont déjà leur réponse écrite quelque part. Un RAG ' +
+    'documentaire fait maison va la chercher, au lieu de laisser un modèle répondre de mémoire.',
+  meta: {
+    title: 'RAG documentaire fait maison pour le support',
+    description:
+      'Réponse automatisée aux tickets de support de niveau 1 : recherche vectorielle ' +
+      'PostgreSQL et API OpenAI, réponses ancrées sur la documentation interne.',
+  },
+  cadre: CADRE_MAILINGVOX,
+  poles: ['data', 'ia'],
+  probleme:
+    'Les tickets de support de niveau 1 posent des questions dont la réponse est déjà dans la ' +
+    'documentation interne. Un modèle qui répond de mémoire invente une réponse plausible — ' +
+    'c’est le pire des deux mondes pour un support.',
+  etapes: [
+    {
+      titre: 'La recherche vectorielle dans PostgreSQL',
+      texte:
+        'La base documentaire est indexée là où vivent déjà les données : pas de base ' +
+        'vectorielle supplémentaire à exploiter, à sauvegarder et à surveiller.',
+    },
+    {
+      titre: 'Des réponses ancrées sur les documents',
+      texte:
+        'API OpenAI, réponse construite sur les passages retrouvés et non sur la mémoire du ' +
+        'modèle.',
+    },
+    {
+      titre: 'Aucun framework tiers',
+      texte:
+        'Le RAG est écrit à la main. Ce qui tourne en production est ce que je peux corriger ' +
+        'sans attendre la version suivante d’une bibliothèque.',
+    },
+  ],
+  resultat:
+    'Aucun résultat n’est publié ici : je n’en ai pas de mesuré. Cette fiche décrit ce qui a ' +
+    'été construit, pas ce que ça a rapporté.',
+  decision: 'Ce que vous laissez répondre automatiquement, et ce qui doit rester devant un humain.',
+}
+
+export const REALISATION_LTV_MULTI_SOURCES: IRealisation = {
+  slug: 'mesure-ltv-multi-sources',
+  titre: 'Mesurer la rentabilité client à long terme, sources réconciliées',
+  chapo:
+    'Une régie mesure ce qu’elle a servi, et ne sait pas qu’elle parle du même client qu’une ' +
+    'autre. Le système agrège les sources, réconcilie les identités et mesure la valeur dans ' +
+    'la durée.',
+  meta: {
+    title: 'Mesurer la rentabilité client à long terme',
+    description:
+      'Système d’analyse multi-sources conforme RGPD mesurant la rentabilité client à long ' +
+      'terme : agrégation et réconciliation des identités.',
+  },
+  cadre: CADRE_MAILINGVOX,
+  poles: ['data', 'sea-ux'],
+  probleme:
+    'Chaque régie mesure ce qu’elle a servi. Aucune ne dit ce qu’un client rapporte sur deux ' +
+    'ans, et aucune ne sait qu’elle parle du même client qu’une autre.',
+  etapes: [
+    {
+      titre: 'Agréger, sur le modèle métier',
+      texte:
+        'Régies — Google Ads, Bing Ads —, produit et CRM agrégés dans un même modèle, construit ' +
+        'sur l’activité plutôt que sur un connecteur générique.',
+    },
+    {
+      titre: 'Réconcilier les identités',
+      texte:
+        'Dédoublonnage, contrôles d’intégrité et de véracité dès l’ingestion, détection ' +
+        'd’anomalies. La qualité est un prérequis, pas un correctif.',
+    },
+    {
+      titre: 'La conformité conditionne la collecte',
+      texte:
+        'RGPD, consentement et déclenchement conditionnel des tags par catégorie. RGPD et DORA ' +
+        'tels qu’ils sont exigés en appel d’offres par la distribution, l’assurance et la ' +
+        'banque.',
+    },
+  ],
+  resultat:
+    'Aucun résultat n’est publié ici : je n’en ai pas de mesuré. Le système existe et il ' +
+    'tourne — c’est tout ce que cette fiche affirme.',
+  decision:
+    'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre — la ' +
+    'rentabilité réelle, pas celle que la régie déclare.',
+}

--- a/src/@vitrine/contenu/realisations/mailingvox-produits.ts
+++ b/src/@vitrine/contenu/realisations/mailingvox-produits.ts
@@ -1,0 +1,163 @@
+// mailingvox-produits.ts — jeromemarichez-fr
+// Acetelecom / MailingVox, 2023-2026 : ce qui a été construit et exploité.
+//
+// Le cadre d'emploi est partagé par toutes les fiches d'ici (`cadres.ts`). Le fichier est
+// séparé de `mailingvox-donnee.ts` pour la seule raison qui vaille dans ce dépôt : la
+// limite de 300 lignes par fichier (docs/tooling.md).
+//
+// Périmètre de confidentialité appliqué : Prézage et Llama 3 sont nommables (autorisation
+// explicite de Jérôme MARICHEZ, 2026-08-07) ; le contenu du corpus, les données et les
+// chiffres du projet restent hors ligne. « Chiffre d'affaires maintenu » n'est donc pas
+// publié ici, et ne l'est nulle part sur le site.
+
+import type { IRealisation } from '@/interfaces/IRealisation'
+import type { IRealisationChiffree } from '@/interfaces/IRealisationChiffree'
+import { CADRE_MAILINGVOX } from './cadres'
+
+/** Fiche chiffrée : le 98/100 Lighthouse du mur de preuves se déplie ici. */
+export const REALISATION_SMS_EN_MASSE: IRealisationChiffree = {
+  slug: 'sms-en-masse-plateforme',
+  titre: 'Internaliser une plateforme SaaS exploitée en marque blanche',
+  chapo:
+    'Le produit vendu aux clients de MailingVox était une solution tierce exploitée en marque ' +
+    'blanche. Il a été remplacé par une plateforme développée en interne, dont le ' +
+    'référencement technique est une propriété du code et non d’un fournisseur.',
+  meta: {
+    title: 'Plateforme SaaS « Sms En Masse » — 98/100 Lighthouse',
+    description:
+      'Une solution tierce en marque blanche remplacée par une plateforme SaaS développée en ' +
+      'interne : rendu arbitré page par page, 98/100 au score Lighthouse.',
+  },
+  cadre: CADRE_MAILINGVOX,
+  poles: ['ingenierie-web', 'sea-ux'],
+  probleme:
+    'La plateforme « Sms En Masse » était une solution tierce revendue en marque blanche. ' +
+    'Tout ce qui touchait au produit — sa vitesse, ses pages, son référencement — se ' +
+    'décidait ailleurs.',
+  etapes: [
+    {
+      titre: 'Un produit développé en propre',
+      texte:
+        'La solution tierce a été remplacée par une plateforme SaaS écrite en interne, front ' +
+        'React et Next.js.',
+    },
+    {
+      titre: 'Une stratégie de rendu par type de page',
+      texte:
+        'CSR, SSR, SSG ou ISR selon ce que la page doit servir. Performance perçue, coût ' +
+        'serveur et référencement s’arbitrent page par page, pas une fois pour tout le site.',
+    },
+    {
+      titre: 'L’accessibilité tenue en parallèle',
+      texte:
+        'Conformité RGAA / WCAG traitée pendant la construction. Reprise après coup, elle ' +
+        'aurait demandé de rouvrir les mêmes pages une seconde fois.',
+    },
+  ],
+  resultat:
+    'Le produit est développé, mesuré et exploité en interne, et son référencement technique ' +
+    'est traité comme une propriété du code.',
+  chiffre: {
+    chiffre: '98/100',
+    libelle: 'au score Lighthouse',
+    portee:
+      'Le score porte sur la plateforme livrée, mesuré par Lighthouse. C’est une mesure de la ' +
+      'page — pas une mesure d’audience, pas un chiffre d’affaires.',
+  },
+  decision:
+    'Quelle page se rend au build, laquelle à la requête — et ce que chacune coûte en serveur ' +
+    'comme en référencement.',
+}
+
+export const REALISATION_PREZAGE_MIGRATION: IRealisation = {
+  slug: 'prezage-migration-mobile',
+  titre: 'Migrer une application mobile sans geler la roadmap',
+  chapo:
+    'L’application Prézage tournait sur Ionic 6 et Angular 15. Les deux migrations ont été ' +
+    'menées pendant que le produit continuait d’évoluer, sans interruption de service.',
+  meta: {
+    title: 'Prézage — migrer Ionic et Angular sans coupure',
+    description:
+      'Migration Ionic 6 vers 8 et Angular 15 vers 19 de l’application mobile Prézage, sans ' +
+      'interruption de service ni gel de la roadmap produit.',
+  },
+  cadre: CADRE_MAILINGVOX,
+  poles: ['ingenierie-web'],
+  probleme:
+    'L’application mobile Prézage accumulait de la dette sur deux socles vieillissants. ' +
+    'L’arrêter le temps d’une migration n’était pas une option : la roadmap produit ' +
+    'continuait, et une application figée est une application qu’on désinstalle.',
+  etapes: [
+    {
+      titre: 'Ionic 6 vers 8, Angular 15 vers 19',
+      texte:
+        'Deux migrations menées par paliers sur iOS et Android, en gardant à chaque palier ' +
+        'une version livrable.',
+    },
+    {
+      titre: 'La dette résorbée en cours de route',
+      texte:
+        'Le rattrapage technique s’est fait dans le même mouvement, plutôt que dans un chantier ' +
+        'à part qui n’aurait jamais été priorisé.',
+    },
+    {
+      titre: 'Parcours et échecs suivis',
+      texte:
+        'Firebase Analytics et Crashlytics, jusqu’au correctif. Pas d’autre outillage de mesure ' +
+        'mobile.',
+    },
+  ],
+  resultat:
+    'Les deux migrations ont été menées sans interruption de service et sans gel de la ' +
+    'roadmap. Les chiffres du projet ne sont pas publiés : ils sont couverts par un accord de ' +
+    'confidentialité.',
+  decision:
+    'Ce qu’on migre ce trimestre, ce qu’on gèle, et le coût réel de l’attente sur un produit ' +
+    'qui continue de sortir des versions.',
+}
+
+export const REALISATION_ANTI_FRAUDE: IRealisation = {
+  slug: 'regles-anti-fraude',
+  titre: 'Tirer des règles anti-fraude de l’historique des inscriptions',
+  chapo:
+    'La question n’était pas de savoir s’il fallait un modèle, mais ce que l’historique disait ' +
+    'déjà. Il disait assez pour écrire des règles explicites, moins chères à faire tourner et ' +
+    'plus simples à corriger.',
+  meta: {
+    title: 'Règles anti-fraude tirées de l’historique',
+    description:
+      'Analyse exploratoire de l’historique des inscriptions sous Orange Data Mining, puis ' +
+      'règles anti-fraude explicites implémentées dans le produit.',
+  },
+  cadre: CADRE_MAILINGVOX,
+  poles: ['ingenierie-web', 'data'],
+  probleme:
+    'Des inscriptions frauduleuses passaient. Le réflexe aurait été d’entraîner un modèle ; ' +
+    'l’historique n’avait pas encore été lu.',
+  etapes: [
+    {
+      titre: 'Faire parler l’historique',
+      texte:
+        'Analyse exploratoire des inscriptions sous Orange Data Mining : pondération et ' +
+        'sélection des variables, élimination des corrélations fortes et du bruit.',
+    },
+    {
+      titre: 'Des règles plutôt qu’un modèle',
+      texte:
+        'Les caractéristiques discriminantes sortent de l’analyse, et une règle explicite les ' +
+        'applique. Moins chère à faire tourner, plus simple à corriger, et explicable à ' +
+        'quelqu’un qui demande pourquoi une inscription a été refusée.',
+    },
+    {
+      titre: 'Implémentées dans le produit',
+      texte:
+        'Les règles ont été intégrées au produit par la même personne que celle qui les a ' +
+        'définies — aucun aller-retour de spécification entre l’analyse et le code.',
+    },
+  ],
+  resultat:
+    'Fraude en baisse, conversion des inscriptions en hausse, latence réduite. Aucun de ces ' +
+    'trois résultats n’est chiffré ici : je n’en publie pas de mesure.',
+  decision:
+    'Ce qui se règle par une règle intégrée à l’existant, et ce qui mérite vraiment un modèle.',
+}

--- a/src/@vitrine/contenu/realisations/realisations-index.ts
+++ b/src/@vitrine/contenu/realisations/realisations-index.ts
@@ -1,0 +1,30 @@
+// realisations-index.ts — jeromemarichez-fr
+// L'en-tête éditoriale de la liste. Les fiches, elles, viennent de `realisations.ts`.
+
+import { ROUTES } from '@/@shared/routes'
+import type { IRealisationsIndex } from '@/interfaces/IRealisationsIndex'
+
+/**
+ * Le libellé « Réalisations » est repris à l'identique dans la navigation, le fil
+ * d'Ariane, le titre de la page et l'URL — même règle que pour le blog.
+ *
+ * Le chapô porte l'arbitrage de nom, et il le porte en clair plutôt qu'en note de bas de
+ * page : un visiteur qui arrive ici cherche des références clients, et il doit apprendre
+ * en deux phrases que ce n'en sont pas. Le dire franchement vaut mieux que le laisser
+ * découvrir fiche par fiche.
+ */
+export const REALISATIONS_INDEX: IRealisationsIndex = {
+  route: ROUTES.realisations,
+  titre: 'Réalisations',
+  meta: {
+    title: 'Réalisations — ce que j’ai construit, et dans quel cadre',
+    description:
+      'Treize réalisations avec leur cadre d’emploi réel : intitulé de poste, période, ' +
+      'équipe. Trois portent un chiffre, les autres n’en portent aucun.',
+  },
+  chapo:
+    'Ce ne sont pas des cas clients : ce sont trois postes salariés, et chaque fiche porte le ' +
+    'cadre dans lequel elle a été menée — intitulé exact, période, équipe. Trois fiches ' +
+    'portent un chiffre ; les autres n’en portent aucun, parce que je ne publie que les ' +
+    'chiffres que je peux tenir.',
+}

--- a/src/@vitrine/contenu/realisations/realisations.ts
+++ b/src/@vitrine/contenu/realisations/realisations.ts
@@ -1,0 +1,56 @@
+// realisations.ts — jeromemarichez-fr
+// La liste des réalisations publiées. Source unique de l'espace `/realisations/`.
+//
+// Tout part d'ici : la liste, les fiches générées au build, le sitemap et les données
+// structurées. Une fiche retirée de ce tableau disparaît partout — il n'y a pas de second
+// endroit à mettre à jour.
+//
+// L'ORDRE DE CE TABLEAU EST L'ORDRE D'AFFICHAGE, à l'intérieur de chaque cadre d'emploi.
+// Le regroupement, lui, est une règle métier : il vit dans
+// `@vitrine/services/find-realisation` et suit l'ordre de `CADRES`.
+//
+// Une convention tenue à la main : chaque cadre s'ouvre sur sa fiche chiffrée quand il en
+// a une, puis déroule du produit vers la donnée. Le type ne peut pas l'imposer — trois
+// fiches chiffrées sur treize ne font pas une règle exprimable.
+
+import type { IRealisation } from '@/interfaces/IRealisation'
+import {
+  REALISATION_DEPOT_VOCAL,
+  REALISATION_LTV_MULTI_SOURCES,
+  REALISATION_PREZAGE_LLAMA,
+  REALISATION_RAG_SUPPORT,
+} from './mailingvox-donnee'
+import {
+  REALISATION_ANTI_FRAUDE,
+  REALISATION_PREZAGE_MIGRATION,
+  REALISATION_SMS_EN_MASSE,
+} from './mailingvox-produits'
+import {
+  REALISATION_ARTEDRONE_AMOA,
+  REALISATION_BUDGET_ADS,
+  REALISATION_TRUFFLE_SITES,
+} from './truffle'
+import {
+  REALISATION_PARCOURS_ACHAT,
+  REALISATION_VERHOEVEN_ERP,
+  REALISATION_VERHOEVEN_MIGRATIONS,
+} from './verhoeven'
+
+export const REALISATIONS: IRealisation[] = [
+  // Acetelecom / MailingVox, 2023-2026
+  REALISATION_SMS_EN_MASSE,
+  REALISATION_PREZAGE_MIGRATION,
+  REALISATION_ANTI_FRAUDE,
+  REALISATION_DEPOT_VOCAL,
+  REALISATION_PREZAGE_LLAMA,
+  REALISATION_RAG_SUPPORT,
+  REALISATION_LTV_MULTI_SOURCES,
+  // Verhoeven Joaillier, 2019-2022
+  REALISATION_PARCOURS_ACHAT,
+  REALISATION_VERHOEVEN_MIGRATIONS,
+  REALISATION_VERHOEVEN_ERP,
+  // Truffle Capital, 2017-2019
+  REALISATION_BUDGET_ADS,
+  REALISATION_TRUFFLE_SITES,
+  REALISATION_ARTEDRONE_AMOA,
+]

--- a/src/@vitrine/contenu/realisations/truffle.ts
+++ b/src/@vitrine/contenu/realisations/truffle.ts
@@ -1,0 +1,157 @@
+// truffle.ts — jeromemarichez-fr
+// Truffle Capital, 2017-2019 : capital-risque, sites du fonds et de ses participations.
+//
+// Trois précautions valent pour tout ce fichier :
+//
+// - **Artedrone est une participation du fonds**, pas un client de Jérôme. La fiche le
+//   dit, et le rôle tenu y est l'AMOA — rien n'est affirmé sur le dispositif médical.
+// - Le **100 000 €** est un budget **piloté**, jamais un résultat. Aucun retour sur
+//   investissement, aucun coût d'acquisition, aucun volume de trafic n'existe en source.
+// - L'équipe coordonnée est **marketing**, et Google Tag Manager n'appartient pas à cette
+//   période (`CLAUDE.md`).
+
+import type { IRealisation } from '@/interfaces/IRealisation'
+import type { IRealisationChiffree } from '@/interfaces/IRealisationChiffree'
+import { CADRE_TRUFFLE } from './cadres'
+
+/** Fiche chiffrée : le 100 000 € de budget piloté du mur de preuves se déplie ici. */
+export const REALISATION_BUDGET_ADS: IRealisationChiffree = {
+  slug: 'truffle-budget-ads-seo',
+  titre: 'Piloter un budget d’acquisition et le justifier devant des dirigeants',
+  chapo:
+    'Un budget d’acquisition se pilote dans les interfaces des régies, et se justifie devant ' +
+    'des gens qui ne les ouvrent jamais. Les deux moitiés du travail étaient sur le même poste.',
+  meta: {
+    title: 'Piloter un budget ADS / SEO de 100 000 €',
+    description:
+      'Budget ADS / SEO de 100 000 € piloté, mesuré et justifié auprès des dirigeants chez ' +
+      'Truffle Capital, avec une équipe marketing et trois prestataires.',
+  },
+  cadre: CADRE_TRUFFLE,
+  poles: ['data', 'sea-ux'],
+  probleme:
+    'Le budget d’acquisition du fonds et de ses participations devait être arbitré chaque ' +
+    'mois, puis expliqué à des dirigeants qui n’ouvrent pas les interfaces des régies.',
+  etapes: [
+    {
+      titre: 'Un budget mesuré',
+      texte:
+        'Google Ads, Bing Ads, SEO, SEA et SMA. Taux de conversion et A/B testing, sur les ' +
+        'sites que j’exploitais moi-même.',
+    },
+    {
+      titre: 'Un budget justifié',
+      texte:
+        'Chaque arbitrage a été présenté aux dirigeants avec le chiffre qui le fonde, et non ' +
+        'avec la capture d’écran d’un tableau de bord.',
+    },
+    {
+      titre: 'Une équipe et des prestataires coordonnés',
+      texte:
+        'Une équipe marketing et SEO/SEA de 5 à 10 personnes et trois prestataires externes, ' +
+        'sur le périmètre, le planning et la qualité.',
+    },
+  ],
+  resultat:
+    'Le budget a été piloté de bout en bout, mesuré et justifié. Cette fiche ne publie aucun ' +
+    'résultat de campagne — ni retour sur investissement, ni coût d’acquisition, ni trafic : ' +
+    'je n’en publie pas de mesure.',
+  chiffre: {
+    chiffre: '100 000 €',
+    libelle: 'de budget ADS / SEO piloté',
+    portee:
+      'C’est un budget piloté, pas un résultat : il dit ce qui a été confié, jamais ce que ' +
+      'ça a rapporté. La durée sur laquelle il court n’est pas publiée.',
+  },
+  decision:
+    'Ce que vous présentez à votre conseil pour tenir une ligne budgétaire — et sur quel ' +
+    'chiffre, quand la régie et la comptabilité ne disent pas la même chose.',
+}
+
+export const REALISATION_TRUFFLE_SITES: IRealisation = {
+  slug: 'truffle-sites',
+  titre: 'Refondre puis exploiter les sites d’un fonds et de ses participations',
+  chapo:
+    'Trois sites, trois publics qui n’ont rien en commun, une seule personne de la conception ' +
+    'à l’exploitation.',
+  meta: {
+    title: 'Refonte des sites d’un fonds de capital-risque',
+    description:
+      'Refonte full stack de truffle.com, truffle100.fr et artedrone.fr, de la conception à ' +
+      'l’exploitation, une équipe marketing et trois prestataires.',
+  },
+  cadre: CADRE_TRUFFLE,
+  poles: ['ingenierie-web'],
+  probleme:
+    'Le fonds, son classement annuel et une participation avaient chacun leur site, leur ' +
+    'public et leur calendrier. Les trois étaient à refondre, puis à faire tourner.',
+  etapes: [
+    {
+      titre: 'Refonte full stack',
+      texte: 'truffle.com, truffle100.fr et artedrone.fr, de la conception à l’exploitation.',
+    },
+    {
+      titre: 'Un seul interlocuteur sur les trois',
+      texte:
+        'Conception, développement, mise en production et exploitation tenus par la même ' +
+        'personne — ce qui évitait d’arbitrer trois fois les mêmes questions.',
+    },
+    {
+      titre: 'La coordination',
+      texte:
+        'Une équipe marketing et SEO/SEA de 5 à 10 personnes et trois prestataires externes, ' +
+        'sur des calendriers qui ne se recouvraient pas.',
+    },
+  ],
+  resultat:
+    'Les trois sites ont été refondus, mis en production et exploités. Ils ont pu être refaits ' +
+    'depuis 2019 : cette fiche ne renvoie donc vers aucun d’eux, ce qui s’y trouve aujourd’hui ' +
+    'ne m’appartient plus.',
+  decision: 'Ce qui se mutualise entre plusieurs sites, et ce qui doit rester propre à chacun.',
+}
+
+export const REALISATION_ARTEDRONE_AMOA: IRealisation = {
+  slug: 'artedrone-amoa',
+  titre: 'Traduire le besoin d’une startup biotech en spécifications exécutables',
+  chapo:
+    'Le besoin était porté par des équipes scientifiques et dirigeantes. Il devait devenir ' +
+    'lisible par des prestataires qui ne connaissaient pas le domaine. C’est tout le travail.',
+  meta: {
+    title: 'AMOA d’une startup biotech — du besoin aux spécifications',
+    description:
+      'AMOA de la startup biotech Artedrone : besoin recueilli auprès des équipes ' +
+      'scientifiques et dirigeantes, BPMN 2.0 et cartographie du système d’information.',
+  },
+  cadre: CADRE_TRUFFLE,
+  // Un seul pôle, et c'est la démonstration : la donnée se livre pour elle-même. Aucun
+  // développement n'a suivi de mon côté, et la fiche ne prétend pas le contraire.
+  poles: ['data'],
+  probleme:
+    'Artedrone, startup biotech et participation du fonds, portait un besoin dans les termes ' +
+    'de ses équipes scientifiques et dirigeantes. Des prestataires extérieurs au domaine ' +
+    'devaient pouvoir l’exécuter.',
+  etapes: [
+    {
+      titre: 'Recueillir auprès de ceux qui savent',
+      texte:
+        'Besoin recueilli auprès des équipes scientifiques et dirigeantes, dans leurs termes ' +
+        'avant d’être traduit dans les miens.',
+    },
+    {
+      titre: 'Mettre par écrit',
+      texte: 'BPMN 2.0 et cartographie du système d’information.',
+    },
+    {
+      titre: 'Écrire pour quelqu’un d’autre que soi',
+      texte:
+        'Les spécifications devaient être lues et exécutées par des prestataires non ' +
+        'spécialistes. C’est cette contrainte qui a commandé leur forme, pas une norme ' +
+        'documentaire.',
+    },
+  ],
+  resultat:
+    'Les spécifications ont été livrées et se sont révélées exploitables par des prestataires ' +
+    'extérieurs au domaine. Rien n’est affirmé ici sur le dispositif médical lui-même : le ' +
+    'périmètre tenu était l’AMOA.',
+  decision: 'Ce qui entre dans la version 1, et ce qui attend sans bloquer le reste.',
+}

--- a/src/@vitrine/contenu/realisations/verhoeven.ts
+++ b/src/@vitrine/contenu/realisations/verhoeven.ts
@@ -1,0 +1,158 @@
+// verhoeven.ts — jeromemarichez-fr
+// Verhoeven Joaillier, 2019-2022 : e-commerce de joaillerie de luxe, poste unique.
+//
+// **Interdiction nominative appliquée ici** : Google Tag Manager n'appartient pas à cette
+// période (`CLAUDE.md`). Ce qui est revendiqué chez Verhoeven, c'est Google Analytics, de
+// l'A/B testing et des heatmaps — rien de plus.
+//
+// Deuxième garde-fou : le poste était unique. Aucune de ces fiches ne doit laisser croire
+// à l'encadrement de développeurs ; ce qui a été encadré, ce sont des prestataires SEA,
+// SEO et SMA, et c'est écrit dans le cadre d'emploi.
+//
+// Troisième : le +50 % porte sur le **panier moyen**. Ni chiffre d'affaires, ni taux de
+// conversion, ni revenus — trois affirmations différentes, dont deux ne sont pas sourcées.
+
+import type { IRealisation } from '@/interfaces/IRealisation'
+import type { IRealisationChiffree } from '@/interfaces/IRealisationChiffree'
+import { CADRE_VERHOEVEN } from './cadres'
+
+/** Fiche chiffrée : le +50 % de panier moyen du mur de preuves se déplie ici. */
+export const REALISATION_PARCOURS_ACHAT: IRealisationChiffree = {
+  slug: 'verhoeven-parcours-achat',
+  titre: 'Refondre les parcours d’achat d’un e-commerce de joaillerie',
+  chapo:
+    'Les tunnels d’achat se discutaient au goût. Ils ont été refondus sur ce que la mesure ' +
+    'disait du visiteur réel — et l’arbitrage décidé était implémenté par la même personne.',
+  meta: {
+    title: 'Refonte des parcours d’achat — panier moyen +50 %',
+    description:
+      'Refonte des tunnels d’achat d’un e-commerce de joaillerie de luxe pilotée par la ' +
+      'mesure : A/B testing des pages et des designs, heatmaps, taux de rebond.',
+  },
+  cadre: CADRE_VERHOEVEN,
+  // Les trois pôles de la chaîne SANS l'IA : construire, mesurer, arbitrer. C'est la
+  // démonstration la plus directe que rien n'oblige à acheter de l'IA pour tirer parti de
+  // sa donnée — et elle est vraie, ce travail n'en a jamais employé.
+  poles: ['ingenierie-web', 'data', 'sea-ux'],
+  probleme:
+    'Les tunnels d’achat se discutaient au goût, page par page. Sur un catalogue de pièces ' +
+    'uniques, une étape de trop coûte une commande — encore fallait-il savoir laquelle.',
+  etapes: [
+    {
+      titre: 'Mesurer avant de trancher',
+      texte:
+        'Google Analytics, heatmaps, taux de rebond, part de trafic mobile : ce que fait le ' +
+        'visiteur réel, pas ce qu’on suppose qu’il fait.',
+    },
+    {
+      titre: 'Tester, page par page',
+      texte:
+        'A/B testing des pages et des designs. Une étape disparaît parce que les chiffres le ' +
+        'disent, pas parce qu’elle déplaît.',
+    },
+    {
+      titre: 'Implémenter soi-même',
+      texte:
+        'Aucun devis et aucun transfert de dossier entre la lecture du chiffre et la ' +
+        'modification du code : c’était le même poste.',
+    },
+  ],
+  resultat:
+    'Les parcours d’achat ont été refondus sur la mesure, et le panier moyen a suivi. Aucune ' +
+    'création graphique dans ce travail : des arbitrages de parcours, puis leur implémentation.',
+  chiffre: {
+    chiffre: '+50 %',
+    libelle: 'de panier moyen',
+    portee:
+      'Le chiffre porte sur le panier moyen et sur rien d’autre : ce n’est ni du chiffre ' +
+      'd’affaires, ni un taux de conversion. La période de mesure et la base de comparaison ne ' +
+      'sont pas publiées.',
+  },
+  decision: 'Quelle étape du tunnel disparaît, et ce que vous gagnez à la supprimer.',
+}
+
+export const REALISATION_VERHOEVEN_MIGRATIONS: IRealisation = {
+  slug: 'verhoeven-migrations',
+  titre: 'Deux migrations sans jamais couper le site marchand',
+  chapo:
+    'PHP 5 vers 7 puis réécriture en Node.js, jQuery vers React. Un site marchand ne se met ' +
+    'pas en maintenance le temps d’une réécriture — et celui-ci a aussi fallu l’exploiter.',
+  meta: {
+    title: 'Deux migrations sans couper un site marchand',
+    description:
+      'PHP 5 vers 7 puis réécriture Node.js, jQuery vers React, sans interruption du site ' +
+      'marchand. Serveurs administrés, pics saisonniers absorbés.',
+  },
+  cadre: CADRE_VERHOEVEN,
+  poles: ['ingenierie-web'],
+  probleme:
+    'Le site marchand tournait sur PHP 5 et jQuery. Sur un e-commerce, chaque heure ' +
+    'd’indisponibilité est une heure de vente perdue : la migration devait se faire sous le ' +
+    'trafic.',
+  etapes: [
+    {
+      titre: 'PHP 5 vers 7, puis la réécriture en Node.js',
+      texte:
+        'Migration du socle d’abord, réécriture ensuite. Deux mouvements séparés, pour que ' +
+        'l’échec de l’un ne fasse pas tomber l’autre.',
+    },
+    {
+      titre: 'jQuery vers React',
+      texte:
+        'Le front est passé à React par pages, en gardant à chaque étape un site marchand ' +
+        'complet et vendable.',
+    },
+    {
+      titre: 'Le run, tenu en même temps',
+      texte:
+        'Serveurs Apache et Linux, on-premise et IaaS. Les pics saisonniers d’un site de ' +
+        'joaillerie ont été absorbés sans incident, SLI et SLO définis et suivis.',
+    },
+  ],
+  resultat:
+    'Les deux migrations ont été menées sans interruption du site marchand, sur un poste ' +
+    'unique.',
+  decision:
+    'Ce qui se migre par étapes et ce qui se réécrit — et ce que chaque option coûte en ' +
+    'risque d’arrêt.',
+}
+
+export const REALISATION_VERHOEVEN_ERP: IRealisation = {
+  slug: 'verhoeven-erp-m3',
+  titre: 'Brancher un ERP sur un site marchand de pièces uniques',
+  chapo:
+    'La boutique physique et le site vendaient le même stock sans se parler. Les flux ont ' +
+    'été modélisés en BPMN avec ceux qui les appliquent, puis l’ERP a été intégré.',
+  meta: {
+    title: 'Intégrer un ERP à un site marchand de pièces uniques',
+    description:
+      'Modélisation BPMN 2.0 des flux commande, stock et facturation, puis intégration de ' +
+      'l’ERP M3 Soft et synchronisation boutique physique / e-commerce.',
+  },
+  cadre: CADRE_VERHOEVEN,
+  poles: ['ingenierie-web', 'data'],
+  probleme:
+    'La boutique physique et le site vendaient le même stock sans se parler. Sur des pièces ' +
+    'uniques, deux ventes simultanées de la même pièce ne se rattrapent pas : il faut ' +
+    'rappeler un client.',
+  etapes: [
+    {
+      titre: 'Modéliser avant d’intégrer',
+      texte:
+        'Flux commande, stock et facturation modélisés en BPMN 2.0, avec les équipes qui les ' +
+        'appliquent au quotidien. Plusieurs règles n’avaient jamais été écrites.',
+    },
+    {
+      titre: 'Intégrer l’ERP M3 Soft',
+      texte: 'Synchronisation de la boutique physique et du e-commerce sur un même état de stock.',
+    },
+    {
+      titre: 'Cadrer les données clients',
+      texte:
+        'Les données clients traitées par les deux canaux ont été cadrées avec ce que le RGPD ' +
+        'autorise, avant l’intégration et non après.',
+    },
+  ],
+  resultat: 'Survente évitée sur des pièces uniques.',
+  decision: 'Ce qui reste synchrone entre vos canaux, et ce qui peut attendre la nuit.',
+}

--- a/src/@vitrine/services/find-pole.ts
+++ b/src/@vitrine/services/find-pole.ts
@@ -30,3 +30,15 @@ export function findPole(id: PoleId): { pole: IPole; suites: IPole[] } {
     suites: POLES_NAV.filter((candidat) => avals.includes(candidat.id)),
   }
 }
+
+/**
+ * Les pôles désignés par une liste d'identifiants — une réalisation, par exemple.
+ *
+ * Le filtre part de `POLES_NAV` et non de la liste reçue, et c'est le point : l'ordre
+ * d'affichage est **la position dans `POLES_NAV`**, jamais celui dans lequel une fiche a
+ * déclaré ses pôles. Une fiche qui écrirait `['sea-ux', 'data']` n'inverserait donc pas
+ * la chaîne à l'écran — c'est le genre d'inversion qu'aucune relecture ne rattrape.
+ */
+export function listPoles(ids: readonly PoleId[]): IPole[] {
+  return POLES_NAV.filter((pole) => ids.includes(pole.id))
+}

--- a/src/@vitrine/services/find-realisation.ts
+++ b/src/@vitrine/services/find-realisation.ts
@@ -1,0 +1,78 @@
+// find-realisation.ts — jeromemarichez-fr
+// Les règles qui s'appliquent aux réalisations : regroupement, recherche, voisinage.
+//
+// Le contenu (`contenu/realisations/`) ne porte aucune de ces règles : il déclare des
+// fiches. Tout ce qui relève d'une décision — comment on les groupe, laquelle on propose
+// ensuite — est ici.
+
+import type { IRealisation } from '@/interfaces/IRealisation'
+import type { IRealisationGroupe } from '@/interfaces/IRealisationGroupe'
+import { CADRES } from '../contenu/realisations/cadres'
+import { REALISATIONS } from '../contenu/realisations/realisations'
+
+/**
+ * Nombre de fiches proposées au pied d'une fiche.
+ *
+ * Deux, comme pour les articles, et pour la même raison : au-delà, le bas d'une fiche
+ * devient un sommaire et cesse d'être une suite de lecture.
+ */
+export const MAX_REALISATIONS_LIEES = 2
+
+/** Les réalisations, dans l'ordre déclaré. Aucun tri : elles ne sont pas datées. */
+export function listRealisations(): IRealisation[] {
+  return REALISATIONS
+}
+
+/**
+ * Les réalisations groupées par cadre d'emploi, du poste le plus récent au plus ancien.
+ *
+ * L'ordre des groupes est celui de `CADRES`, jamais celui d'apparition dans la liste des
+ * fiches : c'est la chronologie des postes qui classe, et elle n'a aucune raison de
+ * dépendre de l'ordre dans lequel les fiches ont été écrites.
+ *
+ * Un cadre sans fiche ne produit pas de groupe vide — un employeur annoncé sans rien à
+ * montrer se lit comme une omission.
+ */
+export function groupRealisationsByCadre(): IRealisationGroupe[] {
+  return CADRES.map((cadre) => ({
+    cadre,
+    realisations: REALISATIONS.filter(
+      (realisation) => realisation.cadre.employeur === cadre.employeur,
+    ),
+  })).filter((groupe) => groupe.realisations.length > 0)
+}
+
+/**
+ * Rend la fiche demandée et jusqu'à deux autres à lire ensuite.
+ *
+ * Le voisinage se calcule sur les **pôles partagés**, et non sur le cadre d'emploi : la
+ * liste groupe déjà par employeur, et proposer trois fois le même employeur en bas de
+ * page n'apprendrait rien. Passer par les pôles montre au contraire qu'un même pôle a été
+ * mobilisé sous trois postes différents, ce qui est exactement l'argument de l'espace.
+ *
+ * Si moins de deux fiches partagent un pôle, la liste est complétée dans l'ordre déclaré :
+ * un bloc « à voir aussi » à moitié rempli se remarque plus que son absence.
+ *
+ * Lève sur un slug inconnu, volontairement : les slugs servis sont énumérés au build par
+ * `generateStaticParams`, donc un slug absent ici est une incohérence de code, pas une URL
+ * saisie par un visiteur.
+ */
+export function findRealisation(slug: string): {
+  realisation: IRealisation
+  autres: IRealisation[]
+} {
+  const realisation = REALISATIONS.find((candidat) => candidat.slug === slug)
+
+  if (!realisation) throw new Error(`Réalisation inconnue : ${slug}`)
+
+  const reste = REALISATIONS.filter((candidat) => candidat.slug !== slug)
+  const voisines = reste.filter((candidat) =>
+    candidat.poles.some((pole) => realisation.poles.includes(pole)),
+  )
+  const complement = reste.filter((candidat) => !voisines.includes(candidat))
+
+  return {
+    realisation,
+    autres: [...voisines, ...complement].slice(0, MAX_REALISATIONS_LIEES),
+  }
+}

--- a/src/@vitrine/views/RealisationView/index.tsx
+++ b/src/@vitrine/views/RealisationView/index.tsx
@@ -1,0 +1,117 @@
+// RealisationView/index.tsx — jeromemarichez-fr
+// Une fiche : son cadre d'emploi, le problème, ce qui a été fait, le résultat, la décision.
+
+import Link from 'next/link'
+import { Breadcrumb } from '@/@shared/components/Breadcrumb'
+import { toRealisationRoute } from '@/@shared/routes'
+import type { IRealisation } from '@/interfaces/IRealisation'
+import type { IRealisationsIndex } from '@/interfaces/IRealisationsIndex'
+import { EmploymentFrame } from '../../components/EmploymentFrame'
+import { PoleTagList } from '../../components/PoleTagList'
+import { RealisationCard } from '../../components/RealisationCard'
+import styles from './realisation-view.module.css'
+
+interface RealisationViewProps {
+  realisation: IRealisation
+  index: IRealisationsIndex
+  /** Fiches proposées en fin de lecture. Choisies par le service, pas par la vue. */
+  autres: IRealisation[]
+}
+
+/**
+ * Quatre sections, toujours les mêmes, toujours dans cet ordre : le problème, ce qui a été
+ * fait, le résultat, ce que ça permettait de trancher. Une fiche n'a pas de plan libre —
+ * un plan libre produit treize fiches qui ne se comparent plus, et une comparaison
+ * impossible est exactement ce qu'un prospect vient chercher ici.
+ *
+ * **Le cadre d'emploi est au-dessus du titre**, pas en bas de page. C'est la première
+ * chose lue, donc la première chose sue : ce travail a été mené sous contrat de travail,
+ * pas vendu à un client.
+ *
+ * Le chiffre, quand il existe, s'affiche avec sa **portée** — ce qu'il mesure et ce qu'il
+ * ne mesure pas. C'est la seule façon de publier « +50 % » sans qu'il se fasse élargir en
+ * « +50 % de chiffre d'affaires » par celui qui le lit.
+ */
+export function RealisationView({ realisation, index, autres }: RealisationViewProps) {
+  const route = toRealisationRoute(realisation.slug)
+
+  return (
+    <div className={styles.page}>
+      <article className={styles.fiche}>
+        <header className={styles.entete}>
+          <Breadcrumb
+            fil={[
+              { nom: index.titre, route: index.route },
+              { nom: realisation.titre, route },
+            ]}
+          />
+          <EmploymentFrame cadre={realisation.cadre} />
+          <h1 className={styles.titre}>{realisation.titre}</h1>
+          <p className={styles.chapo}>{realisation.chapo}</p>
+          <PoleTagList legende="Pôles mobilisés" poles={realisation.poles} />
+        </header>
+
+        {realisation.chiffre ? (
+          <figure className={styles.chiffre}>
+            <p className={styles.nombre}>{realisation.chiffre.chiffre}</p>
+            <p className={styles.mesure}>{realisation.chiffre.libelle}</p>
+            <figcaption className={styles.portee}>{realisation.chiffre.portee}</figcaption>
+          </figure>
+        ) : null}
+
+        <section aria-labelledby="probleme-titre" className={styles.section} id="probleme">
+          <h2 className={styles.sousTitre} id="probleme-titre">
+            Le problème posé
+          </h2>
+          <p className={styles.paragraphe}>{realisation.probleme}</p>
+        </section>
+
+        <section aria-labelledby="travail-titre" className={styles.section} id="travail">
+          <h2 className={styles.sousTitre} id="travail-titre">
+            Ce qui a été fait
+          </h2>
+          <ol className={styles.etapes}>
+            {realisation.etapes.map((etape) => (
+              <li className={styles.etape} key={etape.titre}>
+                <h3 className={styles.titreEtape}>{etape.titre}</h3>
+                <p className={styles.paragraphe}>{etape.texte}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section aria-labelledby="resultat-titre" className={styles.section} id="resultat">
+          <h2 className={styles.sousTitre} id="resultat-titre">
+            Le résultat
+          </h2>
+          <p className={styles.paragraphe}>{realisation.resultat}</p>
+        </section>
+
+        <section aria-labelledby="decision-titre" className={styles.decision} id="decision">
+          <h2 className={styles.sousTitre} id="decision-titre">
+            Ce que ça permettait de trancher
+          </h2>
+          <p className={styles.tranche}>{realisation.decision}</p>
+        </section>
+      </article>
+
+      {autres.length > 0 ? (
+        <aside aria-labelledby="a-voir-ensuite" className={styles.ensuite}>
+          <h2 className={styles.titreEnsuite} id="a-voir-ensuite">
+            Sur les mêmes pôles
+          </h2>
+          <ol className={styles.liste}>
+            {autres.map((autre) => (
+              <li key={autre.slug}>
+                <RealisationCard realisation={autre} />
+              </li>
+            ))}
+          </ol>
+          <p className={styles.retour}>
+            <Link href={index.route}>Toutes les réalisations</Link>
+          </p>
+        </aside>
+      ) : null}
+    </div>
+  )
+}

--- a/src/@vitrine/views/RealisationView/realisation-view.module.css
+++ b/src/@vitrine/views/RealisationView/realisation-view.module.css
@@ -1,0 +1,180 @@
+/* realisation-view.module.css — une fiche de réalisation.
+ * Une seule colonne, mesurée sur le texte, comme un article : la fiche se lit en continu.
+ * Aucun panneau de verre — l'effet distingue des offres (docs/design.md), et une
+ * réalisation n'en est pas une. */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-6);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-6) var(--e-4) var(--e-7);
+}
+
+.fiche {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+}
+
+.entete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+}
+
+.titre {
+  margin: 0;
+  max-width: 22ch;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-family: var(--police-titre-pile);
+  font-variation-settings: "opsz" 24;
+  font-size: var(--t-2);
+  line-height: 1.35;
+  color: var(--accent);
+}
+
+/* Le chiffre est encadré par un filet à gauche, du même dessin que les étiquettes de
+   pôle : c'est une citation dans le texte, pas une bannière. La portée est composée
+   plus petite, mais elle n'est pas grise sur grise — c'est elle qui empêche le chiffre
+   d'être élargi, elle doit se lire. */
+.chiffre {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  max-width: var(--mesure-texte);
+  margin: 0;
+  padding: var(--e-3) var(--e-4);
+  border-left: 2px solid var(--accent-vif);
+  border-radius: 0 var(--rayon-petit) var(--rayon-petit) 0;
+  background: color-mix(in srgb, var(--fond-creux) 60%, transparent);
+}
+
+.nombre {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t-chiffre);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: var(--encre);
+}
+
+.mesure {
+  font-size: var(--t-0);
+  color: var(--encre);
+}
+
+.portee {
+  font-size: var(--t-note);
+  line-height: 1.55;
+  color: var(--encre-douce);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+}
+
+.sousTitre {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-2);
+  line-height: 1.25;
+}
+
+.paragraphe {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-0);
+  line-height: 1.65;
+}
+
+.etapes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: etape;
+}
+
+/* Le numéro est décoratif — la liste est déjà un `<ol>`, et son ordre est annoncé par
+   le balisage. Le rendre en `::before` évite de le répéter dans le texte du titre, où
+   un lecteur d'écran l'entendrait deux fois. */
+.etape {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+  counter-increment: etape;
+  padding-left: var(--e-4);
+  position: relative;
+}
+
+.etape::before {
+  content: counter(etape);
+  position: absolute;
+  left: 0;
+  top: 0.1em;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  color: var(--accent);
+}
+
+.titreEtape {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.3;
+}
+
+/* La décision ferme la fiche : c'est la seule section qui reprend la teinte du site,
+   parce que c'est la seule qui s'adresse au lecteur plutôt qu'à l'histoire. */
+.decision {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+  padding-top: var(--e-4);
+  border-top: 2px solid var(--accent-vif);
+}
+
+.tranche {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.5;
+  color: var(--encre);
+}
+
+.ensuite {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+  padding-top: var(--e-5);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
+}
+
+.titreEnsuite {
+  margin: 0;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: var(--suivi-etiquette);
+  color: var(--encre-douce);
+}
+
+.liste {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.retour {
+  font-size: var(--t-note);
+}

--- a/src/@vitrine/views/RealisationsIndexView/index.tsx
+++ b/src/@vitrine/views/RealisationsIndexView/index.tsx
@@ -1,0 +1,57 @@
+// RealisationsIndexView/index.tsx — jeromemarichez-fr
+// La liste des réalisations, groupée par cadre d'emploi.
+
+import { Breadcrumb } from '@/@shared/components/Breadcrumb'
+import type { IRealisationGroupe } from '@/interfaces/IRealisationGroupe'
+import type { IRealisationsIndex } from '@/interfaces/IRealisationsIndex'
+import { EmploymentFrame } from '../../components/EmploymentFrame'
+import { RealisationCard } from '../../components/RealisationCard'
+import styles from './realisations-index-view.module.css'
+
+interface RealisationsIndexViewProps {
+  index: IRealisationsIndex
+  /** Groupes déjà constitués et classés par le service : la vue n'ordonne rien. */
+  groupes: IRealisationGroupe[]
+}
+
+/**
+ * **Le regroupement par cadre d'emploi n'est pas un classement, c'est l'argument.**
+ *
+ * Une liste plate de treize fiches se lirait comme un portfolio d'agence, et le lecteur
+ * supposerait treize commanditaires. Groupées sous trois employeurs, avec l'intitulé de
+ * poste et la période en tête de chaque groupe, les mêmes fiches disent ce qu'elles sont :
+ * du travail salarié, mené sur trois postes en neuf ans. Le cadre est donc rendu **avant**
+ * les fiches qu'il porte, jamais en note sous chacune d'elles.
+ *
+ * Chaque groupe est une `<section>` étiquetée par le nom de l'employeur : au clavier comme
+ * au lecteur d'écran, on peut passer d'un poste au suivant sans traverser ses fiches.
+ */
+export function RealisationsIndexView({ index, groupes }: RealisationsIndexViewProps) {
+  return (
+    <div className={styles.page}>
+      <header className={styles.entete}>
+        <Breadcrumb fil={[{ nom: index.titre, route: index.route }]} />
+        <h1 className={styles.titre}>{index.titre}</h1>
+        <p className={styles.chapo}>{index.chapo}</p>
+      </header>
+
+      {groupes.map((groupe) => {
+        const titreId = `cadre-${groupe.cadre.periode}`
+
+        return (
+          <section aria-labelledby={titreId} className={styles.groupe} key={titreId}>
+            <EmploymentFrame cadre={groupe.cadre} niveau="h2" titreId={titreId} />
+
+            <ol className={styles.liste}>
+              {groupe.realisations.map((realisation) => (
+                <li key={realisation.slug}>
+                  <RealisationCard realisation={realisation} />
+                </li>
+              ))}
+            </ol>
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/@vitrine/views/RealisationsIndexView/realisations-index-view.module.css
+++ b/src/@vitrine/views/RealisationsIndexView/realisations-index-view.module.css
@@ -1,0 +1,47 @@
+/* realisations-index-view.module.css — la liste des réalisations.
+ * Même gabarit de page que le blog : une colonne, mesurée sur le texte. Ce qui change,
+ * c'est le niveau intermédiaire — les groupes par cadre d'emploi. */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-6);
+  max-width: var(--largeur-page);
+  margin-inline: auto;
+  padding: var(--e-6) var(--e-4) var(--e-7);
+}
+
+.entete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+}
+
+.titre {
+  margin: 0;
+}
+
+.chapo {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-1);
+  line-height: 1.45;
+  color: var(--encre-douce);
+}
+
+/* L'écart entre le cadre et ses fiches est plus court que celui entre deux groupes :
+   c'est ce qui fait lire le cadre comme l'en-tête de ce qui suit, et non comme une
+   ligne de plus. */
+.groupe {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-4);
+}
+
+.liste {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-5);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}

--- a/src/app/realisations/[slug]/page.tsx
+++ b/src/app/realisations/[slug]/page.tsx
@@ -1,0 +1,73 @@
+// src/app/realisations/[slug]/page.tsx — jeromemarichez-fr
+// Routage seul : la fiche est composée dans src/@vitrine/views/RealisationView.
+
+import type { Metadata } from 'next'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { toRealisationRoute } from '@/@shared/routes'
+import { buildPageMetadata } from '@/@shared/seo/page-metadata'
+import { buildBreadcrumbSchema, buildRealisationSchema } from '@/@shared/seo/structured-data'
+import { REALISATIONS_INDEX } from '@/@vitrine/contenu/realisations/realisations-index'
+import { findRealisation, listRealisations } from '@/@vitrine/services/find-realisation'
+import { RealisationView } from '@/@vitrine/views/RealisationView'
+
+interface RealisationPageProps {
+  params: Promise<{ slug: string }>
+}
+
+/**
+ * Obligatoire sous `output: 'export'` : sans cette liste, le build n'a aucune page à
+ * écrire pour ce segment et il échoue. Elle est dérivée des fiches, jamais tenue à la
+ * main — une fiche publiée devient une page servie sans autre geste.
+ */
+export function generateStaticParams(): { slug: string }[] {
+  return listRealisations().map((realisation) => ({ slug: realisation.slug }))
+}
+
+/**
+ * Aucune URL hors de cette liste n'est servie. C'est déjà la conséquence de l'export
+ * statique ; l'écrire noir sur blanc évite qu'un futur passage au rendu serveur ouvre
+ * silencieusement `/realisations/<n-importe-quoi>` sur une page générée à la volée.
+ */
+export const dynamicParams = false
+
+/**
+ * `buildPageMetadata`, et **pas** `buildArticleMetadata` : celui-ci exige une date de
+ * publication et une date de modification. Une réalisation n'est pas datée — ce qui la
+ * situe dans le temps, c'est la période du poste sous lequel elle a été menée, et cette
+ * période appartient au contenu de la fiche. Lui inventer une date pour satisfaire un
+ * constructeur reviendrait à publier un fait faux dans `og:published_time`.
+ */
+export async function generateMetadata({ params }: RealisationPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const { realisation } = findRealisation(slug)
+
+  return buildPageMetadata({ meta: realisation.meta, route: toRealisationRoute(slug) })
+}
+
+export default async function RealisationPage({ params }: RealisationPageProps) {
+  const { slug } = await params
+  const { realisation, autres } = findRealisation(slug)
+  // Une seule dérivation de la route, partagée par le JSON-LD et le fil d'Ariane : c'est
+  // ce qui garantit qu'ils désignent la page réellement servie.
+  const route = toRealisationRoute(realisation.slug)
+
+  return (
+    <>
+      <RealisationView autres={autres} index={REALISATIONS_INDEX} realisation={realisation} />
+      <StructuredData
+        schemas={[
+          buildRealisationSchema({
+            titre: realisation.titre,
+            chapo: realisation.chapo,
+            route,
+            collectionRoute: REALISATIONS_INDEX.route,
+          }),
+          buildBreadcrumbSchema([
+            { nom: REALISATIONS_INDEX.titre, route: REALISATIONS_INDEX.route },
+            { nom: realisation.titre, route },
+          ]),
+        ]}
+      />
+    </>
+  )
+}

--- a/src/app/realisations/page.tsx
+++ b/src/app/realisations/page.tsx
@@ -1,0 +1,41 @@
+// src/app/realisations/page.tsx — jeromemarichez-fr
+// Routage seul : la liste est composée dans src/@vitrine/views/RealisationsIndexView.
+
+import type { Metadata } from 'next'
+import { StructuredData } from '@/@shared/components/StructuredData'
+import { toRealisationRoute } from '@/@shared/routes'
+import { buildPageMetadata } from '@/@shared/seo/page-metadata'
+import { buildBreadcrumbSchema, buildCollectionPageSchema } from '@/@shared/seo/structured-data'
+import { REALISATIONS_INDEX } from '@/@vitrine/contenu/realisations/realisations-index'
+import { groupRealisationsByCadre, listRealisations } from '@/@vitrine/services/find-realisation'
+import { RealisationsIndexView } from '@/@vitrine/views/RealisationsIndexView'
+
+export const metadata: Metadata = buildPageMetadata(REALISATIONS_INDEX)
+
+export default function RealisationsPage() {
+  const groupes = groupRealisationsByCadre()
+
+  return (
+    <>
+      <RealisationsIndexView groupes={groupes} index={REALISATIONS_INDEX} />
+      <StructuredData
+        schemas={[
+          buildCollectionPageSchema({
+            nom: REALISATIONS_INDEX.titre,
+            description: REALISATIONS_INDEX.meta.description,
+            route: REALISATIONS_INDEX.route,
+            // L'inventaire suit l'ordre déclaré des fiches, pas celui des groupes : une
+            // `ItemList` est une liste, elle ne porte pas la hiérarchie de la page.
+            elements: listRealisations().map((realisation) => ({
+              titre: realisation.titre,
+              route: toRealisationRoute(realisation.slug),
+            })),
+          }),
+          buildBreadcrumbSchema([
+            { nom: REALISATIONS_INDEX.titre, route: REALISATIONS_INDEX.route },
+          ]),
+        ]}
+      />
+    </>
+  )
+}

--- a/src/interfaces/IProof.ts
+++ b/src/interfaces/IProof.ts
@@ -1,5 +1,7 @@
 // IProof.ts — jeromemarichez-fr
-// Une preuve chiffrée, avec son contexte.
+// Une preuve chiffrée, avec son contexte et — quand elle en a une — la fiche qui la déplie.
+
+import type { IRealisationChiffree } from './IRealisationChiffree'
 
 /**
  * Un chiffre sans contexte est un chiffre invérifiable.
@@ -15,4 +17,18 @@ export interface IProof {
   libelle: string
   /** Où et quand. Repris à l'identique des CV de référence. */
   contexte: string
+  /**
+   * La fiche de réalisation qui déplie cette preuve, quand elle existe.
+   *
+   * Le type est `IRealisationChiffree` et non `IRealisation` : une preuve ne peut donc
+   * pointer que vers une fiche qui porte **réellement** un chiffre, et `preuves.ts` lit
+   * ce chiffre depuis la fiche plutôt que de le recopier. Le nombre n'est écrit qu'une
+   * fois dans tout le dépôt — c'est ce qui garantit, sans test et sans relecture, que
+   * l'accueil et la fiche affichent la même valeur.
+   *
+   * Optionnel, parce que trois preuves sur six ne racontent pas un travail : les
+   * migrations, les neuf ans d'autonomie et la promesse d'interlocuteur unique n'ont pas
+   * de fiche, et n'ont pas à en avoir une.
+   */
+  fiche?: IRealisationChiffree
 }

--- a/src/interfaces/IRealisation.ts
+++ b/src/interfaces/IRealisation.ts
@@ -1,0 +1,60 @@
+// IRealisation.ts — jeromemarichez-fr
+// Une réalisation : un travail mené, son cadre d'emploi, et ce qu'il permettait de trancher.
+//
+// Le contenu est versionné en TypeScript, comme le reste du site (docs/architecture.md).
+// Ce n'est donc pas une entrée externe et il n'est pas validé par Zod : la seule frontière
+// franchie est le `slug` d'URL, confronté à cette liste close au build par
+// `generateStaticParams`.
+
+import type { IPageMeta } from './IEditorialPage'
+import type { IRealisationCadre } from './IRealisationCadre'
+import type { IRealisationChiffre } from './IRealisationChiffre'
+import type { IRealisationEtape } from './IRealisationEtape'
+import type { PoleId } from './types'
+
+/**
+ * Une réalisation publiée.
+ *
+ * **Ce n'est pas un cas client**, et le modèle le tient par la structure plutôt que par la
+ * relecture : `cadre` est obligatoire, donc aucune fiche ne peut paraître sans son
+ * intitulé de poste, sa période et sa taille d'équipe.
+ *
+ * `poles` est un `readonly PoleId[]` **non contraint**, et c'est un choix. Le modèle de
+ * l'offre — ingénierie web, puis data, puis IA et/ou SEA & UX — décrit ce qui se vend
+ * aujourd'hui, pas un historique. Un type qui exigerait `data` partout forcerait à
+ * réétiqueter des travaux de 2017 et de 2019 pour satisfaire le compilateur : ce serait
+ * le type qui écrirait le contenu. Deux formes portent d'ailleurs tout l'argument —
+ * `['ingenierie-web', 'data', 'sea-ux']` **sans IA** montre qu'on n'est pas obligé
+ * d'acheter de l'IA, et `['data']` seul que la donnée se livre pour elle-même.
+ */
+export interface IRealisation {
+  /** Identifiant kebab-case, dernier segment de l'URL (`/realisations/<slug>/`). Immuable. */
+  slug: string
+  /** Titre affiché, `<h1>` de la fiche. Formulé à l'infinitif : un travail, pas une offre. */
+  titre: string
+  /** Chapô, 2 à 3 phrases. Sert aussi de résumé sur la liste et dans le JSON-LD. */
+  chapo: string
+  /** Métadonnées SEO propres à la fiche. */
+  meta: IPageMeta
+  /** Cadre d'emploi. Obligatoire — voir `IRealisationCadre`. */
+  cadre: IRealisationCadre
+  /** Pôles réellement mobilisés. Non contraint : voir la note ci-dessus. */
+  poles: readonly PoleId[]
+  /** Le problème posé au départ, dans les termes de l'époque. */
+  probleme: string
+  /** Ce qui a été fait, étape par étape. */
+  etapes: readonly IRealisationEtape[]
+  /**
+   * Le résultat, **directionnel et jamais chiffré** : le nombre a sa propre porte
+   * (`chiffre`), et elle n'est ouverte que trois fois sur tout le site.
+   *
+   * Obligatoire, y compris quand aucun résultat n'a été mesuré — le champ dit alors qu'il
+   * n'y en a pas. Le rendre optionnel laisserait une fiche muette sur son issue, ce qui
+   * se lit comme un résultat tu, pas comme un résultat absent.
+   */
+  resultat: string
+  /** Le chiffre, quand la fiche en porte un. Trois fiches seulement. */
+  chiffre?: IRealisationChiffre
+  /** Ce que le commanditaire pouvait trancher à l'arrivée. Une décision, jamais un outil. */
+  decision: string
+}

--- a/src/interfaces/IRealisationCadre.ts
+++ b/src/interfaces/IRealisationCadre.ts
@@ -1,0 +1,34 @@
+// IRealisationCadre.ts — jeromemarichez-fr
+// Le cadre d'emploi d'une réalisation : sous quel statut, quand, et avec qui.
+
+/**
+ * Le cadre réel dans lequel une réalisation a été menée.
+ *
+ * **Aucun champ n'est optionnel, et c'est tout l'objet de cette entité.** Un espace de
+ * réalisations dérive de lui-même vers « mon client X » : les entreprises citées ici sont
+ * des **employeurs**, jamais des clients, et le `CLAUDE.md` impose de reprendre les
+ * intitulés de poste à l'identique des CV de référence, sans réécriture pour coller à une
+ * offre de service.
+ *
+ * Rendre ce cadre facultatif reviendrait à autoriser une fiche à paraître sans dire d'où
+ * elle vient — et une fiche sans provenance se lit comme une prestation vendue. Le
+ * compilateur ferme cette porte : c'est le seul garde-fou qui ne s'oublie pas en
+ * relecture.
+ */
+export interface IRealisationCadre {
+  /** Employeur, nommé tel quel. Jamais présenté comme un client. */
+  employeur: string
+  /** Intitulé de poste, repris à l'identique du CV de référence. Jamais réécrit. */
+  poste: string
+  /** Période d'occupation du poste, au format `AAAA-AAAA`. */
+  periode: string
+  /**
+   * Taille et nature de l'équipe, et ce qui y était encadré.
+   *
+   * Le champ existe pour empêcher la dérive la plus coûteuse du genre : « j'ai managé N
+   * développeurs ». Ce qui est encadré, ce sont des équipes marketing et SEO/SEA, des
+   * prestataires, des alternants et des stagiaires — le titre technique, lui, est Lead
+   * Tech dans une équipe de deux développeurs et un product owner.
+   */
+  equipe: string
+}

--- a/src/interfaces/IRealisationChiffre.ts
+++ b/src/interfaces/IRealisationChiffre.ts
@@ -1,0 +1,30 @@
+// IRealisationChiffre.ts — jeromemarichez-fr
+// Le chiffre d'une réalisation — la seule porte par laquelle un nombre entre dans une fiche.
+
+/**
+ * Un résultat chiffré, et ce qu'il ne dit pas.
+ *
+ * **Trois chiffres seulement sont publiables sur ce site** : le panier moyen de Verhoeven
+ * Joaillier, le score Lighthouse de la plateforme SaaS livrée, le budget ADS / SEO piloté
+ * chez Truffle Capital. Ce sont ceux du mur de preuves de l'accueil, et il n'en existe
+ * pas d'autre qui soit sourcé mot pour mot.
+ *
+ * Toutes les autres fiches sont **sans chiffre** et portent au mieux un résultat
+ * directionnel — « fraude en baisse », « routes vocales coûteuses évitées ». Concentrer
+ * le nombre dans une entité dédiée le rend visible en revue : une quatrième fiche
+ * chiffrée ne peut pas apparaître par inadvertance au détour d'un paragraphe.
+ */
+export interface IRealisationChiffre {
+  /** Le chiffre, tel qu'il s'affiche. Identique au mur de preuves, au caractère près. */
+  chiffre: string
+  /** Ce que le chiffre mesure. Jamais élargi : « panier moyen » n'est pas « chiffre d'affaires ». */
+  libelle: string
+  /**
+   * Ce que le chiffre **ne** dit **pas** : périmètre, base de comparaison, nature.
+   *
+   * Obligatoire, parce qu'un chiffre publié sans sa portée se fait élargir tout seul par
+   * celui qui le lit. C'est ici qu'on écrit qu'un budget piloté n'est pas un résultat, et
+   * qu'une hausse de panier moyen n'est ni du chiffre d'affaires ni un taux de conversion.
+   */
+  portee: string
+}

--- a/src/interfaces/IRealisationChiffree.ts
+++ b/src/interfaces/IRealisationChiffree.ts
@@ -1,0 +1,22 @@
+// IRealisationChiffree.ts — jeromemarichez-fr
+// Une réalisation qui porte un chiffre. Le second des deux gabarits.
+
+import type { IRealisation } from './IRealisation'
+import type { IRealisationChiffre } from './IRealisationChiffre'
+
+/**
+ * Une réalisation dont le chiffre est **acquis au type**.
+ *
+ * Les deux gabarits de l'espace ne sont pas une affaire de rendu, ils sont dans le
+ * modèle : `IRealisation` laisse `chiffre` optionnel — c'est le cas général, une fiche
+ * sans nombre —, cette interface-ci le rend obligatoire.
+ *
+ * Elle sert au mur de preuves de l'accueil : `IProof.fiche` accepte une
+ * `IRealisationChiffree` et rien d'autre, donc une preuve ne peut pointer que vers une
+ * fiche qui porte réellement le chiffre annoncé. C'est ce qui garantit, sans test et sans
+ * relecture, que le chiffre affiché de part et d'autre est le même — il n'est écrit
+ * qu'une fois.
+ */
+export interface IRealisationChiffree extends IRealisation {
+  chiffre: IRealisationChiffre
+}

--- a/src/interfaces/IRealisationEtape.ts
+++ b/src/interfaces/IRealisationEtape.ts
@@ -1,0 +1,16 @@
+// IRealisationEtape.ts — jeromemarichez-fr
+// Une étape d'une réalisation : ce qui a été fait, et dans quel ordre.
+
+/**
+ * Une étape du travail mené.
+ *
+ * Volontairement pauvre — un titre, un paragraphe — pour la même raison qu'une section
+ * d'article : donner des blocs, des encarts et des niveaux de titre libres reviendrait à
+ * réinventer un éditeur, et à produire des fiches qui ne se ressemblent plus.
+ */
+export interface IRealisationEtape {
+  /** Intitulé court de l'étape. */
+  titre: string
+  /** Ce qui a été fait, une à trois phrases. Texte fini, publiable tel quel. */
+  texte: string
+}

--- a/src/interfaces/IRealisationGroupe.ts
+++ b/src/interfaces/IRealisationGroupe.ts
@@ -1,0 +1,17 @@
+// IRealisationGroupe.ts — jeromemarichez-fr
+// Un cadre d'emploi et les réalisations qui s'y rattachent.
+
+import type { IRealisation } from './IRealisation'
+import type { IRealisationCadre } from './IRealisationCadre'
+
+/**
+ * Le groupe tel que la liste l'affiche : un cadre d'emploi, puis ses fiches.
+ *
+ * C'est une **vue dérivée**, pas une donnée saisie : elle est calculée par
+ * `@vitrine/services/find-realisation`, jamais déclarée dans le contenu. La déclarer
+ * aurait créé une seconde liste de fiches, qui aurait fini par contredire la première.
+ */
+export interface IRealisationGroupe {
+  cadre: IRealisationCadre
+  realisations: IRealisation[]
+}

--- a/src/interfaces/IRealisationsIndex.ts
+++ b/src/interfaces/IRealisationsIndex.ts
@@ -1,0 +1,22 @@
+// IRealisationsIndex.ts — jeromemarichez-fr
+// L'en-tête éditoriale de la liste des réalisations.
+
+import type { IPageMeta } from './IEditorialPage'
+
+/**
+ * La page de liste des réalisations, hors fiches.
+ *
+ * Même raison d'être que `IBlogIndex`, et même raison de ne pas être un
+ * `IEditorialPage` : celui-ci porte des sections rédigées, alors que cette page-ci ne
+ * porte qu'une accroche et se remplit toute seule à partir des fiches. Les confondre
+ * aurait obligé à inventer des sections vides pour satisfaire le type.
+ */
+export interface IRealisationsIndex {
+  /** Route servie par la liste. */
+  route: string
+  meta: IPageMeta
+  /** Titre affiché, `<h1>`. Sert aussi de libellé au fil d'Ariane des fiches. */
+  titre: string
+  /** Chapô : ce qu'on trouve ici, sous quel cadre, et ce qu'on n'y trouve pas. */
+  chapo: string
+}

--- a/tests/fixtures/realisation.fixture.json
+++ b/tests/fixtures/realisation.fixture.json
@@ -1,0 +1,144 @@
+{
+  "_lisezmoi": "Jeu de données de réalisations (jeromemarichez-fr) — PAS un mock. Les vrais services (find-realisation, listPoles, buildSitemapEntries, buildCollectionPageSchema, buildRealisationSchema) tournent sur ces fiches réalistes ; aucune doublure de module n'est utilisée. Voir docs/testing.md et docs/data-model.md.",
+  "_cas": {
+    "cadres": "Trois cadres d'emploi, du plus récent au plus ancien. Le troisième ne porte AUCUNE fiche : groupRealisationsByCadre ne doit pas produire de groupe vide.",
+    "ordreDeclaration": "Les fiches sont déclarées dans un ordre volontairement mêlé entre employeurs — la deuxième appartient au second cadre. Un regroupement qui suivrait l'ordre de déclaration au lieu de celui de CADRES se voit immédiatement.",
+    "ficheChiffree": "« refonte-parcours » porte un chiffre, avec sa portée. C'est le gabarit chiffré, et le seul de ce jeu : les trois autres fiches n'ont pas de champ chiffre du tout.",
+    "polesSansIa": "« refonte-parcours » porte ['ingenierie-web', 'data', 'sea-ux'] — la chaîne complète SANS l'IA. Un type qui exigerait l'IA après la donnée rendrait cette fiche inexprimable.",
+    "poleDataSeul": "« cadrage-metier » porte ['data'] seul : la donnée se livre pour elle-même. Aucune autre fiche du jeu ne partage ce pôle sans en partager un autre.",
+    "ordrePoles": "« migration-socle » déclare ses pôles dans l'ordre ['sea-ux', 'ingenierie-web'], inverse de celui de la chaîne. listPoles doit les rendre dans l'ordre de POLES_NAV, jamais dans celui de la fiche.",
+    "voisinage": "findRealisation('cadrage-metier') doit d'abord proposer les fiches partageant le pôle 'data', puis compléter jusqu'à deux avec le reste de la liste — un bloc à moitié rempli se remarque plus que son absence.",
+    "resultatSansMesure": "« interop-agents » n'a aucun résultat mesuré, et son champ resultat le dit. Le champ reste obligatoire : une fiche muette sur son issue se lirait comme un résultat tu.",
+    "slugInconnu": "Slug absent de la liste : findRealisation doit lever, jamais rendre undefined."
+  },
+  "cadres": [
+    {
+      "employeur": "Employeur Récent",
+      "poste": "Lead Tech · Ingénieur full stack",
+      "periode": "2023-2026",
+      "equipe": "Équipe technique de trois — deux développeurs et un product owner."
+    },
+    {
+      "employeur": "Employeur Intermédiaire",
+      "poste": "Développeur Full Stack · E-commerce",
+      "periode": "2019-2022",
+      "equipe": "Poste unique, en autonomie complète. Encadrement de prestataires."
+    },
+    {
+      "employeur": "Employeur Sans Fiche",
+      "poste": "Développeur web & Chef de projet digital",
+      "periode": "2017-2019",
+      "equipe": "Coordination d’une équipe marketing de 5 à 10 personnes."
+    }
+  ],
+  "realisations": [
+    {
+      "slug": "migration-socle",
+      "titre": "Migrer un socle sans interruption de service",
+      "chapo": "Première fiche déclarée, rattachée au cadre le plus récent. Ses pôles sont déclarés à l’envers de la chaîne.",
+      "meta": {
+        "title": "Migrer un socle sans interruption",
+        "description": "Fiche de jeu de données : migration menée sans coupure, sous le cadre le plus récent."
+      },
+      "cadre": {
+        "employeur": "Employeur Récent",
+        "poste": "Lead Tech · Ingénieur full stack",
+        "periode": "2023-2026",
+        "equipe": "Équipe technique de trois — deux développeurs et un product owner."
+      },
+      "poles": ["sea-ux", "ingenierie-web"],
+      "probleme": "Le socle vieillissait et l’arrêter n’était pas une option.",
+      "etapes": [
+        { "titre": "Migrer par paliers", "texte": "Chaque palier garde une version livrable." },
+        {
+          "titre": "Mesurer le run",
+          "texte": "Les contrôles tournent en production, pas seulement en recette."
+        }
+      ],
+      "resultat": "La migration a été menée sans interruption de service.",
+      "decision": "Ce qu’on migre maintenant, et le coût réel de l’attente."
+    },
+    {
+      "slug": "refonte-parcours",
+      "titre": "Refondre un parcours d’achat sur la mesure",
+      "chapo": "Deuxième fiche déclarée mais rattachée au second cadre : le regroupement ne doit pas suivre l’ordre de déclaration.",
+      "meta": {
+        "title": "Refondre un parcours d’achat",
+        "description": "Fiche de jeu de données : seule fiche chiffrée, chaîne complète sans l’IA."
+      },
+      "cadre": {
+        "employeur": "Employeur Intermédiaire",
+        "poste": "Développeur Full Stack · E-commerce",
+        "periode": "2019-2022",
+        "equipe": "Poste unique, en autonomie complète. Encadrement de prestataires."
+      },
+      "poles": ["ingenierie-web", "data", "sea-ux"],
+      "probleme": "Le tunnel se discutait au goût, page par page.",
+      "etapes": [
+        {
+          "titre": "Mesurer avant de trancher",
+          "texte": "Ce que fait le visiteur réel, pas ce qu’on suppose."
+        },
+        {
+          "titre": "Implémenter soi-même",
+          "texte": "Aucun transfert de dossier entre le chiffre et le code."
+        }
+      ],
+      "resultat": "Le parcours a été refondu sur la mesure.",
+      "chiffre": {
+        "chiffre": "+50 %",
+        "libelle": "de panier moyen",
+        "portee": "Le chiffre porte sur le panier moyen et sur rien d’autre : ni chiffre d’affaires, ni taux de conversion."
+      },
+      "decision": "Quelle étape du tunnel disparaît."
+    },
+    {
+      "slug": "cadrage-metier",
+      "titre": "Formaliser les règles métier d’une activité",
+      "chapo": "Troisième fiche déclarée, rattachée au cadre le plus récent : elle doit revenir dans le premier groupe, après « migration-socle ».",
+      "meta": {
+        "title": "Formaliser les règles métier",
+        "description": "Fiche de jeu de données : pôle data seul, aucune suite achetée."
+      },
+      "cadre": {
+        "employeur": "Employeur Récent",
+        "poste": "Lead Tech · Ingénieur full stack",
+        "periode": "2023-2026",
+        "equipe": "Équipe technique de trois — deux développeurs et un product owner."
+      },
+      "poles": ["data"],
+      "probleme": "Les règles s’appliquaient sans avoir jamais été écrites.",
+      "etapes": [
+        { "titre": "Recueillir", "texte": "Auprès de ceux qui les appliquent." },
+        {
+          "titre": "Mettre par écrit",
+          "texte": "BPMN 2.0 et cartographie du système d’information."
+        }
+      ],
+      "resultat": "Les règles ont été formalisées et se sont révélées exploitables par des tiers.",
+      "decision": "S’il y a un problème qui mérite d’être traité par la technique — et lequel."
+    },
+    {
+      "slug": "interop-agents",
+      "titre": "Rendre un produit appelable par un agent",
+      "chapo": "Quatrième fiche, rattachée au cadre le plus récent. Aucun résultat mesuré, et le champ resultat le dit.",
+      "meta": {
+        "title": "Rendre un produit appelable",
+        "description": "Fiche de jeu de données : aucun résultat mesuré, et la fiche l’écrit."
+      },
+      "cadre": {
+        "employeur": "Employeur Récent",
+        "poste": "Lead Tech · Ingénieur full stack",
+        "periode": "2023-2026",
+        "equipe": "Équipe technique de trois — deux développeurs et un product owner."
+      },
+      "poles": ["ia"],
+      "probleme": "Le produit n’était appelable que par son interface.",
+      "etapes": [
+        { "titre": "Ouvrir une surface", "texte": "Serveur MCP et plugins no-code, documentés." }
+      ],
+      "resultat": "Aucun résultat n’est publié ici : je n’en ai pas de mesuré.",
+      "decision": "Ce que vous ouvrez à l’automatisation, et ce qui reste fermé."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #70

## Ce que ça fait

`/realisations/` liste treize fiches groupées par cadre d'emploi ;
`/realisations/<slug>/` sert une page par fiche, produite au build par
`generateStaticParams()` avec `dynamicParams = false`. Le socle du blog est réutilisé, pas
dupliqué : `Breadcrumb`, `buildBreadcrumbSchema`, `buildPageMetadata`, `sitemap-entries`.

## Le nom est un arbitrage de véracité, pas une préférence

Jérôme MARICHEZ avait demandé « cas clients ». **Aucune des trois entreprises n'est un
client** : ce sont trois postes salariés — Lead Tech chez Acetelecom / MailingVox
(2023-2026), Développeur Full Stack chez Verhoeven Joaillier (2019-2022, poste **unique**),
Développeur web & Chef de projet digital chez Truffle Capital (2017-2019). Artedrone est une
**participation du fonds** Truffle. Nommer la page « cas clients » affirmerait une relation
commerciale qui n'a jamais existé, et réécrirait des intitulés de poste que le `CLAUDE.md`
impose de reprendre à l'identique des CV.

## Ce que le type interdit

Un espace de réalisations dérive tout seul vers « mon client X ». Le garde-fou est donc dans
le modèle, pas dans la relecture :

- **`IRealisationCadre` n'a aucun champ optionnel** — employeur, intitulé de poste exact,
  période, équipe. Une fiche ne peut pas paraître sans dire d'où elle vient. Le champ
  `equipe` existe pour la même raison : il oblige à écrire ce qui a réellement été encadré,
  ce qui ferme la porte à « j'ai managé N développeurs ».
- **Le chiffre n'a qu'une porte d'entrée**, `IRealisationChiffre`, avec une `portee`
  obligatoire — ce que le chiffre **ne** dit **pas**. Un chiffre publié sans sa portée se
  fait élargir tout seul : « +50 % de panier moyen » devient « +50 % de chiffre d'affaires ».
- **`IRealisationChiffree` porte les deux gabarits dans le type.** `IProof.fiche` n'accepte
  qu'elle, donc le mur de preuves de l'accueil **lit** le chiffre sur la fiche au lieu de le
  recopier : le nombre n'est écrit qu'une fois dans le dépôt, et les deux pages ne peuvent
  pas diverger.
- **`resultat` est obligatoire même quand il n'y a rien à annoncer.** Deux fiches n'ont aucun
  résultat mesuré et l'écrivent. Le rendre optionnel laisserait une fiche muette sur son
  issue, ce qui se lit comme un résultat tu, pas comme un résultat absent.
- **`poles` reste un `readonly PoleId[]` non contraint.** Le modèle décrit l'offre
  d'aujourd'hui, pas un historique : exiger `data` partout forcerait à réétiqueter des
  travaux de 2017 pour satisfaire le compilateur — ce serait le type qui écrirait le contenu.
  Les deux formes qui portent l'argument existent bien :
  `['ingenierie-web', 'data', 'sea-ux']` **sans IA** sur `verhoeven-parcours-achat`, et
  `['data']` **seul** sur `artedrone-amoa`.

## Les treize fiches

| Cadre | Fiches | Chiffrées |
|---|---|---|
| Acetelecom / MailingVox, 2023-2026 | `sms-en-masse-plateforme`, `prezage-migration-mobile`, `regles-anti-fraude`, `echecs-depot-vocal`, `prezage-llama-3`, `rag-support-niveau-1`, `mesure-ltv-multi-sources` | 98/100 Lighthouse |
| Verhoeven Joaillier, 2019-2022 | `verhoeven-parcours-achat`, `verhoeven-migrations`, `verhoeven-erp-m3` | +50 % de panier moyen |
| Truffle Capital, 2017-2019 | `truffle-budget-ads-seo`, `truffle-sites`, `artedrone-amoa` | 100 000 € de budget piloté |

Treize et non quinze : les candidats qui restaient — la conformité RGPD/DORA transverse,
l'interopérabilité MCP — décrivent des **propriétés**, pas des objets livrés. Une fiche qui
ne raconte pas une chose faite est une fiche creuse.

**Les dix autres sont sans chiffre** et s'arrêtent au résultat directionnel, dans sa
formulation maximale : « fraude en baisse, conversion des inscriptions en hausse, latence
réduite », « routes vocales coûteuses évitées », « charge de travail des prestataires
réduite », « survente évitée sur des pièces uniques ». Aucun n'est quantifié. Sur
`rag-support-niveau-1` et `mesure-ltv-multi-sources`, **aucun résultat n'existe** et la fiche
le dit : « Aucun résultat n'est publié ici : je n'en ai pas de mesuré. » Même doctrine que les
certifications publiées sans lien plutôt qu'avec un lien mort.

## Interdits du genre, vérifiés un par un

- Pas de « mon client X », « mission pour le compte de », « prestation réalisée pour » —
  l'intitulé de poste est rendu tel quel, au-dessus du titre de chaque fiche. Les seules
  occurrences de « client » dans le contenu désignent les clients **de l'employeur**
  (rentabilité client, données clients).
- Pas de « j'ai tout fait seul » ni d'« aucune sous-traitance ». Le cadre Truffle nomme les
  trois prestataires coordonnés, le cadre Verhoeven l'encadrement de prestataires SEA/SEO/SMA.
- Pas de management de développeurs : Lead Tech dans une équipe de deux développeurs et un
  product owner, et l'encadrement porte sur des équipes marketing/SEO-SEA, des prestataires,
  des alternants et des stagiaires.
- **Pas de GTM sur la fiche Verhoeven** — Google Analytics, A/B testing, heatmaps, et rien
  d'autre. La seule occurrence de « Google Tag Manager » dans `verhoeven.ts` est le
  commentaire d'en-tête qui rappelle l'interdiction.
- Pas d'« appel d'offres remporté » : la conformité RGPD et DORA était **exigée en** appel
  d'offres, et seuls les secteurs sont nommés — jamais un grand compte.
- Aucun verbatim, aucun logo, aucun lien « voir le site » vers truffle.com, truffle100.fr ou
  artedrone.fr : ils ont pu être refaits depuis 2019, et `truffle-sites` l'écrit.
- Kubernetes n'apparaît que sous la forme « Pas de cluster Kubernetes administré en propre ».
- **NDA Prézage** : Prézage et Llama 3 sont nommés ; le contenu du corpus, les données et les
  chiffres du projet ne le sont pas, et les deux fiches concernées disent explicitement
  pourquoi. « Chiffre d'affaires maintenu » n'est pas publié.

## Technique

- **Données structurées** : `CollectionPage` + `ItemList` sur la liste, `WebPage` avec
  `isPartOf` sur la fiche. Ni `Service`, ni `CreativeWork`, ni `Project` — aucun type qui
  affirmerait une prestation vendue ou une œuvre détenue.
- **Métadonnées** : `buildPageMetadata`, pas `buildArticleMetadata`. Une réalisation n'est pas
  datée : ce qui la situe est la période du poste, et elle appartient au contenu. Même raison
  au sitemap, où les fiches portent la révision globale du site.
- **`ROUTES`** : l'union du `satisfies` est élargie à `'realisations'`, `toRealisationRoute()`
  compose l'URL une seule fois pour la liste, le `canonical`, l'`og:url`, le fil d'Ariane, le
  JSON-LD, le sitemap et les renvois du mur de preuves.
- **Navigation** : bloc secondaire de l'en-tête et colonne « Le site » du pied de page, comme
  le blog. Les réalisations passent devant le blog.
- **Aucune dépendance ajoutée.** Contenu en données TypeScript, comme tout le site.
- Version : **0.5.0** (fonctionnalité, SemVer). Le fichier de verrouillage était resté sur
  0.3.0, il est resynchronisé.

## Vérification

`make lint`, `make type-check`, `make build`, `make test` verts. Les quatorze pages sont
produites (`out/realisations/index.html` + treize `out/realisations/<slug>/index.html`) et les
quatorze URL entrent au sitemap.

`make budgets` — l'index et une fiche ont été ajoutés à `scripts/budgets/pages.mjs`, sinon les
nouveaux gabarits n'auraient jamais été mesurés :

| Page | Perf | A11y | Bonnes prat. | SEO |
|---|---|---|---|---|
| accueil | 96 | 100 | 100 | 100 |
| pole-ingenierie-web | 97 | 100 | 100 | 100 |
| article | 97 | 100 | 100 | 100 |
| **realisations** | **97** | **100** | **100** | **100** |
| **realisation** | **97** | **100** | **100** | **100** |

Le seuil est à 95 : l'accueil garde son point de marge unique, inchangé. axe-core : zéro
violation bloquante sur les cinq pages.

## Tests — intentions à poser par Jérôme MARICHEZ

Aucun fichier de test n'est écrit ici. Le **jeu de données** est prêt :
`tests/fixtures/realisation.fixture.json`, avec un bloc `_cas` qui documente chaque situation.
Intentions proposées, toutes de niveau **unitaire** sauf mention :

1. **`groupRealisationsByCadre` suit l'ordre des cadres, pas celui de déclaration.** Le jeu de
   données déclare la fiche du deuxième employeur en position 2 : un regroupement qui suivrait
   l'ordre de déclaration inverserait les groupes.
2. **Un cadre sans fiche ne produit pas de groupe vide.** Le troisième cadre du jeu n'a aucune
   fiche ; un employeur annoncé sans rien à montrer se lit comme une omission.
3. **`listPoles` ordonne selon `POLES_NAV`, jamais selon la fiche.** `migration-socle` déclare
   `['sea-ux', 'ingenierie-web']` : le rendu doit inverser, sinon la chaîne se lit à l'envers.
4. **`findRealisation` propose d'abord les fiches partageant un pôle, puis complète à deux.**
   Sur `cadrage-metier` (`['data']` seul), le voisinage doit commencer par les fiches `data`.
5. **`findRealisation` lève sur un slug inconnu**, et ne rend jamais `undefined`.
6. **Le sitemap contient une entrée par fiche, avec la révision globale du site** — pas une
   date par fiche. Le cas limite est qu'un contributeur ajoute une date : le test doit échouer.
7. **Intégration — le chiffre est le même de part et d'autre.** Rendre le mur de preuves et la
   fiche, et vérifier que la tuile affiche exactement `REALISATION_X.chiffre.chiffre`. Le type
   le garantit déjà ; le test protège contre un futur découplage.
8. **Intégration — véracité.** C'est le test annoncé par le `README` mais absent du dépôt
   (`veracite-contenu.spec.ts`) : échouer si un terme proscrit apparaît dans le **contenu
   publié**. Cet espace en est le premier justiciable — « GTM » sur une fiche Verhoeven,
   « appel d'offres remporté », « mon client », un quatrième chiffre. Les commentaires
   d'en-tête des fichiers de contenu nomment volontairement les termes interdits : le test
   doit inspecter les valeurs publiées, pas le source.
9. **e2e — le parcours preuve → fiche.** Depuis l'accueil, cliquer un renvoi du mur de preuves
   mène à la fiche correspondante, dont le fil d'Ariane affiche
   `Accueil / Réalisations / <fiche>`.

## À autoriser par Jérôme MARICHEZ avant mise en production

Ces points ne bloquent pas la fusion vers `dev`, mais ils bloquent la mise en ligne :

1. **Nommer chaque entreprise sur une page commerciale indexée** — Acetelecom / MailingVox,
   Verhoeven Joaillier, Truffle Capital. L'usage sur un CV privé n'emporte pas l'usage sur un
   site public référencé. Les trois sont nommées treize fois ici, en tête de chaque fiche.
2. **Nommer Artedrone**, qui est un **tiers** (participation du fonds) et non l'employeur : son
   accord est distinct de celui de Truffle Capital.
3. **Clauses de confidentialité et de non-dénigrement des contrats de travail** — aucun contrat
   n'est dans le dépôt, seul Jérôme peut les vérifier.
4. **Périmètre exact du NDA Prézage.** Le `CLAUDE.md` dit qu'il couvre le corpus, les données et
   les chiffres ; le document lui-même n'existe nulle part dans le dépôt. Couvre-t-il aussi
   l'architecture, le nom du client final, ou la mention même du fine-tuning ? Deux fiches
   dépendent de la réponse (`prezage-llama-3`, `prezage-migration-mobile`).
5. **Le +50 % de panier moyen** : période de mesure, périmètre du site, base de comparaison. La
   fiche écrit aujourd'hui qu'ils ne sont pas publiés — c'est tenable, mais c'est un aveu.
6. **Le 100 000 €** : durée (annuel ou cumulé 2017-2019), et « **de** » ou « **jusqu'à** ». Le
   CV Tracking Specialist écrit « jusqu'à », les deux autres « de » ; le site suit la majorité.
7. **Le « chiffre d'affaires maintenu » sur Prézage** — publier ou non ? Non publié aujourd'hui,
   ici comme ailleurs sur le site. Touche au périmètre du NDA.
8. **Existe-t-il un vrai client au sens commercial** (prestation facturée en indépendant) ? Il
   n'apparaît dans aucune des trois sources. S'il en existe un, il change le nom de l'espace.


https://claude.ai/code/session_01Vz8szo5e81R85kUGnwNftH
