### PR TITLE
release: v0.7.0 — titres resserres, dalles marquees, scene animee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {

--- a/src/@shared/components/ChainCanvas/SlabScene.tsx
+++ b/src/@shared/components/ChainCanvas/SlabScene.tsx
@@ -28,6 +28,7 @@
 // `data-pole` : il hérite du cuivre de la racine, la couleur de la maison — celle de
 // l'interlocuteur, qui n'appartient à aucun pôle parce qu'il les porte tous.
 
+import { PoleGlyph } from '../PoleGlyph'
 import styles from './slab-scene.module.css'
 
 interface SlabSceneProps {
@@ -68,49 +69,68 @@ export function SlabScene({ fige = false }: SlabSceneProps) {
           qui ne se referment jamais au même moment suffisent à faire lire du volume, là
           où une seule donnerait un balancement de métronome. */}
       <g className={styles.groupe}>
-        <rect
-          className={styles.socle}
-          data-pole="ingenierie-web"
-          fill="url(#dalle-lueur)"
-          height="92"
-          rx="14"
-          width="168"
-          x="126"
-          y="18"
-        />
-        <rect
-          className={styles.passage}
-          data-pole="data"
-          fill="url(#dalle-lueur)"
-          height="92"
-          rx="14"
-          width="168"
-          x="106"
-          y="130"
-        />
-        {/* Les deux suites : même largeur, même hauteur, même classe, même dégradé. Seuls
-            `x`, `y` et le déphasage de la dérive les distinguent — rien qui se lise
-            comme un ordre. */}
-        <rect
-          className={styles.suite}
-          data-pole="ia"
-          fill="url(#dalle-lueur)"
-          height="96"
-          rx="14"
-          width="150"
-          x="26"
-          y="250"
-        />
-        <rect
-          className={`${styles.suite} ${styles.suiteDecalee}`}
-          data-pole="sea-ux"
-          fill="url(#dalle-lueur)"
-          height="96"
-          rx="14"
-          width="150"
-          x="244"
-          y="262"
-        />
+        <g className={styles.socle}>
+          <rect
+            data-pole="ingenierie-web"
+            fill="url(#dalle-lueur)"
+            height="92"
+            rx="14"
+            width="168"
+            x="126"
+            y="18"
+          />
+          <g className={styles.marque} data-pole="ingenierie-web" transform="translate(146 42)">
+            <PoleGlyph pole="ingenierie-web" />
+          </g>
+        </g>
+
+        <g className={styles.passage}>
+          <rect
+            data-pole="data"
+            fill="url(#dalle-lueur)"
+            height="92"
+            rx="14"
+            width="168"
+            x="106"
+            y="130"
+          />
+          <g className={styles.marque} data-pole="data" transform="translate(126 154)">
+            <PoleGlyph pole="data" />
+          </g>
+        </g>
+
+        {/* Les deux suites : même largeur, même hauteur, même classe, même dégradé, et
+            désormais une marque posée au même endroit de leur dalle. Seuls `x`, `y` et
+            le déphasage de la dérive les distinguent — rien qui se lise comme un ordre. */}
+        <g className={styles.suite}>
+          <rect
+            data-pole="ia"
+            fill="url(#dalle-lueur)"
+            height="96"
+            rx="14"
+            width="150"
+            x="26"
+            y="250"
+          />
+          <g className={styles.marque} data-pole="ia" transform="translate(46 276)">
+            <PoleGlyph pole="ia" />
+          </g>
+        </g>
+
+        <g className={`${styles.suite} ${styles.suiteDecalee}`}>
+          <rect
+            data-pole="sea-ux"
+            fill="url(#dalle-lueur)"
+            height="96"
+            rx="14"
+            width="150"
+            x="244"
+            y="262"
+          />
+          <g className={styles.marque} data-pole="sea-ux" transform="translate(264 288)">
+            <PoleGlyph pole="sea-ux" />
+          </g>
+        </g>
       </g>
     </svg>
   )

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -41,39 +41,45 @@
 }
 
 .socle {
-  animation: deriver-dalle 19s var(--courbe-poser) infinite alternate;
+  animation: deriver-dalle 11s var(--courbe-poser) infinite alternate;
 }
 
 .passage {
-  animation: deriver-dalle 15s var(--courbe-poser) -5s infinite alternate;
+  animation: deriver-dalle 9s var(--courbe-poser) -3s infinite alternate;
 }
 
 /* Les deux sœurs partagent CETTE règle, entièrement. Même durée, même courbe, même
    amplitude : rien dans leur mouvement ne peut se lire comme un ordre. Seul le déphasage
    ci-dessous les désynchronise, et un déphasage n'a ni premier ni second. */
 .suite {
-  animation: deriver-dalle 13s var(--courbe-poser) infinite alternate;
+  animation: deriver-dalle 8s var(--courbe-poser) infinite alternate;
 }
 
 .suiteDecalee {
-  animation-delay: -7s;
+  animation-delay: -4s;
 }
 
 .groupe {
   transform-box: fill-box;
   transform-origin: center;
-  animation: respirer-groupe 24s var(--courbe-poser) infinite alternate;
+  animation: respirer-groupe 14s var(--courbe-poser) infinite alternate;
 }
 
