### PR TITLE
feat: refraction SVG du verre, Blink et desktop seulement

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -49,9 +49,14 @@ site, et aucune n'est autorisée.
 |-----|---------|-------|
 | `720px` | mobile / tablette | l'en-tête passe en colonne ; la barre de pôle repasse dans le flux ; le rembourrage des panneaux de verre se resserre |
 | `900px` | tablette | le décalage en diagonale du schéma de chaîne est supprimé |
-| `1024px` | desktop | flou des **bandes collantes** uniquement ; le pied de page passe de deux à quatre colonnes |
+| `1024px` | desktop | flou des **bandes collantes** ; **réfraction** des panneaux (Blink seul) ; le pied de page passe de deux à quatre colonnes |
 
-**Le verre des panneaux n'a plus de seuil.** Il en avait un — 1024px — pour deux raisons
+**Le flou des panneaux n'a plus de seuil ; leur réfraction en a un.** Les deux ne se
+confondent pas : le flou est le verre lui-même et il est servi partout, la réfraction est
+un enrichissement desktop qui coûtait un point de budget sur mobile pour un écart de
+2/255 — voir « La réfraction » plus bas.
+
+**Le flou des panneaux, donc, n'a plus de seuil.** Il en avait un — 1024px — pour deux raisons
 qui appartenaient toutes deux à liquidGL : Safari devenait instable dès qu'une lentille
 dépassait la moitié du viewport, et le flou promettait une couche GPU pour un mouvement
 qui n'arrivait jamais sur un petit écran. La bibliothèque partie, il ne reste qu'un
@@ -444,6 +449,7 @@ trois `z-index` qui l'accompagnaient ont disparu avec la bibliothèque qui les e
 | lavis d'`--accent`, éteint avant la moitié | le verre prend la couleur du pôle qu'il porte. Une teinte uniforme se lirait comme un fond coloré ; une teinte qui décroît se lit comme de la lumière prise par la tranche haute |
 | arête spéculaire (`::before` masqué en anneau) | vive en haut, éteinte au milieu, rebond faible en bas. Elle suit le `border-radius`, ce qu'un `box-shadow: inset` ne sait pas faire |
 | `--verre-ombre`, basse et très étalée | le panneau flotte de peu. Un rayon court et sombre en ferait une carte |
