### PR TITLE
chore: version 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {


### PR DESCRIPTION
Bump SemVer avant mise en production.

Depuis `v0.6.0`, `dev` a recu la PR #89 : correction des titres qui s'empilaient sur trois ou quatre lignes, marques posees sur les quatre dalles du seuil, et animation de la scene rendue perceptible.

Increment **mineur** et non correctif : le lot contient un `feat` — les dalles portent desormais leur marque et la scene s'anime reellement — pas seulement le `fix` des titres.