-/* Amplitudes délibérément minuscules : la scène doit se remarquer si on la regarde et
-   passer inaperçue si on lit le texte à côté. Au-delà de deux ou trois pixels, un décor
-   en périphérie du champ devient une distraction pendant la lecture du `h1`. */
+/* Les amplitudes étaient de deux à trois pixels sur treize à vingt-quatre secondes :
+   la scène ne passait pas inaperçue, elle passait INVISIBLE. Sur un portable large, une
+   dérive de 2,5 px étalée sur dix-neuf secondes se situe sous le seuil de perception du
+   mouvement — le décor coûtait son poids sans rien rendre.
+   Les valeurs sont donc relevées **à la demande explicite de Jérôme MARICHEZ** : environ
+   trois fois l'amplitude, environ moitié moins de durée. On reste dans le registre de la
+   dérive lente — rien ne traverse le cadre, rien ne clignote — mais le mouvement se voit
+   maintenant du coin de l'œil, ce qui est tout ce qu'on lui demande. Les unités
+   s'entendent dans le `viewBox` (420 × 360), pas en pixels d'écran. */
 @keyframes deriver-dalle {
   from {
     transform: translate3d(0, 0, 0);
   }
   to {
-    transform: translate3d(-2.5px, -3.5px, 0);
+    transform: translate3d(-7px, -9px, 0);
   }
 }
 
@@ -82,7 +88,7 @@
     transform: translate3d(0, 0, 0) scale(1);
   }
   to {
-    transform: translate3d(1.5px, 0, 0) scale(1.008);
+    transform: translate3d(4px, 0, 0) scale(1.022);
   }
 }
 
@@ -90,13 +96,24 @@
    pose où elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
    quelqu'un qui appuie sur « Figer l'animation » en la regardant. */
 .scene[data-fige="true"] .groupe,
