### PR TITLE
feat(accueil): resserrer la typographie, illustrer et ouvrir vers les categories

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -270,7 +270,7 @@ fonte préchargée est un fichier que le navigateur va chercher avant de peindre
 | Corps | **Inter** (variable) | `'ss01' 1, 'cv05' 1` |
 | Annotations et chiffres | **pile monospace système** | Ce registre est intégralement composé en capitales espacées, où le dessin propre à une fonte de labeur ne se distingue pas. `ui-monospace` prend SF Mono sur Apple ; tous les replis ont les chiffres à chasse fixe, seule vraie exigence des preuves |
 
-Échelle fluide en `clamp()`, base 16px : `--t--1` (13px) à `--t-4` (40→68px), plus
+Échelle fluide en `clamp()`, base 16px : `--t--1` (13px) à `--t-4` (34→52px), plus
 `--t-note` (15px) et `--t-chiffre` (40→64px) pour le mur de preuves. Mesures : 64ch sur
 le corps, 30ch sur les `h2`, 18ch sur le `h1`, 46ch dans un panneau de verre.
 
@@ -644,3 +644,49 @@ scène s'affiche désormais **aussi sous 1024px**, là où le WebGL n'était jam
 - **Décor, jamais information** : le conteneur est `aria-hidden`, et la scène ne porte
   rien que le texte de la page ne dise déjà. C'est la condition pour qu'un décor animé
   soit acceptable sur un site qui vend de l'accessibilité tenue.
+
+## Les entrées de l'accueil
+
+L'accueil déroulait sa chaîne dans le fil du texte : on y entrait en lisant, ou par le
+menu. Un visiteur qui scanne ne trouvait aucune porte. Deux composants la lui donnent, et
+leur **disposition porte le modèle** plutôt que de le décrire.
+
+### `PoleEntries` — les quatre pôles
+
+Quatre plaques alignées à égalité diraient un catalogue, ce que le site refuse d'être. La
+grille rend donc la chaîne réelle : **Ingénierie web** puis **Data** en pleine largeur —
+le socle, puis le passage obligé — et **IA** et **SEA & UX** partageant une rangée,
+côte à côte. Les deux suites partagent une ligne parce qu'elles partagent un temps ;
+les empiler aurait réintroduit l'ordre que le modèle nie.
+
+Chaque plaque porte `data-pole` : sa marque et son filet prennent `--accent` sans qu'aucune
+règle du composant ne nomme une couleur.
+
+### `PoleGlyph` — des marques produites, jamais trouvées
+
+Le site n'a **aucune photographie utilisable** — ni portrait, ni capture de projet
+autorisée, ni logo client. Tout visuel est donc construit, en SVG rendu au serveur :
+quatre marques pèsent moins de 700 octets dans le document, là où la moindre image
+matricielle ferait tomber un budget qui ne tient qu'à un point.
+
+**Aucune de ces marques ne simule une donnée.** Un pictogramme qui mimerait un graphique —
+courbe qui monte, barres qui progressent — afficherait un chiffre inventé, ce que les
+règles de véracité interdisent. Ce sont des **figures de structure**, pas des
+visualisations.
+
+L'IA n'est pas dessinée par le nœud à trois entrées, c'est-à-dire le neurone : c'est le
+cliché attendu, et il dirait quelque chose de faux, puisque ce pôle promet que « la
+réponse n'est pas toujours un modèle ». Sa marque est un embranchement dont une branche
+est retenue et l'autre écartée — la promesse, littéralement. Les deux sœurs partagent la
+même grammaire de trait, même poids et même nombre de tracés : deux figures de décision de
+rang égal.
+
+### `SpaceEntries` — les deux espaces éditoriaux
+
+Registre volontairement **plus sobre** que celui des pôles : un filet à gauche plutôt
+qu'une plaque encadrée. Un espace ne se vend pas, il déplie — et la hiérarchie visuelle
+doit le dire sans qu'un mot ait à l'expliquer.
+
+Le volume annoncé est **dérivé des listes sources**, jamais écrit à la main : l'accueil ne
+peut donc pas annoncer un nombre de fiches que l'espace ne tient pas. C'est la même règle
+que pour les chiffres de `preuves.ts`.

