### PR TITLE
chore: version 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {


### PR DESCRIPTION
Bump SemVer avant mise en production.

Depuis `v0.7.0`, `dev` a recu la PR #92 : retour aux amplitudes d'origine de la scene du seuil. Quatre plaques qui glissent de 7 px ne lisent pas comme du volume mais comme un **defaut d'alignement** — le commentaire d'origine du fichier le disait deja.

Increment **correctif** : le lot annule un reglage, il n'ajoute rien. Les marques de pole sur les dalles sont conservees, elles n'etaient pour rien dans le defaut.