-.scene[data-fige="true"] .groupe rect {
+.scene[data-fige="true"] .groupe > g {
   animation-play-state: paused;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .groupe,
-  .groupe rect {
+  .groupe > g {
     animation: none;
   }
+}
+
+/* La marque du pôle, posée au bord d'attaque de sa dalle. Elle dérive AVEC elle — c'est
+   pour cela que la dalle est devenue un groupe : une marque animée séparément se serait
+   décollée de la plaque qu'elle nomme.
+   Une dalle teintée ne dit pas quel pôle elle est ; la couleur seule ne peut pas le
+   porter (WCAG 1.4.1), et la scène est de toute façon `role="presentation"` — la marque
+   est un repère visuel, et le texte voisin reste le porteur de l'information. */
+.marque {
+  --taille-glyphe: 44px;
+  opacity: 0.92;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,25 +66,30 @@
   --t-note: 0.9375rem;
   --t-0: clamp(1rem, 0.955rem + 0.22vw, 1.125rem);
   --t-1: clamp(1.25rem, 1.16rem + 0.44vw, 1.5rem);
-  /* Les trois crans de titre et le cran de chiffre ont été RESSERRÉS d'environ un quart
-     au sommet de l'échelle : 68 px de `h1` sur un écran large tenaient de l'affiche, pas
-     de la page de service. Le RAPPORT entre les crans est conservé — c'est lui qui fait
-     la hiérarchie, pas l'amplitude —, et la borne basse ne bouge que de quelques pixels :
-     à 320 px, l'échelle était déjà juste, c'est en s'ouvrant qu'elle dérapait. */
-  --t-2: clamp(1.3125rem, 1.2rem + 0.6vw, 1.625rem); /* 21 → 26 px */
-  --t-3: clamp(1.625rem, 1.41rem + 1.07vw, 2.1875rem); /* 26 → 35 px */
-  --t-4: clamp(2.125rem, 1.72rem + 2.02vw, 3.25rem); /* 34 → 52 px */
-  --t-chiffre: clamp(2.125rem, 1.75rem + 1.87vw, 3.125rem); /* 34 → 50 px */
+  /* Les trois crans de titre et le cran de chiffre ont été resserrés une PREMIÈRE fois
+     d'environ un quart (68 → 52 px de `h1`), puis une SECONDE fois ici. La première
+     passe traitait l'amplitude ; elle n'a pas traité ce qui se voyait vraiment à
+     l'écran — un titre de 78 signes qui retombait sur QUATRE lignes, soit 225 px de
+     titre avant le premier mot du chapô. Un titre qui s'empile n'est pas ample, il est
+     encombrant, et c'est ce que voit un lecteur sur un portable large.
+     Le RAPPORT entre les crans est conservé — c'est lui qui fait la hiérarchie, pas
+     l'amplitude —, et la borne basse ne bouge presque pas : à 320 px l'échelle était
+     déjà juste, c'est en s'ouvrant qu'elle dérapait. */
+  --t-2: clamp(1.25rem, 1.16rem + 0.44vw, 1.5rem); /* 20 → 24 px */
+  --t-3: clamp(1.5rem, 1.35rem + 0.75vw, 1.875rem); /* 24 → 30 px */
+  --t-4: clamp(1.875rem, 1.59rem + 1.43vw, 2.6875rem); /* 30 → 43 px */
+  --t-chiffre: clamp(1.875rem, 1.62rem + 1.25vw, 2.5625rem); /* 30 → 41 px */
 
   /* — Interlettrage — */
   /* Une fonte de titre gagne en tenue quand elle se resserre à mesure qu'elle grandit :
      à 68 px, l'approche dessinée pour du labeur laissait des trous entre les lettres. Les
      étiquettes font l'inverse — capitales de 13 px, elles ont besoin d'air pour rester
      lisibles. Trois valeurs, jamais réécrites dans un module.
-     `--suivi-display` remonte de -0.028 à -0.02 em avec l'échelle : l'approche négative
-     compense une taille, elle n'est pas un style. À 52 px, -0.028 em recollait les
-     lettres au lieu de refermer un trou. */
-  --suivi-display: -0.02em;
+     `--suivi-display` remonte avec l'échelle — -0.028 em à 68 px, -0.02 em à 52 px,
+     -0.016 em à 43 px : l'approche négative compense une taille, elle n'est pas un
+     style. Laissée à -0.02 em sur un titre redescendu à 43 px, elle recollerait les
+     lettres au lieu de refermer un trou qui n'existe plus. */
+  --suivi-display: -0.016em;
   --suivi-titre: -0.016em;
   --suivi-etiquette: 0.09em;
 
@@ -238,16 +243,24 @@ h1 {
   line-height: 1.08;
   letter-spacing: var(--suivi-display);
   /* La mesure suit l'échelle en sens INVERSE de la taille : c'est le nombre de signes
-     par ligne qui fait la tenue d'un titre. 18ch était le repli d'un titre à 68 px ;
-     à 52 px, la ligne peut reprendre les 21 signes sans se rompre. */
-  max-width: 21ch;
+     par ligne qui fait la tenue d'un titre. 18ch était le repli d'un titre à 68 px, 21ch
+     celui d'un titre à 52 px — mais 21ch appliqués à un `h1` de 78 signes le repliaient
+     sur QUATRE lignes, et un plafond qui casse la phrase plus tôt que la colonne ne
+     l'exige ne protège plus rien : il empile. À 43 px, 32 signes tiennent sans que la
+     ligne se rompe, et le titre reprend la largeur que la colonne lui offrait déjà. */
+  max-width: 32ch;
 }
 
 h2 {
   font-size: var(--t-3);
   line-height: 1.08;
   letter-spacing: var(--suivi-titre);
-  max-width: 30ch;
+  /* 30ch coupait en deux des titres de 40 à 49 signes — « Ce qui est mesuré, pas ce qui
+     est promis », « Ce qui a été évalué par quelqu'un d'autre que moi » — alors que la
+     colonne avait la place de les tenir d'un trait. Une phrase courte cassée en deux
+     lignes se lit comme un titre trop grand, ce qu'elle n'était pas. 46ch les ramène sur
+     une ligne aux largeurs de portable, sans jamais dépasser la mesure de lecture. */
+  max-width: 46ch;
 }
 
 h3 {


### PR DESCRIPTION
Mise en production de `dev`.

## Ce qui part

**PR #89** — trois corrections sur la page d'accueil, toutes issues d'un retour direct :

- **Les titres s'empilaient sur trois ou quatre lignes.** La cause n'etait pas la police mais un **plafond de largeur en `ch`** qui coupait la phrase avant que la colonne ne l'exige : le `h1` du seuil, 78 signes, etait borne a `21ch` et occupait ~225 px de haut sur n'importe quel ecran. Deux leviers : l'echelle redescend au sommet (`h1` 52 → **43 px**) et les plafonds remontent (`h1` 21 → 32ch, `h2` 30 → 46ch). Le rapport entre les crans est conserve — c'est lui qui fait la hierarchie, pas l'amplitude.
- **Les quatre dalles du seuil portent desormais leur marque**, reprise de `PoleGlyph`. `ia` et `sea-ux` gardent une egalite stricte de taille et de position : le `CLAUDE.md` interdit de les presenter comme deux etapes.
- **La scene s'anime reellement.** Elle bougeait deja — 2,5 px sur 19 s, c'est-a-dire **sous le seuil de perception**. Le decor coutait son poids sans rien rendre. Amplitude ×3, durees divisees par deux environ.

**Zero octet de JavaScript ajoute** : les marques sont du SVG rendu au serveur, verifie dans l'export. `prefers-reduced-motion` et le bouton « Figer l'animation » coupent toujours tout, et seuls `transform` et `opacity` sont animes.

Version **0.7.0** — increment mineur : le lot contient une fonctionnalite, pas seulement un correctif.

## Reste ouvert

**#80** — environ 153 Kio de JavaScript inutilise, a ne pas traiter avant l'arbitrage sur les polices.

Deux points signales par l'agent et **non traites**, faute d'arbitrage : le **manque d'images** au sens photographique, et la **direction visuelle IA/DATA** facon getminds.ai. Ce ne sont pas des reglages — `output: 'export'` desactive l'optimisation `next/image`, donc chaque visuel doit etre budgete a la main sous une contrainte Lighthouse qui ne tient qu'a un point.