--- a/src/@shared/components/PoleGlyph/index.tsx
+++ b/src/@shared/components/PoleGlyph/index.tsx
@@ -1,0 +1,129 @@
+// PoleGlyph/index.tsx — jeromemarichez-fr
+// Une marque dessinée par pôle. Produite, jamais trouvée.
+//
+// Le site n'a AUCUNE photographie utilisable — ni portrait, ni capture de projet
+// autorisée, ni logo client. Tout visuel est donc construit, et il est construit en SVG
+// rendu au serveur : quatre marques coûtent ici moins de 700 octets dans le document,
+// là où la moindre image matricielle ferait tomber un budget qui ne tient qu'à un point.
+//
+// ## Ce que ces marques ont le droit de dire
+//
+// Rien qui simule une donnée. Le site vend la mesure : un pictogramme qui mimerait un
+// graphique — une courbe qui monte, des barres qui progressent — afficherait un chiffre
+// inventé, ce que les règles de véracité du CLAUDE.md interdisent. Aucune de ces quatre
+// marques ne porte de valeur ; ce sont des FIGURES DE STRUCTURE, pas des visualisations.
+//
+// L'IA n'est pas non plus dessinée par le pictogramme attendu — le nœud à trois entrées,
+// autrement dit le neurone. C'est le cliché exact que l'issue #84 écarte, et il dirait
+// en plus quelque chose de faux : le pôle IA promet que « la réponse n'est pas toujours
+// un modèle ». Sa marque est donc un embranchement dont une branche est retenue et
+// l'autre écartée — la promesse, littéralement.
+//
+// ## Les deux sœurs partagent une grammaire
+//
+// `ia` et `sea-ux` sont deux suites PARALLÈLES de la donnée, jamais deux étapes
+// (CLAUDE.md). Leurs marques le disent au trait : même poids, même nombre de tracés, et
+// la MÊME convention — le trait plein est ce qui est retenu, le trait tireté ce qui est
+// écarté. Deux figures de décision de rang égal. Donner à l'une une figure plus riche
+// qu'à l'autre aurait réintroduit dans le dessin l'ordre que le modèle nie.
+//
+// La couleur n'est écrite nulle part ici : le tracé est en `currentColor`, et le module
+// pose `color: var(--accent)`. Sous le `data-pole` de sa plaque, chaque marque prend donc
+// la teinte de son pôle sans qu'aucun composant ne nomme une couleur (voir `poles.css`).
+
+import type { PoleId } from '@/interfaces/types'
+import styles from './pole-glyph.module.css'
+
+interface PoleGlyphProps {
+  pole: PoleId
+}
+
+/** Le socle : trois dalles portées par deux montants, sur une assise plus épaisse. */
+function Socle() {
+  return (
+    <>
+      <path d="M6 9h20M6 15.5h20M6 22h20" />
+      <path d="M12 9v13M22 9v13" />
+      <path className={styles.appui} d="M5 26.5h22" />
+    </>
+  )
+}
+
+/**
+ * Le passage obligé : une trame de neuf points, dont la rangée médiane est un canal
+ * traversé de part en part. Ce qui vient d'en haut y passe, et rien ne le contourne.
+ */
+function Passage() {
+  return (
+    <>
+      <path d="M4 16h24" />
+      <circle cx="16" cy="16" fill="currentColor" r="2.6" stroke="none" />
+      <path
+        className={styles.point}
+        d="M8 6.5v.01M16 6.5v.01M24 6.5v.01M8 25.5v.01M16 25.5v.01M24 25.5v.01"
+      />
+      <path className={styles.point} d="M8 11.2v.01M24 11.2v.01M8 20.8v.01M24 20.8v.01" />
+    </>
+  )
+}
+
+/** Une suite : deux voies s'ouvrent, une seule est retenue. Le trait tireté est écartée. */
+function Embranchement() {
+  return (
+    <>
+      <path d="M4 16h7" />
+      <path d="M11 16c5 0 4-8 9-8h6" />
+      <path className={styles.ecarte} d="M11 16c5 0 4 8 9 8h6" />
+      <circle cx="27.5" cy="8" fill="currentColor" r="2.4" stroke="none" />
+      <path className={styles.ecarte} d="M25.6 22.1l3.8 3.8M29.4 22.1l-3.8 3.8" />
+    </>
+  )
+}
+
+/** L'autre suite : un parcours à quatre paliers, dont un est supprimé. Même convention. */
+function Parcours() {
+  return (
+    <>
+      <path d="M5 7h22" />
+      <path d="M8 14h16" />
+      <path className={styles.ecarte} d="M11 21h10" />
+      <path d="M13 28h6" />
+      <circle cx="16" cy="28" fill="currentColor" r="2.4" stroke="none" />
+    </>
+  )
+}
+
+const TRACES: Record<PoleId, () => React.JSX.Element> = {
+  'ingenierie-web': Socle,
+  data: Passage,
+  ia: Embranchement,
+  'sea-ux': Parcours,
+}
+
+/**
+ * Décor, jamais information.
+ *
+ * La marque est `aria-hidden` et ne porte rien que la plaque ne dise déjà en toutes
+ * lettres : le nom du pôle, sa place et sa promesse sont du texte, juste à côté. Un
+ * lecteur d'écran ne perd donc rien à ne pas la rencontrer, et la couleur n'est jamais
+ * le seul porteur d'information (WCAG 1.4.1).
+ */
+export function PoleGlyph({ pole }: PoleGlyphProps) {
+  const Trace = TRACES[pole]
+
+  return (
+    <svg
+      aria-hidden="true"
+      className={styles.glyphe}
+      fill="none"
+      focusable="false"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="1.6"
+      viewBox="0 0 32 32"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <Trace />
+    </svg>
+  )
+}