+| réfraction SVG (`--verre-refraction`), ≥ 1024px, Blink seul | l'épaisseur prend une **forme** : au ras de l'arête, le verre va chercher son image un peu plus loin vers le dedans. Mesurée à 2/255 sur ce fond — voir « La réfraction » |
 | repli `@supports` | là où `backdrop-filter` manque, le voile opaque `--verre-voile` reprend la garantie de contraste du texte |
 
 Le plafond de panneaux par page (`glass-policy.ts` : 3 sur l'accueil, 3 sur une page de
@@ -468,17 +474,121 @@ de 1164 × 282 px :
 Rendre cela présentable demandait un `!important` sur huit propriétés en ligne. Ce n'est
 plus consommer une bibliothèque, c'est la combattre.
 
-**La réfraction a ensuite été réimplémentée en propre** — `feDisplacementMap` sur
-`backdrop-filter`, la même technique que la bibliothèque, en ~30 lignes de SVG et sans
-dépendance. Elle a été écartée aussi, pour une raison qui vaut pour les deux : **le fond
-de ce site n'a rien à courber.** Un lavis quasi uniforme et une trame à 5,5 % d'alpha ne
-produisent aucune déformation lisible ; il n'en restait que des artefacts en losange dans
-les quatre angles, là où les deux rampes du déplacement se croisent. C'est le même
-arbitrage que celui qui a fait passer la scène du seuil de WebGL à SVG : *ce qui est perdu
-n'était lisible par personne*.
-
 Ce que le site vend étant la performance tenue, un effet payé 33 ko et visible d'un seul
-navigateur, sur un fond qui ne l'exprime pas, ne se défend pas.
+navigateur ne se défend pas **sous cette forme**. La technique, elle, se défend : elle a
+été réimplémentée en propre, et c'est l'objet de la section suivante.
+
+### La réfraction : ce qu'elle coûte, ce qu'elle rend
+
+**`feImage` + `feDisplacementMap`, deux primitives, zéro dépendance** — la même technique
+que `liquid-glass-react`, en ~30 lignes de SVG rendues au serveur
+([`GlassRefraction`](../src/@shared/components/GlassRefraction/index.tsx)). Le filtre est
+déclaré une fois par la mise en page racine ; les panneaux le consomment par le jeton
+`--verre-refraction`, jamais en écrivant `url(#…)` dans un module.
+
+**Les artefacts en losange du premier essai ont disparu par construction, pas par
+réglage.** La carte de déplacement pose un **plateau neutre au centre** — l'effet ne vit
+que sur ~10 % de chaque bord, le seul endroit où un vrai verre courbe ce qu'il y a
+derrière — et **échantillonne toujours vers l'intérieur** aux quatre bords. Aucun pixel ne
+va donc chercher hors de la région du filtre, ce qui rend la frange impossible plutôt
+qu'improbable. Vérifié sur damier haute fréquence jusqu'à six fois l'amplitude retenue.
+
+#### Ce que la mesure dit, et elle est têtue
+
+Écart pixel entre un panneau réfractant et le même panneau simplement flouté, sur le fond
+réel, panneau de 1164 × 282 px :
+
+| Configuration | Écart max | Moyenne |
+|---|---|---|
+| réfraction **avant** le flou, région élargie | **2 / 255** | 0,302 |
+| réfraction **après** le flou | 1 / 255 | 0,001 |
+| réfraction seule, sans flou | 17 / 255 | 1,954 |
+
+**2 sur 255 est sous le seuil de perception**, et c'est arithmétiquement inévitable : la
+trame du fond est à 5,5 % d'alpha avec un pas de 32px ; floutée à 22px elle ne pèse plus
+que ~0,4 niveau, et le lavis radial varie de ~10 niveaux sur 1000px. **Un déplacement ne
+crée pas du contraste qui n'existe pas.**
+
+Un piège mérite d'être noté, parce qu'il aurait fait livrer l'inverse de ce qu'on croyait :
+la variante qui « faisait le plus d'effet » (7/255) donnait **exactement les mêmes chiffres
+avec un filtre identité**, qui ne fait rien. Ces sept niveaux n'étaient pas de la
+réfraction mais le `blur(22px)` qui se dégradait faute de matière près des bords — la
+version « visible » **abîmait** le verre. D'où la région élargie à 40 % de la boîte : il
+faut au moins trois écarts-types de flou de matière autour du panneau.
+
+#### Ce qu'elle coûte, et où elle est donc coupée
+
+Lighthouse, mobile bridé, seuil ≥ 95 :
+
+| Accueil | Perf |
+|---|---|
+| sans réfraction | 96 |
+| réfraction sur toutes les largeurs | **95** — tout le reste de marge |
+| réfraction ≥ 1024px (livré) | **96** — la marge est rendue |
+
+Le seuil rend le point, et il faut dire pourquoi sans se payer de mots : **le budget est
+mesuré en mobile bridé, donc il ne mesure plus la réfraction du tout.** Le coût d'un point
+reste réel en desktop Blink. Ce que le seuil supprime, c'est de le faire payer à chaque
+visiteur sur téléphone pour un effet qui, à ~350px de large, a encore moins à montrer que
+les 2/255 du desktop.
+
+Un point de budget pour un effet à 2/255, c'est trop cher, et **un budget pile sur le
+seuil échoue en CI au tirage au sort**. La réfraction est donc **desktop seulement
+(≥ 1024px)** : c'est déjà la règle posée en tête de ce document — le verre réfractant est
+un enrichissement, jamais un prérequis de lecture. Sur un téléphone le panneau fait ~350px,
+la rampe de 10 % n'y couvre plus que 35px, et il y a encore moins à voir qu'en desktop.
+**Le seuil ne concerne que la réfraction** : le flou, lui, n'a plus de seuil et reste sur
+tous les téléphones — c'est le gain du lot précédent, il n'est pas repris.
+
+#### Le test de moteur, et pourquoi il existe
+
+La réfraction est servie **à Blink seulement**, derrière un test de moteur explicite —
+**la seule entorse de ce genre dans le projet**, et elle est assumée :
+
+```css
+@supports (backdrop-filter: url("#verre-refraction")) and
+  (not (-webkit-backdrop-filter: blur(1px))) and
+  (not (-moz-appearance: none))
+```
+
+`@supports` ne teste que la **grammaire**, jamais l'implémentation. WebKit et Gecko peuvent
+accepter `backdrop-filter: url(…)` puis ne rien en faire — et une déclaration acceptée
+**remplace** celle du dessus : ils perdraient leur flou, c'est-à-dire tout leur verre.
+
+On ne peut pas s'en remettre à l'ordre des déclarations, et c'est un **défaut mesuré sur le
+CSS livré** : Lightning CSS **synthétise le préfixe** — il écrit
+`-webkit-backdrop-filter: url(…)` à l'intérieur du bloc — **et élargit la condition** en
+`(-webkit-backdrop-filter: url(…)) or (backdrop-filter: url(…))`. Écrire le préfixe avant,
+après ou pas du tout n'y change rien, et sur Safari 18+ les deux formes sont des alias.
+C'est la **même famille que le bug de production déjà corrigé** (le minifieur ne gardant
+que la dernière des deux formes), par une autre porte — et il ne se voit pas en `next dev`,
+où rien n'est minifié.
+
+Les deux sondes sont choisies pour être **vérifiables des deux côtés**, pas pour leur
+exotisme. `-webkit-backdrop-filter` écarte WebKit : Blink y répond `false` (mesuré), et
+Safari y répond **forcément** `true` — c'est la propriété même par laquelle le site lui
+livre son flou aujourd'hui ; s'il y répondait `false`, il n'aurait déjà aucun verre.
+L'exclusion de Safari n'est donc pas une supposition sur un moteur, elle est **forcée par
+une propriété dont le site dépend déjà**. `-moz-appearance` écarte Gecko, `false` dans
+Blink (mesuré).
+
+**Le rendu de Safari et de Firefox reste raisonné et non observé** — l'automation Safari
+est désactivée sur le poste et Firefox n'y est pas installé. C'est précisément pourquoi le
+gate est construit ainsi : l'incertitude porte sur ce que ces moteurs *feraient* d'un
+`url()`, et le gate fait en sorte qu'ils n'y soient jamais confrontés. Ils gardent
+exactement le verre d'aujourd'hui.
+
+Vérifié sur le CSS livré et sur la page rendue : à 412px le panneau calcule
+`blur(22px) saturate(1.7)`, à 1280px `url("#verre-refraction") blur(22px) saturate(1.7)`.
+
+**Ce qui permettrait de le retirer** : que `backdrop-filter: url()` soit rendu par les trois
+moteurs, ou qu'un `@supports` sache tester le rendu et non la seule syntaxe.
+
+`prefers-reduced-motion` et le `MotionToggle` coupent la réfraction et gardent le flou :
+elle ne bouge pas d'elle-même, mais le compositeur la recalcule à chaque image où le fond
+défile derrière le panneau. Les deux gardes sont indépendantes — requête média sans
+JavaScript d'un côté, attribut publié sur `<html>` par
+[`MotionState`](../src/@shared/components/MotionState/index.tsx) de l'autre (WCAG 2.2.2).
 
 ## La scène des quatre dalles
 

