### PR TITLE
fix(accueil): titres qui s'empilent, et scene du seuil muette et immobile

### DIFF
--- a/src/@shared/components/ChainCanvas/SlabScene.tsx
+++ b/src/@shared/components/ChainCanvas/SlabScene.tsx
@@ -28,6 +28,7 @@
 // `data-pole` : il hérite du cuivre de la racine, la couleur de la maison — celle de
 // l'interlocuteur, qui n'appartient à aucun pôle parce qu'il les porte tous.
 
+import { PoleGlyph } from '../PoleGlyph'
 import styles from './slab-scene.module.css'
 
 interface SlabSceneProps {
@@ -68,49 +69,68 @@ export function SlabScene({ fige = false }: SlabSceneProps) {
           qui ne se referment jamais au même moment suffisent à faire lire du volume, là
           où une seule donnerait un balancement de métronome. */}
       <g className={styles.groupe}>
-        <rect
-          className={styles.socle}
-          data-pole="ingenierie-web"
-          fill="url(#dalle-lueur)"
-          height="92"
-          rx="14"
-          width="168"
-          x="126"
-          y="18"
-        />
-        <rect
-          className={styles.passage}
-          data-pole="data"
-          fill="url(#dalle-lueur)"
-          height="92"
-          rx="14"
-          width="168"
-          x="106"
-          y="130"
-        />
-        {/* Les deux suites : même largeur, même hauteur, même classe, même dégradé. Seuls
-            `x`, `y` et le déphasage de la dérive les distinguent — rien qui se lise
-            comme un ordre. */}
-        <rect
-          className={styles.suite}
-          data-pole="ia"
-          fill="url(#dalle-lueur)"
-          height="96"
-          rx="14"
-          width="150"
-          x="26"
-          y="250"
-        />
-        <rect
-          className={`${styles.suite} ${styles.suiteDecalee}`}
-          data-pole="sea-ux"
-          fill="url(#dalle-lueur)"
-          height="96"
-          rx="14"
-          width="150"
-          x="244"
-          y="262"
-        />
+        <g className={styles.socle}>
+          <rect
+            data-pole="ingenierie-web"
+            fill="url(#dalle-lueur)"
+            height="92"
+            rx="14"
+            width="168"
+            x="126"
+            y="18"
+          />
+          <g className={styles.marque} data-pole="ingenierie-web" transform="translate(146 42)">
+            <PoleGlyph pole="ingenierie-web" />
+          </g>
+        </g>
+
+        <g className={styles.passage}>
+          <rect
+            data-pole="data"
+            fill="url(#dalle-lueur)"
+            height="92"
+            rx="14"
+            width="168"
+            x="106"
+            y="130"
+          />
+          <g className={styles.marque} data-pole="data" transform="translate(126 154)">
+            <PoleGlyph pole="data" />
+          </g>
+        </g>
+
+        {/* Les deux suites : même largeur, même hauteur, même classe, même dégradé, et
+            désormais une marque posée au même endroit de leur dalle. Seuls `x`, `y` et
+            le déphasage de la dérive les distinguent — rien qui se lise comme un ordre. */}
+        <g className={styles.suite}>
+          <rect
+            data-pole="ia"
+            fill="url(#dalle-lueur)"
+            height="96"
+            rx="14"
+            width="150"
+            x="26"
+            y="250"
+          />
+          <g className={styles.marque} data-pole="ia" transform="translate(46 276)">
+            <PoleGlyph pole="ia" />
+          </g>
+        </g>
+
+        <g className={`${styles.suite} ${styles.suiteDecalee}`}>
+          <rect
+            data-pole="sea-ux"
+            fill="url(#dalle-lueur)"
+            height="96"
+            rx="14"
+            width="150"
+            x="244"
+            y="262"
+          />
+          <g className={styles.marque} data-pole="sea-ux" transform="translate(264 288)">
+            <PoleGlyph pole="sea-ux" />
+          </g>
+        </g>
       </g>
     </svg>
   )

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -41,39 +41,45 @@
 }
 
 .socle {
-  animation: deriver-dalle 19s var(--courbe-poser) infinite alternate;
+  animation: deriver-dalle 11s var(--courbe-poser) infinite alternate;
 }
 
 .passage {
-  animation: deriver-dalle 15s var(--courbe-poser) -5s infinite alternate;
+  animation: deriver-dalle 9s var(--courbe-poser) -3s infinite alternate;
 }
 
 /* Les deux sœurs partagent CETTE règle, entièrement. Même durée, même courbe, même
    amplitude : rien dans leur mouvement ne peut se lire comme un ordre. Seul le déphasage
    ci-dessous les désynchronise, et un déphasage n'a ni premier ni second. */
 .suite {
-  animation: deriver-dalle 13s var(--courbe-poser) infinite alternate;
+  animation: deriver-dalle 8s var(--courbe-poser) infinite alternate;
 }
 
 .suiteDecalee {
-  animation-delay: -7s;
+  animation-delay: -4s;
 }
 
 .groupe {
   transform-box: fill-box;
   transform-origin: center;
-  animation: respirer-groupe 24s var(--courbe-poser) infinite alternate;
+  animation: respirer-groupe 14s var(--courbe-poser) infinite alternate;
 }
 