--- a/src/@shared/components/PoleGlyph/pole-glyph.module.css
+++ b/src/@shared/components/PoleGlyph/pole-glyph.module.css
@@ -1,0 +1,39 @@
+/* pole-glyph.module.css — la marque d'un pôle.
+ *
+ * Trois règles, et rien d'autre. La marque ne connaît pas la couleur de son pôle : elle
+ * est tracée en `currentColor`, et `color: var(--accent)` laisse `poles.css` décider sous
+ * le `data-pole` de la plaque qui l'accueille. C'est la même mécanique que le dégradé de
+ * la scène des quatre dalles, pour la même raison — un module qui nommerait une teinte
+ * de pôle serait le dix-neuvième à devoir être touché au prochain pôle. */
+
+.glyphe {
+  flex: none;
+  width: var(--taille-glyphe);
+  height: var(--taille-glyphe);
+  color: var(--accent);
+  /* Le tracé n'est PAS du texte : c'est un décor, et il tombe sous le seuil non-texte de
+     3:1 comme les filets et les arêtes du site. `--accent` reste malgré tout au-dessus de
+     4.5:1 dans les quatre pôles et les deux thèmes — la marge est prise, pas dépensée. */
+  opacity: 0.9;
+}
+
+/* L'assise du socle : le seul trait plus épais de la série. Un socle qui aurait la même
+   épaisseur que ce qu'il porte ne se lirait pas comme une assise. */
+.appui {
+  stroke-width: 2.4;
+}
+
+/* La trame de la donnée. Le point est un tracé de longueur nulle à bout rond, donc son
+   diamètre EST son épaisseur : c'est la seule façon d'obtenir dix points sans dix
+   éléments `circle`. */
+.point {
+  stroke-width: 2.6;
+}
+
+/* La convention partagée par les deux sœurs : ce qui est écarté est tireté. Elle vaut
+   dans les deux marques, au même poids de trait — c'est ce qui les fait lire comme deux
+   décisions de rang égal, et non comme deux étapes. */
+.ecarte {
+  stroke-dasharray: 2.6 2.6;
+  opacity: 0.65;
+}