--- a/src/@shared/components/GlassRefraction/glass-refraction.module.css
+++ b/src/@shared/components/GlassRefraction/glass-refraction.module.css
@@ -1,0 +1,18 @@
+/* glass-refraction.module.css — le porte-filtre.
+ *
+ * Ce `<svg>` ne dessine rien : il ne transporte qu'un `<filter>` que le CSS référence.
+ * Il doit néanmoins rester dans le rendu — un `display: none` empêche certains moteurs
+ * de résoudre la référence — d'où une boîte de zéro pixel sortie du flux plutôt qu'un
+ * élément masqué.
+ *
+ * `globals.css` donne `display: block` et `max-width: 100%` à tout `svg` : sans la
+ * taille nulle explicite, celui-ci occuperait la largeur de page et pousserait le
+ * contenu de sa hauteur par défaut. */
+
+.defs {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  pointer-events: none;
+}

--- a/src/@shared/components/GlassRefraction/index.tsx
+++ b/src/@shared/components/GlassRefraction/index.tsx
@@ -1,0 +1,156 @@
+// GlassRefraction/index.tsx — jeromemarichez-fr
+// La réfraction du verre : un filtre SVG, déclaré une fois pour tout le site.
+
+import styles from './glass-refraction.module.css'
+
+/**
+ * Identifiant du filtre. Le CSS le consomme par le jeton `--verre-refraction`
+ * (`src/app/verre.css`), jamais en écrivant `url(#…)` dans un module.
+ */
+export const ID_REFRACTION = 'verre-refraction'
+
+/**
+ * Part de chaque bord occupée par la rampe de déplacement.
+ *
+ * Au-delà de cette part, la carte est neutre et le déplacement nul : **l'effet se lit sur
+ * l'arête et disparaît au centre**, ce qui est le seul endroit où un vrai verre courbe ce
+ * qu'il y a derrière. Une carte pleine surface — deux dégradés croisés de bord à bord,
+ * la recette qui circule — déforme tout le panneau et croise ses deux axes dans les
+ * angles : c'est de là que venaient les artefacts en losange du premier essai.
+ */
+const BANDE = 0.1
+
+/**
+ * Amplitude du déplacement, en unités de boîte englobante (`primitiveUnits`).
+ *
+ * SVG multiplie cette valeur par la demi-diagonale de la boîte : un grand panneau courbe
+ * donc plus qu'un petit, comme une lentille plus épaisse. Sur le panneau de référence
+ * (1164 × 282 px) cela fait ±17 px au ras du bord.
+ */
+const ECHELLE = 0.04
+
+/**
+ * Élargissement de la région du filtre, en pourcentage de la boîte, sur chaque côté.
+ *
+ * **Ce n'est pas un réglage de confort, c'est la correction d'un défaut mesuré.** Une
+ * région calée sur la boîte du panneau (`x="0%" width="100%"`) rogne l'image de fond
+ * AVANT le `blur(22px)` qui suit dans la chaîne : le flou n'a plus de matière à moyenner
+ * près des bords et cesse d'effacer la trame. Mesuré sur le fond réel, un filtre
+ * **identité** — qui ne fait rien du tout — placé dans une région serrée déplace déjà
+ * jusqu'à 7 niveaux sur 255. À 30 % d'élargissement l'écart retombe à 0,000 exactement.
+ * 40 % garde de la marge pour les panneaux courts : il faut au moins trois écarts-types
+ * de flou, soit 66 px, et 40 % d'un panneau de 300 px en fait 120.
+ */
+const MARGE = 40
+
+/**
+ * La carte de déplacement, en image.
+ *
+ * `feDisplacementMap` lit le **rouge** pour le déplacement horizontal et le **vert** pour
+ * le vertical, 128 valant « ne bouge pas ». Deux dégradés suffisent donc, l'un par axe,
+ * composés en `screen` — les deux canaux sont disjoints, `screen` vaut alors une somme.
+ *
+ * Les quatre arrêts par dégradé dessinent la rampe : extrême au ras du bord, neutre à
+ * `BANDE`, neutre encore à `1 - BANDE`, extrême à l'autre bord.
+ *
+ * **Le sens compte.** Au bord gauche le rouge vaut 255, donc le déplacement est positif,
+ * donc le pixel est allé chercher sa couleur *vers l'intérieur*. C'est vrai des quatre
+ * bords : la carte échantillonne toujours vers le dedans. Aucun pixel ne va donc chercher
+ * ce qui se trouve hors de la région du filtre — et c'est cette propriété, et non un
+ * réglage prudent de l'amplitude, qui garantit l'absence de frange sur le pourtour.
+ */
+const CARTE = [
+  '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">',
+  '<defs>',
+  '<linearGradient id="x" x1="0" y1="0" x2="1" y2="0">',
+  '<stop offset="0" stop-color="rgb(255,0,0)"/>',
+  `<stop offset="${BANDE}" stop-color="rgb(128,0,0)"/>`,
+  `<stop offset="${1 - BANDE}" stop-color="rgb(128,0,0)"/>`,
+  '<stop offset="1" stop-color="rgb(0,0,0)"/>',
+  '</linearGradient>',
+  '<linearGradient id="y" x1="0" y1="0" x2="0" y2="1">',
+  '<stop offset="0" stop-color="rgb(0,255,0)"/>',
+  `<stop offset="${BANDE}" stop-color="rgb(0,128,0)"/>`,
+  `<stop offset="${1 - BANDE}" stop-color="rgb(0,128,0)"/>`,
+  '<stop offset="1" stop-color="rgb(0,0,0)"/>',
+  '</linearGradient>',
+  '</defs>',
+  '<rect width="100" height="100" fill="url(#x)"/>',
+  '<rect width="100" height="100" fill="url(#y)" style="mix-blend-mode:screen"/>',
+  '</svg>',
+].join('')
+
+const CARTE_URI = `data:image/svg+xml,${encodeURIComponent(CARTE)}`
+
+/**
+ * Le filtre de réfraction, posé une fois par la mise en page racine.
+ *
+ * ## Ce qu'il fait, et ce qu'il ne fait pas
+ *
+ * `backdrop-filter: url(…) blur(…) saturate(…)` : le déplacement s'applique à l'image de
+ * fond **avant** le flou. L'ordre inverse ne produit rien du tout — mesuré : 1 niveau sur
+ * 255 — parce qu'une surface déjà floutée est uniforme, et qu'on ne courbe pas ce qui
+ * n'a plus de dessin.
+ *
+ * `url()` dans `backdrop-filter` n'est **rendu** que par Blink, et c'est le seul moteur à
+ * qui le module `glass-surface.module.css` le sert : il garde la réfraction derrière un
+ * test de moteur explicite, et derrière un seuil de 1024px. Les raisons des deux — dont
+ * un défaut mesuré de la minification, qui interdit de s'en remettre à l'ordre des
+ * déclarations — sont écrites en toutes lettres dans ce module, au-dessus de la règle.
+ *
+ * Ce qu'il faut en retenir ici : **le flou et la saturation ne dépendent jamais de ce
+ * fichier.** Safari, Firefox et tous les téléphones gardent exactement le verre que le
+ * site leur livre aujourd'hui ; la réfraction n'est qu'une couche en plus, là où elle
+ * est réellement rendue.
+ *
+ * ## Ce que cela donne sur CE fond, et pourquoi c'est dit ici
+ *
+ * Le fond du site est un lavis quasi uniforme et une trame à 5,5 % d'alpha. Il n'y a
+ * presque rien à courber, et cela se mesure : entre le panneau flouté seul et le même
+ * panneau réfractant, l'écart maximal est de **2 niveaux sur 255**, sur l'arête. C'est
+ * sous le seuil de perception. Le filtre est juste, il ne triche pas, il n'abîme rien —
+ * mais ce qu'il déplace ici n'a pas de quoi se voir. Il prendra son sens le jour où un
+ * panneau passera sur une image ou sur la scène du seuil. Les chiffres et la méthode sont
+ * dans `docs/design.md`.
+ *
+ * Aucun état, aucun effet, aucun `'use client'` : le filtre est du balisage, rendu au
+ * serveur, présent au premier octet de HTML.
+ */
+export function GlassRefraction() {
+  return (
+    <svg aria-hidden="true" className={styles.defs} focusable="false">
+      <defs>
+        <filter
+          colorInterpolationFilters="sRGB"
+          height={`${100 + 2 * MARGE}%`}
+          id={ID_REFRACTION}
+          primitiveUnits="objectBoundingBox"
+          width={`${100 + 2 * MARGE}%`}
+          x={`-${MARGE}%`}
+          y={`-${MARGE}%`}
+        >
+          {/* La sous-région cale la carte sur la BOÎTE du panneau, pas sur la région
+              élargie du filtre. Sans elle, la rampe se poserait à 40 % hors du panneau et
+              la carte serait neutre partout où on la regarde — le déplacement serait nul
+              sans que rien ne le signale. */}
+          <feImage
+            height="1"
+            href={CARTE_URI}
+            preserveAspectRatio="none"
+            result="carte"
+            width="1"
+            x="0"
+            y="0"
+          />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="carte"
+            scale={ECHELLE}
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
+      </defs>
+    </svg>
+  )
+}

