### PR TITLE
chore: version 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {


### PR DESCRIPTION
Bump SemVer avant la mise en production.

Depuis le tag `v0.5.0`, `dev` a recu trois ajouts et aucune rupture :

- **la refraction SVG du verre** (#47) — gatee sur Blink et au-dessus de 1024 px ;
- **deux controles CI** (#79) — `nginx -t` sur la configuration reelle, et construction de l'image Docker avec fumee HTTP ;
- **la refonte visuelle de l'accueil** (#84) — echelle typographique resserree, marques dessinees, entrees vers les quatre poles et les deux espaces.

Increment **mineur** : ce sont des fonctionnalites, pas des correctifs.

Sans ce bump, `release-main.yml` ne publierait aucune release — il lit la version de `package.json` et `v0.5.0` existe deja.