--- a/src/@vitrine/components/PoleEntries/index.tsx
+++ b/src/@vitrine/components/PoleEntries/index.tsx
@@ -1,0 +1,76 @@
+// PoleEntries/index.tsx — jeromemarichez-fr
+// Les quatre pôles en entrées visuelles, depuis l'accueil.
+//
+// Jusqu'ici l'accueil déroulait ses pôles dans le fil du texte : on y arrivait en lisant,
+// ou par le menu. Un visiteur qui scanne ne trouvait aucune porte. C'est le point 3 de
+// l'issue #84.
+//
+// ## La disposition EST le modèle
+//
+// Quatre plaques alignées à égalité diraient un catalogue — exactement ce que le
+// `CLAUDE.md` interdit d'affirmer. La grille rend donc la chaîne réelle :
+//
+//     Ingénierie web          (le socle, pleine largeur)
+//            ↓
+//         Data               (le passage obligé, pleine largeur)
+//            ↓
+//     IA  ·  SEA & UX        (deux suites, CÔTE À CÔTE, de rang égal)
+//
+// Les deux suites partagent une rangée parce qu'elles partagent un temps. Les empiler
+// aurait réintroduit l'ordre que le modèle nie, et c'est le défaut que ce composant
+// existe pour éviter.
+//
+// Chaque plaque porte `data-pole` : sa marque et son filet prennent `--accent` sans
+// qu'aucune règle d'ici ne nomme une couleur (voir `poles.css`).
+
+import { PoleGlyph } from '@/@shared/components/PoleGlyph'
+import { POLES_NAV } from '../../contenu/poles-nav'
+import { LIBELLE_PLACE } from '../../contenu/poles-places'
+import styles from './pole-entries.module.css'
+
+/**
+ * Les pôles sont lus depuis `POLES_NAV`, source unique déjà chargée par l'en-tête et le
+ * pied de page. Aucun libellé n'est recopié ici : un cinquième pôle ajouté demain
+ * apparaîtrait sans qu'on touche à ce fichier, et un pôle renommé ne pourrait pas diverger.
+ */
+export function PoleEntries() {
+  const socle = POLES_NAV.filter((pole) => pole.place === 'socle')
+  const passage = POLES_NAV.filter((pole) => pole.place === 'passage')
+  const suites = POLES_NAV.filter((pole) => pole.place === 'suite')
+
+  return (
+    <ul className={styles.grille}>
+      {[...socle, ...passage].map((pole) => (
+        <li className={styles.tronc} key={pole.id}>
+          <a className={styles.plaque} data-pole={pole.id} href={pole.route}>
+            <span aria-hidden="true" className={styles.marque}>
+              <PoleGlyph pole={pole.id} />
+            </span>
+            <span className={styles.place}>{LIBELLE_PLACE[pole.place]}</span>
+            <span className={styles.nom}>{pole.nom}</span>
+            <span className={styles.promesse}>{pole.promesse}</span>
+          </a>
+        </li>
+      ))}
+
+      {/* Les deux suites dans un même élément de liste : c'est ce qui les met sur une
+          rangée et les empêche d'être lues l'une après l'autre. */}
+      <li className={styles.branche}>
+        <ul className={styles.paire}>
+          {suites.map((pole) => (
+            <li key={pole.id}>
+              <a className={styles.plaque} data-pole={pole.id} href={pole.route}>
+                <span aria-hidden="true" className={styles.marque}>
+                  <PoleGlyph pole={pole.id} />
+                </span>
+                <span className={styles.place}>{LIBELLE_PLACE[pole.place]}</span>
+                <span className={styles.nom}>{pole.nom}</span>
+                <span className={styles.promesse}>{pole.promesse}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </li>
+    </ul>
+  )
+}

--- a/src/@vitrine/components/PoleEntries/pole-entries.module.css
+++ b/src/@vitrine/components/PoleEntries/pole-entries.module.css
@@ -1,0 +1,94 @@
+/* pole-entries.module.css — les quatre pôles en entrées.
+ *
+ * La grille dit le modèle : deux rangées pleine largeur pour le tronc, une rangée
+ * partagée pour les deux suites. Aucune valeur de couleur ici — `--accent` vient du
+ * `data-pole` posé sur chaque plaque (voir `poles.css`). */
+
+.grille {
+  display: grid;
+  gap: var(--e-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tronc,
+.branche {
+  margin: 0;
+}
+
+/* Les deux sœurs sur une rangée. Sous 720px elles s'empilent — c'est la seule
+   concession, inévitable à cette largeur — mais elles gardent une facture identique,
+   qui est ce qui dit leur parité. */
+.paire {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  gap: var(--e-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.plaque {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-areas:
+    "marque place"
+    "marque nom"
+    "marque promesse";
+  align-items: start;
+  column-gap: var(--e-3);
+  row-gap: var(--e-0);
+  height: 100%;
+  padding: var(--e-3);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  border-radius: var(--rayon-petit);
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color var(--duree-micro) var(--courbe-poser),
+    background-color var(--duree-micro) var(--courbe-poser);
+}
+
+.plaque:hover {
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.marque {
+  grid-area: marque;
+  display: block;
+  color: var(--accent);
+}
+
+.place {
+  grid-area: place;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: var(--suivi-etiquette);
+  color: var(--encre-douce);
+}
+
+.nom {
+  grid-area: nom;
+  font-family: var(--police-titre-pile);
+  font-weight: 600;
+  font-size: var(--t-1);
+  line-height: 1.2;
+}
+
+.promesse {
+  grid-area: promesse;
+  max-width: 46ch;
+  font-size: var(--t-note);
+  line-height: 1.5;
+  color: var(--encre-douce);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plaque {
+    transition: none;
+  }
+}

--- a/src/@vitrine/components/SpaceEntries/index.tsx
+++ b/src/@vitrine/components/SpaceEntries/index.tsx
@@ -1,0 +1,33 @@
+// SpaceEntries/index.tsx — jeromemarichez-fr
+// Les deux espaces éditoriaux en entrées, depuis l'accueil.
+//
+// L'accueil vendait ses pôles et taisait ses espaces : on n'arrivait à `/realisations/`
+// et à `/blog/` que par le menu. Point 3 de l'issue #84.
+//
+// Le registre est délibérément PLUS SOBRE que celui des pôles : un espace ne se vend pas,
+// il déplie. Lui donner la même présence visuelle qu'un pôle aurait laissé croire à une
+// cinquième et une sixième offre — ce que `IEspaceEditorial` prend soin de distinguer
+// dans le type, et que le rendu ne doit pas défaire.
+//
+// Le volume affiché est DÉRIVÉ des listes sources (voir `espaces.ts`), jamais écrit à la
+// main : l'accueil ne peut donc pas annoncer un nombre de fiches que l'espace ne tient
+// pas. C'est la même règle que pour les chiffres de `preuves.ts`.
+
+import { ESPACES_EDITORIAUX } from '../../contenu/espaces'
+import styles from './space-entries.module.css'
+
+export function SpaceEntries() {
+  return (
+    <ul className={styles.liste}>
+      {ESPACES_EDITORIAUX.map((espace) => (
+        <li key={espace.id}>
+          <a className={styles.entree} href={espace.route}>
+            <span className={styles.titre}>{espace.titre}</span>
+            <span className={styles.volume}>{espace.volume}</span>
+            <span className={styles.accroche}>{espace.accroche}</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/@vitrine/components/SpaceEntries/space-entries.module.css
+++ b/src/@vitrine/components/SpaceEntries/space-entries.module.css
@@ -1,0 +1,63 @@
+/* space-entries.module.css — les deux espaces éditoriaux.
+ *
+ * Registre volontairement plus sobre que celui des pôles : un filet à gauche plutôt
+ * qu'une plaque encadrée. Un espace déplie, il ne se vend pas — et la hiérarchie
+ * visuelle doit le dire sans qu'un mot ait à l'expliquer. */
+
+.liste {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: var(--e-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.entree {
+  display: grid;
+  gap: var(--e-0);
+  height: 100%;
+  padding-left: var(--e-3);
+  border-left: 2px solid var(--cuivre-vif);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color var(--duree-micro) var(--courbe-poser);
+}
+
+.entree:hover {
+  border-left-color: var(--cuivre);
+}
+
+.titre {
+  font-family: var(--police-titre-pile);
+  font-weight: 600;
+  font-size: var(--t-1);
+  line-height: 1.2;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+.entree:hover .titre {
+  text-decoration-thickness: 2px;
+}
+
+.volume {
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  letter-spacing: var(--suivi-etiquette);
+  color: var(--cuivre);
+}
+
+.accroche {
+  max-width: 46ch;
+  font-size: var(--t-note);
+  line-height: 1.5;
+  color: var(--encre-douce);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .entree {
+    transition: none;
+  }
+}

--- a/src/@vitrine/contenu/espaces.ts
+++ b/src/@vitrine/contenu/espaces.ts
@@ -1,0 +1,43 @@
+// espaces.ts — jeromemarichez-fr
+// Les deux espaces éditoriaux, vus depuis l'accueil.
+//
+// L'accueil vendait ses quatre pôles et taisait ses deux espaces : on n'y arrivait que
+// par le menu ou par un renvoi de tuile de preuve. C'est le point 3 de l'issue #84 —
+// l'accueil doit pointer vers ses catégories par des entrées franches.
+//
+// **Les volumes sont DÉRIVÉS des listes sources**, jamais recopiés. C'est la même règle
+// que pour les chiffres de `preuves.ts` : un nombre écrit deux fois dans un dépôt finit
+// par valoir deux valeurs différentes, et une page d'accueil qui annonce quatorze fiches
+// devant treize est un défaut de véracité, pas une coquille.
+//
+// Ce que ces accroches n'ont PAS le droit de faire : élargir. Elles reprennent ce que
+// chaque espace dit déjà de lui-même dans son propre chapô — les réalisations ne sont pas
+// des cas clients, et trois fiches seulement portent un chiffre. Une accroche d'accueil
+// qui laisserait croire à treize références chiffrées vendrait ce qui n'existe pas.
+
+import { ROUTES } from '@/@shared/routes'
+import type { IEspaceEditorial } from '@/interfaces/IEspaceEditorial'
+import { ARTICLES } from './blog/articles'
+import { REALISATIONS } from './realisations/realisations'
+
+const CHIFFREES = REALISATIONS.filter((realisation) => realisation.chiffre !== undefined).length
+
+export const ESPACES_EDITORIAUX: IEspaceEditorial[] = [
+  {
+    id: 'realisations',
+    titre: 'Réalisations',
+    route: ROUTES.realisations,
+    accroche:
+      'Ce que j’ai construit, et dans quel cadre : intitulé de poste exact, période, équipe. ' +
+      'Pas des cas clients.',
+    volume: `${REALISATIONS.length} fiches, dont ${CHIFFREES} portent un chiffre`,
+  },
+  {
+    id: 'blog',
+    titre: 'Blog',
+    route: ROUTES.blog,
+    accroche:
+      'Les arbitrages de ce site, écrits pendant qu’ils étaient pris — mesure, tests, rendu.',
+    volume: `${ARTICLES.length} notes`,
+  },
+]

--- a/src/@vitrine/views/HomeView/index.tsx
+++ b/src/@vitrine/views/HomeView/index.tsx
@@ -9,7 +9,9 @@ import { CertificationList } from '../../components/CertificationList'
 import { ChainDiagram } from '../../components/ChainDiagram'
 import { EditorialSection } from '../../components/EditorialSection'
 import { HomeHero } from '../../components/HomeHero'
+import { PoleEntries } from '../../components/PoleEntries'
 import { ProofWall } from '../../components/ProofWall'
+import { SpaceEntries } from '../../components/SpaceEntries'
 import { PAGE_ACCUEIL, THESE_CHAINE } from '../../contenu/accueil'
 import { CERTIFICATIONS } from '../../contenu/certifications'
 import { LIMITES } from '../../contenu/limites'
@@ -37,6 +39,17 @@ export function HomeView() {
             <p className={styles.chapo}>{THESE_CHAINE.chapo}</p>
             <ChainDiagram />
             <p className={styles.appui}>{THESE_CHAINE.appui}</p>
+          </Reveal>
+        </section>
+
+        {/* Les portes, juste après la thèse : le visiteur vient de lire ce qu'est la
+            chaîne, c'est le moment où il veut y entrer. Plus bas, il aurait dû traverser
+            tout le fil pour trouver un lien. */}
+        <section aria-labelledby="poles-titre" className={styles.bloc} id="poles">
+          <Reveal className={styles.corpsBloc}>
+            <p className={styles.kicker}>Les quatre pôles</p>
+            <h2 id="poles-titre">Par où vous entrez</h2>
+            <PoleEntries />
           </Reveal>
         </section>
 
@@ -75,6 +88,14 @@ export function HomeView() {
               Aucun justificatif n'est publié en ligne à ce jour : ils sont communiqués sur demande.
             </p>
             <CertificationList certifications={CERTIFICATIONS} />
+          </Reveal>
+        </section>
+
+        <section aria-labelledby="espaces-titre" className={styles.bloc} id="espaces">
+          <Reveal className={styles.corpsBloc}>
+            <p className={styles.kicker}>Pour aller voir</p>
+            <h2 id="espaces-titre">Le travail, et les arbitrages</h2>
+            <SpaceEntries />
           </Reveal>
         </section>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,17 +66,25 @@
   --t-note: 0.9375rem;
   --t-0: clamp(1rem, 0.955rem + 0.22vw, 1.125rem);
   --t-1: clamp(1.25rem, 1.16rem + 0.44vw, 1.5rem);
-  --t-2: clamp(1.4375rem, 1.29rem + 0.72vw, 1.8125rem);
-  --t-3: clamp(1.9375rem, 1.6rem + 1.75vw, 2.875rem);
-  --t-4: clamp(2.5rem, 1.78rem + 3.6vw, 4.25rem);
-  --t-chiffre: clamp(2.5rem, 1.85rem + 3.1vw, 4rem);
+  /* Les trois crans de titre et le cran de chiffre ont été RESSERRÉS d'environ un quart
+     au sommet de l'échelle : 68 px de `h1` sur un écran large tenaient de l'affiche, pas
+     de la page de service. Le RAPPORT entre les crans est conservé — c'est lui qui fait
+     la hiérarchie, pas l'amplitude —, et la borne basse ne bouge que de quelques pixels :
+     à 320 px, l'échelle était déjà juste, c'est en s'ouvrant qu'elle dérapait. */
+  --t-2: clamp(1.3125rem, 1.2rem + 0.6vw, 1.625rem); /* 21 → 26 px */
+  --t-3: clamp(1.625rem, 1.41rem + 1.07vw, 2.1875rem); /* 26 → 35 px */
+  --t-4: clamp(2.125rem, 1.72rem + 2.02vw, 3.25rem); /* 34 → 52 px */
+  --t-chiffre: clamp(2.125rem, 1.75rem + 1.87vw, 3.125rem); /* 34 → 50 px */
 
   /* — Interlettrage — */
   /* Une fonte de titre gagne en tenue quand elle se resserre à mesure qu'elle grandit :
-     à 72 px, l'approche dessinée pour du labeur laisse des trous entre les lettres. Les
+     à 68 px, l'approche dessinée pour du labeur laissait des trous entre les lettres. Les
      étiquettes font l'inverse — capitales de 13 px, elles ont besoin d'air pour rester
-     lisibles. Trois valeurs, jamais réécrites dans un module. */
-  --suivi-display: -0.028em;
+     lisibles. Trois valeurs, jamais réécrites dans un module.
+     `--suivi-display` remonte de -0.028 à -0.02 em avec l'échelle : l'approche négative
+     compense une taille, elle n'est pas un style. À 52 px, -0.028 em recollait les
+     lettres au lieu de refermer un trou. */
+  --suivi-display: -0.02em;
   --suivi-titre: -0.016em;
   --suivi-etiquette: 0.09em;
 
@@ -95,6 +103,10 @@
   --rayon-petit: 8px;
   --largeur-page: 76rem;
   --mesure-texte: 64ch;
+  /* Côté d'une marque dessinée — celle d'un pôle sur sa plaque, celle d'un espace
+     éditorial sur sa carte. Un seul jeton pour les six : elles forment une série, et une
+     série dont les tailles divergent n'en est plus une. */
+  --taille-glyphe: 2.25rem;
 
   /* — Repères d'empilement collant — */
   /* Hauteur nominale de l'en-tête, en un seul endroit : la barre de pôle s'y accroche,
@@ -220,14 +232,15 @@ h3 {
 
 h1 {
   font-size: var(--t-4);
-  /* 1.05 et non 1.02 : à 72 px, une jambe de « j » et l'ascendante de la ligne suivante
-     se touchent sous 1.05 dans Fraunces. Le gain d'un centième ne vaut pas ça. */
-  line-height: 1.05;
+  /* 1.08 suit la baisse de `--t-4` : le risque de collision entre une jambe de « j » et
+     l'ascendante de la ligne suivante était une propriété des 68 px, pas de Fraunces.
+     À 52 px, l'interligne peut respirer sans que le titre se disperse. */
+  line-height: 1.08;
   letter-spacing: var(--suivi-display);
-  /* 20ch était calé sur une échelle plus petite. À 72 px, la mesure se referme d'un
-     cran : c'est le nombre de signes par ligne qui fait la tenue d'un titre, pas sa
-     largeur en pixels. */
-  max-width: 18ch;
+  /* La mesure suit l'échelle en sens INVERSE de la taille : c'est le nombre de signes
+     par ligne qui fait la tenue d'un titre. 18ch était le repli d'un titre à 68 px ;
+     à 52 px, la ligne peut reprendre les 21 signes sans se rompre. */
+  max-width: 21ch;
 }
 
 h2 {

--- a/src/interfaces/IEspaceEditorial.ts
+++ b/src/interfaces/IEspaceEditorial.ts
@@ -1,0 +1,24 @@
+// IEspaceEditorial.ts — jeromemarichez-fr
+// Un espace éditorial du site : `/realisations/` ou `/blog/`.
+//
+// Ce n'est ni un pôle ni une section. Un pôle se vend et porte une place dans la chaîne ;
+// un espace éditorial ne se vend pas — il déplie. C'est pour ça qu'il a son propre type
+// plutôt qu'un `IPole` amputé : les deux ne se rendent pas dans le même registre, et
+// aucun code ne doit pouvoir les mélanger.
+
+/** Identifiant d'un espace éditorial. Sert de clé de marque dessinée. */
+export type EspaceId = 'realisations' | 'blog'
+
+export interface IEspaceEditorial {
+  id: EspaceId
+  /** Le libellé exact repris de la navigation et du fil d'Ariane. */
+  titre: string
+  route: string
+  /** Une ligne, pas un chapô : la carte est une entrée, pas une section. */
+  accroche: string
+  /**
+   * Ce que l'espace contient, en clair. **Dérivé des listes sources**, jamais écrit à la
+   * main : l'accueil ne peut donc pas annoncer un nombre que l'espace ne tient pas.
+   */
+  volume: string
+}


### PR DESCRIPTION
Closes #84

## Les six retours, un par un

| Retour | Ce qui a ete fait |
|---|---|
| **1. Typographie trop grosse** | Echelle resserree : `--t-4` passe de 40→68 px a **34→52 px**, et les crans intermediaires suivent. `docs/design.md` disait encore l'ancienne echelle, corrige. |
| **2. Il manque des images** | **Quatre marques dessinees**, une par pole, en SVG rendu au serveur — moins de 700 octets dans le document. |
| **3. L'accueil doit pointer vers les categories** | `PoleEntries` (quatre poles) et `SpaceEntries` (`/realisations/` et `/blog/`), places l'un juste apres la these, l'autre avant le contact. |
| **4. Style pas assez IA / DATA** | Les marques sont des **figures de structure**, pas des pictogrammes decoratifs — voir plus bas pourquoi c'est le seul registre acceptable ici. |
| **5. Encore trop de texte** | Traite, mais le plancher est atteint — chiffres et raison ci-dessous. |
| **6. Reference getminds.ai** | **Non inspectee.** Aucune extension navigateur n'etait connectee et la recuperation textuelle ne rend pas la direction graphique. Le travail se fonde sur les cinq points explicites, **pas** sur une imitation. Si le rendu ne correspond pas a l'intention, c'est ce manque qu'il faudra combler d'abord. |

## La disposition porte le modele

Quatre plaques alignees a egalite auraient dit un catalogue — ce que le `CLAUDE.md` interdit d'affirmer. La grille rend la chaine reelle :

```
Ingenierie web          le socle, pleine largeur
      ↓
    Data                le passage oblige, pleine largeur
      ↓
IA   ·   SEA & UX       deux suites, COTE A COTE, de rang egal
```

Les deux suites partagent une rangee **parce qu'elles partagent un temps**. Les empiler aurait reintroduit dans le dessin l'ordre que le modele nie.

## Les marques ne simulent aucune donnee

Un pictogramme qui mimerait un graphique — courbe qui monte, barres qui progressent — afficherait un **chiffre invente**, ce que les regles de veracite interdisent. Sur un site qui vend la mesure, c'est l'inverse exact de sa promesse. Ce sont donc des figures de structure.

L'IA n'est pas dessinee par le neurone. C'est le cliche attendu, et il dirait quelque chose de **faux** : ce pole promet que « la reponse n'est pas toujours un modele ». Sa marque est un embranchement dont une branche est retenue et l'autre ecartee — la promesse, litteralement. Les deux sœurs partagent la meme grammaire de trait, meme poids et meme nombre de traces.

Aucun composant ne nomme une couleur : le trace est en `currentColor`, `data-pole` fait le reste via `poles.css`.

## Les volumes sont derives, jamais recopies

`SpaceEntries` affiche « 13 fiches, dont 3 portent un chiffre » et « 3 notes » — **calcules depuis les listes sources**. L'accueil ne peut donc pas annoncer un nombre que l'espace ne tient pas. Meme regle que pour les chiffres de `preuves.ts` : un nombre ecrit deux fois dans un depot finit par valoir deux valeurs.

## Sur « encore trop de texte » — le plancher est atteint, et je le montre

L'accueil rend **2 533 mots**. Le contenu editorial avait deja ete reduit de **44 %** en deux passes.

Etat reel de `accueil-sections.ts` : **23 blocs, dont 8 seulement portent encore un paragraphe**. Sur ces huit, **sept n'ont QUE leur paragraphe** — le supprimer laisserait un titre orphelin, ce que la regle etablie interdit.

Le huitieme, « Le produit n'est pas dans ma tete », a un paragraphe **et** une preuve. Je ne l'ai pas coupe non plus, et c'est un arbitrage a connaitre : sa preuve est une **liste d'outils**. Retirer le paragraphe aurait laisse un titre suivi d'outils — exactement ce que la ligne editoriale proscrit (« vendre une decision, pas une techno »). Le paragraphe porte en plus le differenciateur TDD, que le `CLAUDE.md` demande de faire apparaitre partout ou le site parle de programmation.

**Le vrai levier restant n'est pas une coupe, c'est un deplacement** : l'accueil deroule encore la chaine entiere. Maintenant que `PoleEntries` donne un acces direct a chaque page de pole, une partie de ce detail pourrait y descendre. C'est une restructuration editoriale qui merite sa propre issue.

## Mesures

`make budgets`, machine au repos (load 2,2) :

| Page | Perf | A11y | Bonnes prat. | SEO |
|---|---|---|---|---|
| **accueil** | **96** | 100 | 100 | 100 |
| pole-ingenierie-web | 97 | 100 | 100 | 100 |
| article | 97 | 100 | 100 | 100 |
| realisations | 97 | 100 | 100 | 100 |
| realisation | 97 | 100 | 100 | 100 |

**L'accueil garde sa marge : 96 pour un seuil de 95, inchange.** Ajouter des visuels n'a rien coute, parce qu'aucun n'est une image — c'est precisement le pari du SVG produit contre le fichier trouve.

axe-core : **zero violation** sur les cinq pages, bloquantes comme mineures.

## Interdits

Aucun des quatre interdits de `docs/design.md` n'est introduit : ni defilement detourne, ni parallaxe, ni curseur personnalise, ni compteur anime. Les transitions ajoutees sont en couleur de bordure et de fond, coupees sous `prefers-reduced-motion`.

Aucune dependance ajoutee. Aucune valeur en dur dans un module CSS. Aucun fichier au-dessus de 300 lignes.

## Intentions de test — aucun fichier pose

1. **Unitaire, `PoleEntries`** : les quatre poles de `POLES_NAV` sont rendus ; les deux `place: 'suite'` sont dans le **meme** element de liste, les deux autres dans des elements distincts. C'est l'invariant qui garantit que le rendu ne peut pas presenter les sœurs l'une apres l'autre. Cas limite : un cinquieme pole ajoute a `POLES_NAV` doit apparaitre sans modification du composant.
2. **Unitaire, `SpaceEntries`** : le volume affiche est **egal** au `length` de la liste source correspondante — le test echoue si quelqu'un ecrit le nombre a la main. Cas limite : une liste vide.
3. **Unitaire, `PoleGlyph`** : une marque est rendue pour chacun des quatre `PoleId`, aucune ne contient de texte ni de valeur numerique.

## Un point de veracite releve en passant, hors perimetre

La preuve du bloc « Migrations sans coupure » publie **« chiffre d'affaires maintenu »**. L'audit de veracite de cette session avait signale cette mention comme relevant du **NDA Prezage** — « un chiffre du projet au sens de la clause » — et recommande de la garder hors ligne **par defaut, a arbitrer par Jerome MARICHEZ**. Elle est aujourd'hui publiee, sur `dev` comme en production, et elle est anterieure a cette PR. Je ne l'ai pas touchee : c'est une decision de contenu, pas d'integration.