-/* Amplitudes délibérément minuscules : la scène doit se remarquer si on la regarde et
-   passer inaperçue si on lit le texte à côté. Au-delà de deux ou trois pixels, un décor
-   en périphérie du champ devient une distraction pendant la lecture du `h1`. */
+/* Les amplitudes étaient de deux à trois pixels sur treize à vingt-quatre secondes :
+   la scène ne passait pas inaperçue, elle passait INVISIBLE. Sur un portable large, une
+   dérive de 2,5 px étalée sur dix-neuf secondes se situe sous le seuil de perception du
+   mouvement — le décor coûtait son poids sans rien rendre.
+   Les valeurs sont donc relevées **à la demande explicite de Jérôme MARICHEZ** : environ
+   trois fois l'amplitude, environ moitié moins de durée. On reste dans le registre de la
+   dérive lente — rien ne traverse le cadre, rien ne clignote — mais le mouvement se voit
+   maintenant du coin de l'œil, ce qui est tout ce qu'on lui demande. Les unités
+   s'entendent dans le `viewBox` (420 × 360), pas en pixels d'écran. */
 @keyframes deriver-dalle {
   from {
     transform: translate3d(0, 0, 0);
   }
   to {
-    transform: translate3d(-2.5px, -3.5px, 0);
+    transform: translate3d(-7px, -9px, 0);
   }
 }
 
@@ -82,7 +88,7 @@
     transform: translate3d(0, 0, 0) scale(1);
   }
   to {
-    transform: translate3d(1.5px, 0, 0) scale(1.008);
+    transform: translate3d(4px, 0, 0) scale(1.022);
   }
 }
 
@@ -90,13 +96,24 @@
    pose où elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
    quelqu'un qui appuie sur « Figer l'animation » en la regardant. */
 .scene[data-fige="true"] .groupe,