--- a/src/@shared/components/GlassSurface/glass-surface.module.css
+++ b/src/@shared/components/GlassSurface/glass-surface.module.css
@@ -54,6 +54,91 @@
   }
 }
 
+/* La réfraction, en plus du flou.
+ *
+ * Le déplacement est écrit AVANT le flou. L'ordre inverse ne produit rien : une surface
+ * déjà floutée est uniforme, et on ne courbe pas ce qui n'a plus de dessin. Mesuré sur le
+ * fond réel : 1 niveau sur 255 dans l'autre sens.
+ *
+ * Ce que cela donne ici est documenté dans `docs/design.md`, chiffres à l'appui : le fond
+ * du site n'a presque rien à courber, et l'écart mesuré plafonne à 2 niveaux sur 255.
+ *
+ * ## Pourquoi un test de MOTEUR, seule entorse de ce genre dans le projet
+ *
+ * `@supports` ne teste que la GRAMMAIRE, jamais l'implémentation. `url()` dans
+ * `backdrop-filter` n'est rendu que par Blink, mais WebKit et Gecko peuvent très bien
+ * accepter la déclaration puis ne rien en faire — et une déclaration acceptée REMPLACE
+ * celle du dessus. Ils perdraient alors leur flou, c'est-à-dire tout leur verre.
+ *
+ * L'ordre des déclarations ne peut pas servir de garde-fou, et c'est le point mesuré :
+ * Lightning CSS **synthétise le préfixe** et écrit, dans le CSS livré,
+ * `-webkit-backdrop-filter: url(…) …` à l'intérieur de ce bloc — puis **élargit la
+ * condition** en `(-webkit-backdrop-filter: url(…)) or (backdrop-filter: url(…))`. Écrire
+ * le préfixe avant, après, ou pas du tout n'y change rien, et sur Safari 18+ les deux
+ * formes sont de toute façon des alias : la dernière écrite gagne. C'est la même famille
+ * que le bug de production corrigé plus haut dans ce fichier, par une autre porte.
+ *
+ * D'où ce test de moteur, assumé comme tel. Les deux sondes sont choisies pour être
+ * **vérifiables des deux côtés**, et non pour leur exotisme :
+ *
+ *   `not (-webkit-backdrop-filter: blur(1px))` écarte WebKit. Blink y répond `false`
+ *   (mesuré), et Safari y répond forcément `true` — c'est exactement la propriété dont ce
+ *   fichier se sert plus haut pour lui livrer son flou. Si Safari y répondait `false`, il
+ *   n'aurait déjà aucun verre.
+ *
+ *   `not (-moz-appearance: none)` écarte Gecko. `false` dans Blink (mesuré).
+ *
+ * Le gate ne protège donc pas d'un défaut de grammaire mais d'un défaut de RENDU, que
+ * rien en CSS ne sait interroger.
+ *
+ * **Ce qui permettrait de le retirer** : que `backdrop-filter: url()` soit rendu par les
+ * trois moteurs, ou qu'un `@supports` sache tester le rendu et non la seule syntaxe. À ce
+ * moment-là, les deux `not (…)` sautent et la première condition suffit.
+ *
+ * ## Pourquoi 1024px
+ *
+ * La réfraction est un **enrichissement desktop**, jamais un prérequis de lecture — c'est
+ * la règle posée par `docs/design.md`. Le seuil ne concerne QUE la réfraction : le flou,
+ * lui, n'a plus de seuil depuis le lot précédent et reste sur tous les téléphones.
+ *
+ * Deux raisons. L'effet a été dessiné et mesuré sur un panneau de 1164 × 282 px ; sur un
+ * téléphone le même panneau fait ~350 px de large, la rampe de 10 % n'y couvre plus que
+ * 35 px, et il y a encore moins à voir que les 2/255 mesurés en desktop. Et un
+ * `backdrop-filter` portant un filtre SVG coûte au compositeur : sur l'accueil mesuré en
+ * mobile bridé, il prenait le dernier point de marge du budget (96 → 95, seuil 95). Payer
+ * le budget de tout le monde pour un effet que personne ne voit sur téléphone ne se
+ * défend pas. */
+@media (min-width: 1024px) {
+  @supports (backdrop-filter: url("#verre-refraction")) and
+    (not (-webkit-backdrop-filter: blur(1px))) and
+    (not (-moz-appearance: none)) {
+    .panneau {
+      backdrop-filter: var(--verre-refraction) blur(var(--verre-flou))
+        saturate(var(--verre-saturation));
+    }
+  }
+}
+
+/* Mouvement coupé : la réfraction tombe, le verre reste.
+ *
+ * Elle ne bouge pas d'elle-même, mais elle est recalculée par le compositeur à chaque
+ * image où le fond défile derrière le panneau. La couper, c'est rendre l'arête
+ * strictement immobile pendant le défilement, et rendre au passage le travail par image
+ * qu'elle demande.
+ *
+ * Deux gardes, comme partout ailleurs sur ce site : la préférence système en requête
+ * média — donc sans JavaScript — et le contrôle de la page, publié sur `<html>` par
+ * `MotionState` (WCAG 2.2.2). Aucune des deux ne dépend de l'autre. */
+@media (prefers-reduced-motion: reduce) {
+  .panneau {
+    backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation));
+  }
+}
+
+:global(html[data-fige="true"]) .panneau {
+  backdrop-filter: blur(var(--verre-flou)) saturate(var(--verre-saturation));
+}
+
 /* L'arête spéculaire.
  *
  * Un `box-shadow: inset 0 1px 0` poserait un trait d'épaisseur CONSTANTE sur toute la

--- a/src/@shared/components/MotionState/index.tsx
+++ b/src/@shared/components/MotionState/index.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+// MotionState/index.tsx — jeromemarichez-fr
+// Le choix « animation figée », publié sur la racine du document pour que le CSS le lise.
+
+import { useEffect } from 'react'
+import { useMotionPaused } from '../../hooks/use-motion-paused'
+
+/** Attribut posé sur `<html>`. Les modules CSS le lisent en `:global`. */
+export const ATTRIBUT_FIGE = 'data-fige'
+
+/**
+ * Ne rend rien, et c'est tout son rôle : refléter l'état de mise en pause sur
+ * `document.documentElement`.
+ *
+ * ## Pourquoi un composant, et pas le bouton
+ *
+ * `MotionToggle` porte déjà l'état, mais il est rendu **deux fois** sur l'accueil (au
+ * pied de la scène et au pied de page) : deux instances se disputeraient la propriété
+ * d'un attribut global, et retirer l'une changerait le comportement de l'autre sans
+ * qu'aucune ne le dise. La mise en page racine en rend **un seul**, toujours, sur toutes
+ * les pages présentes et futures.
+ *
+ * ## Pourquoi le DOM et pas une prop
+ *
+ * Ce que l'attribut coupe est du CSS pur — le `backdrop-filter` d'un panneau de verre,
+ * rendu au serveur, sans JavaScript. Faire descendre l'état par des props obligerait
+ * `GlassSurface` à devenir un composant client, donc à hydrater trois panneaux par page
+ * pour un réglage que personne ne touche : le site perdrait un rendu identique avec et
+ * sans JavaScript pour rien.
+ *
+ * `prefers-reduced-motion` est déjà couvert par une requête média dans les modules — la
+ * garde CSS ne dépend donc jamais du seul JavaScript. Cet attribut ne sert qu'au
+ * contrôle de la page, celui qui satisfait WCAG 2.2.2.
+ */
+export function MotionState() {
+  const fige = useMotionPaused()
+
+  useEffect(() => {
+    const racine = document.documentElement
+    if (fige) racine.setAttribute(ATTRIBUT_FIGE, 'true')
+    else racine.removeAttribute(ATTRIBUT_FIGE)
+  }, [fige])
+
+  return null
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@
 
 import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
+import { GlassRefraction } from '@/@shared/components/GlassRefraction'
+import { MotionState } from '@/@shared/components/MotionState'
 import { SiteFooter } from '@/@shared/components/SiteFooter'
 import { SiteHeader } from '@/@shared/components/SiteHeader'
 import { SkipLink } from '@/@shared/components/SkipLink'
@@ -55,6 +57,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body>
         <SkipLink />
         <div aria-hidden="true" className="fond-atelier" />
+        {/* Le filtre de réfraction est déclaré une fois pour toute la page : c'est du
+            balisage inerte, référencé par le CSS des panneaux. Il est posé APRÈS le fond
+            d'atelier et avant tout ce qui porte du verre, comme le fond lui-même — la
+            règle de ce document est que ce qui est peint derrière est déclaré avant. */}
+        <GlassRefraction />
+        {/* Reflète « animation figée » sur `<html>`, pour que les gardes CSS des surfaces
+            de verre puissent le lire sans qu'aucune d'elles ne devienne cliente. */}
+        <MotionState />
         <SiteHeader />
         <main id="contenu">{children}</main>
         <SiteFooter />

--- a/src/app/verre.css
+++ b/src/app/verre.css
@@ -24,6 +24,17 @@
  * **texte** : au même réglage, elle le transformerait en traînée colorée. Elle floute
  * moins, sature à peine, et compense par un voile plus opaque.
  *
+ * ## La réfraction n'est pas le flou non plus
+ *
+ * Un flou dit « il y a une épaisseur entre le fond et moi ». Une **réfraction** dit « et
+ * cette épaisseur a une forme » : au ras de l'arête, un vrai verre va chercher son image
+ * un peu plus loin vers le dedans. `--verre-refraction` porte la référence au filtre SVG
+ * qui le fait (`@shared/components/GlassRefraction`) : le module CSS n'écrit donc jamais
+ * `url(#…)`, il consomme un jeton comme pour tout le reste.
+ *
+ * Le jeton ne s'applique qu'aux **panneaux**. Une bande collante passe sur du texte, et
+ * courber du texte est exactement le fantôme que le voile et le flou servent à éviter.
+ *
  * ## Le voile n'est pas le flou
  *
  * Deux réglages indépendants font une surface de verre : le **flou** de ce qui passe
@@ -63,6 +74,10 @@
      qu'il n'entre. C'est ce réglage, plus que le flou, qui distingue un verre d'Apple
      d'un simple dépoli — et il n'a de sens que sur un fond qui porte de la couleur. */
   --verre-saturation: 1.7;
+  /* Référence au filtre SVG de réfraction, posé une fois par la mise en page racine.
+     L'identifiant vit ici et nulle part ailleurs : un module qui écrirait `url(#…)` en
+     dur ferait de cette chaîne une valeur en dur de plus. */
+  --verre-refraction: url("#verre-refraction");
 
   /* — Verre : les bandes collantes — */
   --verre-flou-bande: 14px;


### PR DESCRIPTION
Closes #47

Ajoute la **réfraction SVG** au verre — `feImage` + `feDisplacementMap`, deux primitives, **zéro dépendance ajoutée**. Le filtre est déclaré une fois par la mise en page racine et consommé par le jeton `--verre-refraction` : aucun module n'écrit `url(#…)` en dur.

## Pas d'artefacts en losange, et pas par prudence

Le premier essai avait été abandonné à cause de franges en losange dans les quatre angles, là où deux rampes de bord à bord se croisent. La carte de déplacement livrée ici pose un **plateau neutre au centre** — l'effet ne vit que sur ~10 % de chaque bord, le seul endroit où un vrai verre courbe ce qu'il y a derrière — et **échantillonne toujours vers l'intérieur** aux quatre bords. Aucun pixel ne va chercher hors de la région du filtre : la frange est **impossible par construction**, pas improbable par réglage. Vérifié sur damier haute fréquence jusqu'à six fois l'amplitude retenue.

## Ce que la mesure dit — y compris ce qui n'arrange pas

Écart pixel entre un panneau réfractant et le même panneau simplement flouté, sur le fond réel, panneau 1164 × 282 px :

| Configuration | Écart max | Moyenne |
|---|---|---|
| réfraction **avant** le flou, région élargie | **2 / 255** | 0,302 |
| réfraction **après** le flou | 1 / 255 | 0,001 |
| réfraction seule, sans flou | 17 / 255 | 1,954 |

**2 sur 255 est sous le seuil de perception.** C'est arithmétiquement inévitable : la trame du fond est à 5,5 % d'alpha avec un pas de 32px ; floutée à 22px elle ne pèse plus que ~0,4 niveau, et le lavis radial varie de ~10 niveaux sur 1000px. Un déplacement ne crée pas du contraste qui n'existe pas.

Un piège a été évité : la variante qui « faisait le plus d'effet » (7/255) donnait **exactement les mêmes chiffres avec un filtre identité**, qui ne fait rien. Ces sept niveaux n'étaient pas de la réfraction mais le `blur(22px)` qui se dégradait faute de matière près des bords — la version « visible » **abîmait** le verre. D'où la région élargie à 40 % de la boîte.

L'effet est donc livré **en sachant et en écrivant qu'il ne se voit pas** sur ce fond. Il prendra son sens le jour où un panneau passera sur une image.

## Le test de moteur : pourquoi il existe, et ce qu'il a révélé

**Un défaut a été trouvé dans le CSS livré, et il aurait pu partir en production sans être vu.** `@supports` ne teste que la **grammaire**, jamais le rendu. WebKit et Gecko peuvent accepter `backdrop-filter: url(…)` puis n'en rien faire — et une déclaration acceptée **remplace** celle du dessus : ils perdraient leur flou, c'est-à-dire tout leur verre.

L'ordre des déclarations ne protège de rien, et c'est **mesuré sur l'artefact construit** : Lightning CSS **synthétise le préfixe** — il écrit `-webkit-backdrop-filter: url(…)` à l'intérieur du bloc — **et élargit la condition** en `(-webkit-backdrop-filter: url(…)) or (backdrop-filter: url(…))`. Écrire le préfixe avant, après ou pas du tout n'y change rien, et sur Safari 18+ les deux formes sont des alias. C'est la **même famille que le bug de production déjà corrigé** sur `dev` (le minifieur ne gardant que la dernière des deux formes), par une autre porte — et il ne se voit pas en `next dev`, où rien n'est minifié.

D'où un test de moteur explicite, **seule entorse de ce genre dans le projet**, assumée et documentée :

```css
@supports (backdrop-filter: url("#verre-refraction")) and
  (not (-webkit-backdrop-filter: blur(1px))) and
  (not (-moz-appearance: none))
```

Les deux sondes sont choisies pour être **vérifiables des deux côtés**, pas pour leur exotisme :

- `-webkit-backdrop-filter` écarte WebKit. **Faux dans Blink** (mesuré), et **forcément vrai dans Safari** — c'est la propriété même par laquelle le site lui livre son flou aujourd'hui ; s'il y répondait faux, il n'aurait déjà aucun verre. L'exclusion de Safari n'est donc pas un pari sur un moteur, elle est **forcée par une propriété dont le site dépend déjà**.
- `-moz-appearance` écarte Gecko. Faux dans Blink (mesuré).

**Vérifié dans le CSS livré** : les deux clauses `not (…)` survivent à la minification intactes.

**Ce qui permettrait de le retirer** : que `backdrop-filter: url()` soit rendu par les trois moteurs, ou qu'un `@supports` sache tester le rendu et non la seule syntaxe.

## État des navigateurs — ce qui est observé et ce qui est raisonné

| Moteur | Ce qu'il reçoit | Statut |
|---|---|---|
| Blink (Chrome 152) | flou + saturation + **réfraction** ≥ 1024px | **observé** — `CSS.supports` et rendu vérifiés |
| WebKit / Safari | flou + saturation, inchangé | **raisonné, non observé** |
| Gecko / Firefox | flou + saturation, inchangé | **raisonné, non observé** |
| Mobile, toutes largeurs < 1024px | flou + saturation, inchangé | **observé** (412px et 900px) |

**À dire clairement : le comportement de Safari et de Firefox est raisonné, pas observé.** L'automation Safari est désactivée sur le poste (« Allow Remote Automation » et « Allow JavaScript from Apple Events » requièrent une action manuelle) et Firefox n'y est pas installé. C'est précisément pourquoi le gate est construit ainsi : l'incertitude porte sur ce que ces moteurs *feraient* d'un `url()`, et le gate fait en sorte qu'ils n'y soient **jamais confrontés**. Ils gardent exactement le verre d'aujourd'hui.

Vérifié sur la page rendue :

| Largeur | `backdrop-filter` calculé |
|---|---|
| 412px | `blur(22px) saturate(1.7)` |
| 900px | `blur(22px) saturate(1.7)` |
| 1280px | `url("#verre-refraction") blur(22px) saturate(1.7)` |

## Performance — le seuil de 1024px, et ce qu'il ne fait pas

Lighthouse, mobile bridé, seuil ≥ 95, machine au repos :

| Accueil | Perf |
|---|---|
| sans réfraction (`dev`) | 96 |
| réfraction sur toutes les largeurs | **95** — tout le reste de marge |
| réfraction ≥ 1024px (livré) | **96** — la marge est rendue |

Un budget **pile sur le seuil échoue en CI au tirage au sort**, ce qui serait pire que pas d'effet du tout. La réfraction est donc restreinte au desktop — ce n'est pas une règle inventée pour arranger un chiffre, `docs/design.md` posait déjà que « le verre réfractant est un **enrichissement desktop**, jamais un prérequis de lecture ».

**Ce que le seuil ne fait pas, et il faut le dire :** le budget étant mesuré en mobile bridé, il ne mesure plus la réfraction du tout. Le coût d'un point reste réel en desktop Blink. Ce que le seuil supprime, c'est de le faire payer à chaque visiteur sur téléphone pour un effet qui, à ~350px de large, a encore moins à montrer que les 2/255 du desktop.

**Le seuil ne concerne que la réfraction.** Le flou garde son absence de seuil et reste sur tous les téléphones : le gain du lot précédent n'est pas repris.

Tableau final :

| Page | Perf | A11y | Bonnes prat. | SEO |
|---|---|---|---|---|
| accueil | ✓ 96 | ✓ 100 | ✓ 100 | ✓ 100 |
| pole-ingenierie-web | ✓ 97 | ✓ 100 | ✓ 100 | ✓ 100 |
| article | ✓ 99 | ✓ 100 | ✓ 100 | ✓ 100 |
| realisations | ✓ 97 | ✓ 100 | ✓ 100 | ✓ 100 |
| realisation | ✓ 97 | ✓ 100 | ✓ 100 | ✓ 100 |

axe-core : 0 bloquante, 0 mineure/modérée sur les cinq pages.

## Accessibilité

`prefers-reduced-motion` et le `MotionToggle` **coupent la réfraction et gardent le flou**. Elle ne bouge pas d'elle-même, mais le compositeur la recalcule à chaque image où le fond défile derrière le panneau. Les deux gardes sont indépendantes : requête média sans JavaScript d'un côté, attribut publié sur `<html>` par le nouveau composant `MotionState` de l'autre (WCAG 2.2.2). `MotionState` est rendu une seule fois par la mise en page racine — `MotionToggle` est rendu deux fois sur l'accueil et deux instances se disputeraient la propriété d'un attribut global.

`GlassSurface` reste un composant serveur : le verre est du CSS, identique avec et sans JavaScript.

## Correction annexe

La docstring de `GlassRefraction` affirmait que Safari et Firefox « abandonnent la seule partie SVG » d'une chaîne `backdrop-filter`. C'est faux — une déclaration est valide ou tombe **en entier** — et c'est justement l'hypothèse qui rendait le lot dangereux. Réécrite.

## Tests

**Aucun fichier de test n'a été écrit** (règle du projet : les tests sont écrits par Jérôme MARICHEZ). Intentions proposées, si un niveau est jugé utile :

- **Unitaire** — `GlassRefraction` rend un `<filter>` portant l'identifiant `verre-refraction`, `aria-hidden="true"`, une `feImage` et une `feDisplacementMap` avec `xChannelSelector="R"` / `yChannelSelector="G"` ; la carte encodée porte un arrêt neutre (`128`) à 10 % et à 90 % sur les deux axes — c'est l'invariant « plateau neutre au centre », celui dont dépend l'absence de losange.
- **Unitaire** — `MotionState` pose `data-fige="true"` sur `document.documentElement` quand le mouvement est coupé et le retire sinon, sans rien rendre.
- **Intégration / rendu** — sur l'export statique servi : à 412px le panneau calcule `blur(22px) saturate(1.7)`, à 1280px `url("#verre-refraction") blur(22px) saturate(1.7)`. C'est le test qui garde le gate honnête, et celui que je referais en priorité — il a déjà attrapé le défaut une fois.

Jeu de données : aucun ; les trois portent sur du rendu.

## Vérifications

`make lint`, `make type-check`, `make build`, `make budgets` — verts. Aucun fichier au-dessus de 300 lignes. Aucune valeur en dur dans un module CSS. Aucune dépendance ajoutée.