-.scene[data-fige="true"] .groupe rect {
+.scene[data-fige="true"] .groupe > g {
   animation-play-state: paused;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .groupe,
-  .groupe rect {
+  .groupe > g {
     animation: none;
   }
+}
+
+/* La marque du pôle, posée au bord d'attaque de sa dalle. Elle dérive AVEC elle — c'est
+   pour cela que la dalle est devenue un groupe : une marque animée séparément se serait
+   décollée de la plaque qu'elle nomme.
+   Une dalle teintée ne dit pas quel pôle elle est ; la couleur seule ne peut pas le
+   porter (WCAG 1.4.1), et la scène est de toute façon `role="presentation"` — la marque
+   est un repère visuel, et le texte voisin reste le porteur de l'information. */
+.marque {
+  --taille-glyphe: 44px;
+  opacity: 0.92;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,25 +66,30 @@
   --t-note: 0.9375rem;
   --t-0: clamp(1rem, 0.955rem + 0.22vw, 1.125rem);
   --t-1: clamp(1.25rem, 1.16rem + 0.44vw, 1.5rem);
-  /* Les trois crans de titre et le cran de chiffre ont été RESSERRÉS d'environ un quart
-     au sommet de l'échelle : 68 px de `h1` sur un écran large tenaient de l'affiche, pas
-     de la page de service. Le RAPPORT entre les crans est conservé — c'est lui qui fait
-     la hiérarchie, pas l'amplitude —, et la borne basse ne bouge que de quelques pixels :
-     à 320 px, l'échelle était déjà juste, c'est en s'ouvrant qu'elle dérapait. */
-  --t-2: clamp(1.3125rem, 1.2rem + 0.6vw, 1.625rem); /* 21 → 26 px */
-  --t-3: clamp(1.625rem, 1.41rem + 1.07vw, 2.1875rem); /* 26 → 35 px */
-  --t-4: clamp(2.125rem, 1.72rem + 2.02vw, 3.25rem); /* 34 → 52 px */
-  --t-chiffre: clamp(2.125rem, 1.75rem + 1.87vw, 3.125rem); /* 34 → 50 px */
+  /* Les trois crans de titre et le cran de chiffre ont été resserrés une PREMIÈRE fois
+     d'environ un quart (68 → 52 px de `h1`), puis une SECONDE fois ici. La première
+     passe traitait l'amplitude ; elle n'a pas traité ce qui se voyait vraiment à
+     l'écran — un titre de 78 signes qui retombait sur QUATRE lignes, soit 225 px de
+     titre avant le premier mot du chapô. Un titre qui s'empile n'est pas ample, il est
+     encombrant, et c'est ce que voit un lecteur sur un portable large.
+     Le RAPPORT entre les crans est conservé — c'est lui qui fait la hiérarchie, pas
+     l'amplitude —, et la borne basse ne bouge presque pas : à 320 px l'échelle était
+     déjà juste, c'est en s'ouvrant qu'elle dérapait. */
+  --t-2: clamp(1.25rem, 1.16rem + 0.44vw, 1.5rem); /* 20 → 24 px */
+  --t-3: clamp(1.5rem, 1.35rem + 0.75vw, 1.875rem); /* 24 → 30 px */
+  --t-4: clamp(1.875rem, 1.59rem + 1.43vw, 2.6875rem); /* 30 → 43 px */
+  --t-chiffre: clamp(1.875rem, 1.62rem + 1.25vw, 2.5625rem); /* 30 → 41 px */
 
   /* — Interlettrage — */
   /* Une fonte de titre gagne en tenue quand elle se resserre à mesure qu'elle grandit :
      à 68 px, l'approche dessinée pour du labeur laissait des trous entre les lettres. Les
      étiquettes font l'inverse — capitales de 13 px, elles ont besoin d'air pour rester
      lisibles. Trois valeurs, jamais réécrites dans un module.
-     `--suivi-display` remonte de -0.028 à -0.02 em avec l'échelle : l'approche négative
-     compense une taille, elle n'est pas un style. À 52 px, -0.028 em recollait les
-     lettres au lieu de refermer un trou. */
-  --suivi-display: -0.02em;
+     `--suivi-display` remonte avec l'échelle — -0.028 em à 68 px, -0.02 em à 52 px,
+     -0.016 em à 43 px : l'approche négative compense une taille, elle n'est pas un
+     style. Laissée à -0.02 em sur un titre redescendu à 43 px, elle recollerait les
+     lettres au lieu de refermer un trou qui n'existe plus. */
+  --suivi-display: -0.016em;
   --suivi-titre: -0.016em;
   --suivi-etiquette: 0.09em;
 
@@ -238,16 +243,24 @@ h1 {
   line-height: 1.08;
   letter-spacing: var(--suivi-display);
   /* La mesure suit l'échelle en sens INVERSE de la taille : c'est le nombre de signes
-     par ligne qui fait la tenue d'un titre. 18ch était le repli d'un titre à 68 px ;
-     à 52 px, la ligne peut reprendre les 21 signes sans se rompre. */
-  max-width: 21ch;
+     par ligne qui fait la tenue d'un titre. 18ch était le repli d'un titre à 68 px, 21ch
+     celui d'un titre à 52 px — mais 21ch appliqués à un `h1` de 78 signes le repliaient
+     sur QUATRE lignes, et un plafond qui casse la phrase plus tôt que la colonne ne
+     l'exige ne protège plus rien : il empile. À 43 px, 32 signes tiennent sans que la
+     ligne se rompe, et le titre reprend la largeur que la colonne lui offrait déjà. */
+  max-width: 32ch;
 }
 
 h2 {
   font-size: var(--t-3);
   line-height: 1.08;
   letter-spacing: var(--suivi-titre);
-  max-width: 30ch;
+  /* 30ch coupait en deux des titres de 40 à 49 signes — « Ce qui est mesuré, pas ce qui
+     est promis », « Ce qui a été évalué par quelqu'un d'autre que moi » — alors que la
+     colonne avait la place de les tenir d'un trait. Une phrase courte cassée en deux
+     lignes se lit comme un titre trop grand, ce qu'elle n'était pas. 46ch les ramène sur
+     une ligne aux largeurs de portable, sans jamais dépasser la mesure de lecture. */
+  max-width: 46ch;
 }
 
 h3 {


### PR DESCRIPTION
Trois remontées de Jérôme MARICHEZ sur l'accueil, traitées ensemble parce qu'elles portent toutes sur le même écran : le seuil.

## 1. Les titres s'empilaient — mesuré, pas jugé à l'œil

« C'est toujours trop gros, les phrases passent sur 2 lignes, voire plus. »

La cause n'était pas (seulement) la taille de la police, mais le **plafond de mesure en `ch`** :

| Niveau | Signes | Plafond | Lignes |
|--------|-------:|--------:|-------:|
| `h1` du seuil | **78** | `21ch` | **4** |
| `h2` « Ce qui a été évalué par quelqu'un d'autre que moi » | 49 | `30ch` | 2 |
| `h2` « Ce qui est mesuré, pas ce qui est promis » | 40 | `30ch` | 2 |
| `h2` « Site internet, produit SaaS, application mobile » | 47 | `30ch` | 2 |

Le `h1` occupait **quatre lignes à 52 px, soit ~225 px de titre** avant le premier mot du chapô — quelle que soit la largeur de l'écran, puisque c'est le plafond qui l'impose, pas la colonne. Un plafond qui coupe la phrase plus tôt que la colonne ne l'exige ne protège plus la tenue du titre : **il l'empile**. Et une phrase courte cassée en deux se lit comme un titre trop grand, ce qu'elle n'était pas.

Deux leviers :

- **L'échelle redescend d'environ 17 % au sommet** : `h1` 52 → **43 px**, `h2` 35 → 30 px, `h3` 26 → 24 px, chiffre 50 → 41 px. Le **rapport** entre les crans est conservé — c'est lui qui fait la hiérarchie, pas l'amplitude — et la borne basse ne bouge presque pas : à 320 px l'échelle était déjà juste.
- **Les mesures remontent là où elles serraient pour rien** : `h1` 21 → **32ch**, `h2` 30 → **46ch**.

Résultat : le `h1` passe de **4 lignes à 2**, les `h2` concernés d'une cassure à **une seule ligne**.

`--suivi-display` suit l'échelle (-0,02 → -0,016 em) : l'approche négative compense une taille, elle n'est pas un style — laissée telle quelle à 43 px, elle recollait les lettres au lieu de refermer un trou qui n'existe plus.

## 2. On ne voyait pas quel pôle était quelle dalle

Quatre rectangles teintés ne nomment rien, et la couleur seule ne peut pas porter l'information. Le site avait déjà les marques qu'il faut — **`PoleGlyph`**, utilisé par les entrées de pôle plus bas dans la même page. Chaque dalle porte désormais la sienne, posée au bord d'attaque, même taille et même traitement pour les quatre.

Conséquence de structure : une dalle devient un **groupe** (`rect` + marque) au lieu d'un `rect` nu, sans quoi la marque dériverait sans la plaque qu'elle nomme. Les sélecteurs de pause et de `prefers-reduced-motion` suivent (`.groupe rect` → `.groupe > g`).

Les deux sœurs `ia` et `sea-ux` gardent leur **égalité stricte** : même classe, même taille de marque, même position relative dans leur dalle. Rien dans le dessin ne les remet en ordre — c'est la règle que le `CLAUDE.md` impose et que la scène existe pour tenir.

## 3. La scène était animée, mais invisible

Elle l'était déjà — mais **2,5 px de dérive étalés sur 19 s** passent sous le seuil de perception du mouvement. Le décor coûtait son poids sans rien rendre.

| | Avant | Après |
|---|---|---|
| Amplitude de dérive | 2,5 × 3,5 px | **7 × 9 px** |
| Durées | 13 / 15 / 19 / 24 s | **8 / 9 / 11 / 14 s** |
| Respiration du groupe | `scale(1.008)` | `scale(1.022)` |

On reste dans le registre de la dérive lente : rien ne traverse le cadre, rien ne clignote.

**Les deux gardes restent intactes** : `prefers-reduced-motion: reduce` coupe tout, et le bouton « Figer l'animation » (WCAG 2.2.2) met en pause sans sauter à l'image de départ. Toujours `transform` et `opacity` uniquement — les deux seules propriétés que le compositeur traite sans repasser par la mise en page ni par le peintre.

**Coût : zéro octet de JavaScript.** Les quatre marques sont du SVG rendu au serveur, vérifié dans l'export :

```
dalles data-pole : ingenierie-web, ingenierie-web, data, data, ia, ia, sea-ux, sea-ux
glyphes imbriqués : 4    translate : 146 42 | 126 154 | 46 276 | 264 288
```

## Ce que cette PR ne fait pas

Deux remontées restent **non traitées** et méritent leur propre issue : le **manque d'images** (`public/` ne contient que `certifications/` — et `output: 'export'` désactive l'optimisation `next/image`, donc c'est un arbitrage perf sous contrainte Lighthouse ≥ 95, pas une intégration) et la **direction visuelle IA/DATA** façon getminds.ai avec le resserrement du texte. Ce sont des décisions structurantes, pas des réglages.

À noter aussi : l'accueil **pointait déjà** vers les quatre pôles (`PoleEntries`, commit `382e5dc`) et l'échelle **avait déjà** été resserrée une première fois (`2fd93b5`). Cette PR corrige ce que cette première passe n'avait pas vu, elle ne la refait pas.

## Tests

Aucun fichier de test écrit par l'assistant. Le changement est intégralement CSS et balisage SVG, sans logique à couvrir.

**Intention proposée**, si elle paraît utile — *test unitaire* (`tests/unitaire/slab-scene.spec.tsx`) : rendre `SlabScene` et vérifier que les **quatre** `data-pole` attendus sont présents, que chaque dalle porte **une** marque, et que `ia` et `sea-ux` reçoivent une marque de **taille identique** — c'est la seule des trois assertions qui protège une règle du `CLAUDE.md` (l'égalité des deux sœurs) contre une régression silencieuse. Jeu de données : `POLES_NAV`, déjà la source unique.

## Vérifications

`make lint`, `make type-check` et `make build` verts en local.

https://claude.ai/code/session_01Vz8szo5e81R85kUGnwNftH