### PR TITLE
feat: titre « Ingenieur-conseil independant » et couronne speculaire sur bande et boutons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jeromemarichez.fr
 
-Site portfolio et vitrine de services de **Jérôme Marichez**, ingénieur logiciel à Lille :
+Site portfolio et vitrine de services de **Jérôme Marichez**, ingénieur-conseil indépendant à Lille :
 ingénierie web, data, IA, SEA & UX.
 
 **Stack** : TypeScript — Next.js (App Router).

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -99,16 +99,16 @@
 /* Deux façons de figer, une seule règle. `paused` et non `none` : la scène garde la
    pose où elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
    quelqu'un qui appuie sur « Figer l'animation » en la regardant. */
-.scene[data-fige="true"] .groupe,
-.scene[data-fige="true"] .groupe > g {
-  animation-play-state: paused;
-}
-
 @media (prefers-reduced-motion: reduce) {
   .groupe,
   .groupe > g {
     animation: none;
   }
+}
+
+.scene[data-fige="true"] .groupe,
+.scene[data-fige="true"] .groupe > g {
+  animation-play-state: paused;
 }
 
 /* La marque du pôle, posée au bord d'attaque de sa dalle. Elle dérive AVEC elle — c'est

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -96,9 +96,18 @@
   }
 }
 
-/* Deux façons de figer, une seule règle. `paused` et non `none` : la scène garde la
-   pose où elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
-   quelqu'un qui appuie sur « Figer l'animation » en la regardant. */
+/* Deux façons de figer, et elles ne figent pas pareil.
+ *
+ * La préférence système d'abord : `animation: none`. Quelqu'un qui demande moins de
+ * mouvement ne demande pas une pause, il demande qu'il n'y en ait pas — la scène doit
+ * donc se poser sur son image de départ et ne plus rien devoir au hasard du moment où
+ * la page s'est chargée.
+ *
+ * L'ORDRE des deux blocs n'est pas indifférent, et il est le seul possible : le
+ * sélecteur `[data-fige]` est plus spécifique (0, 3, 1) que celui de la requête média
+ * (0, 1, 1). Écrit dans l'autre sens, c'était une spécificité descendante — Biome la
+ * relève (`lint/style/noDescendingSpecificity`), et c'est un piège réel dès qu'une
+ * troisième règle s'ajoutera entre les deux. Ne pas les réintervertir. */
 @media (prefers-reduced-motion: reduce) {
   .groupe,
   .groupe > g {
@@ -106,6 +115,11 @@
   }
 }
 
+/* Le contrôle de la page ensuite : `paused` et NON `none`. La scène garde la pose où
+   elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
+   quelqu'un qui appuie sur « Figer l'animation » en la regardant. C'est le mécanisme
+   de mise en pause qu'exige WCAG 2.2.2, que la préférence système ne remplace pas :
+   elle ne se change pas depuis la page. */
 .scene[data-fige="true"] .groupe,
 .scene[data-fige="true"] .groupe > g {
   animation-play-state: paused;

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -30,6 +30,15 @@
          Voir `GlassSurface/glass-surface.module.css`. */
       -webkit-backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation-bande));
       backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation-bande));
+      /* La couronne spéculaire, réduite à ce qu'une BANDE peut en porter : un seul trait
+         de lumière au ras du haut. Le panneau de verre a un anneau complet, masqué et
+         suivant ses angles ; une bande pleine largeur n'a pas d'angle, et ses côtés
+         sortent du champ — un anneau y dessinerait deux traits verticaux qui ne
+         correspondent à aucune tranche. Reste le haut, qui est justement d'où vient la
+         lumière du site, et le bas, déjà tenu par `border-bottom`.
+         C'est ce liseré qui manquait pour que la bande se lise comme du verre et non
+         comme un fond translucide : sans lui, rien ne marque l'épaisseur. */
+      box-shadow: inset 0 var(--verre-epaisseur-lueur) 0 var(--verre-lueur);
     }
   }
 }

--- a/src/@shared/seo/site.ts
+++ b/src/@shared/seo/site.ts
@@ -7,7 +7,7 @@ export const SITE_URL = 'https://jeromemarichez.fr'
 /** Identité publiée. Reprise à l'identique des CV de référence. */
 export const SITE_IDENTITY = {
   nom: 'Jérôme Marichez',
-  titre: 'Ingénieur logiciel',
+  titre: 'Ingénieur-conseil indépendant',
   ville: 'Lille',
   region: 'Hauts-de-France',
   pays: 'FR',

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -72,16 +72,62 @@
   color: var(--fond);
   text-decoration: none;
   font-weight: 500;
+  /* La couronne, sur un fond PLEIN. L'action principale garde son aplat d'accent : c'est
+     le seul élément du seuil dont le contraste texte/fond est critique, et un fond
+     translucide le rendrait dépendant de ce qui passe derrière. Ce qu'elle prend du
+     verre, c'est sa lumière — un trait vif au ras du haut, un rebond plus faible au ras
+     du bas. Deux traits d'un pixel suffisent à faire lire une épaisseur ; c'est ce que
+     fait Apple sur ses boutons pleins, et ça ne coûte pas un point de contraste. */
+  box-shadow:
+    var(--elevation-posee),
+    inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond);
   transition: box-shadow var(--duree-micro) ease-out;
 }
 
+/* Au survol, l'ombre portée s'ajoute — la couronne ne disparaît pas. Réécrire
+   `box-shadow` sans la reprendre éteindrait la lumière au moment précis où la main
+   arrive, c'est-à-dire à l'inverse de ce qu'on attend d'une surface éclairée. */
 .actionPrincipale:hover {
-  box-shadow: var(--elevation-levee);
+  box-shadow:
+    var(--elevation-posee),
+    inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond),
+    var(--elevation-levee);
 }
 
+/* L'action secondaire devient une pastille de verre : c'est elle, et non l'action
+   principale, qui peut porter la translucidité — son texte est en `--encre` sur le fond
+   de la page, donc son contraste ne dépend pas du verre.
+   Le flou et la couronne restent derrière `@supports` : là où `backdrop-filter` n'existe
+   pas, la pastille garde un fond opaque et reste parfaitement lisible. */
 .actionSecondaire {
+  display: inline-block;
+  padding: var(--e-2) var(--e-4);
+  border: var(--verre-epaisseur) solid var(--verre-arete);
+  border-radius: var(--rayon-petit);
+  background: color-mix(in srgb, var(--fond) var(--verre-voile-barre), transparent);
   color: var(--encre);
+  text-decoration: none;
   text-underline-offset: 0.24em;
+  transition: box-shadow var(--duree-micro) ease-out;
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .actionSecondaire {
+    /* Préfixe AVANT le standard : le minifieur ne garde que la dernière des deux.
+       Voir `GlassSurface/glass-surface.module.css`. */
+    -webkit-backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation));
+    backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation));
+    box-shadow:
+      var(--elevation-posee),
+      inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond);
+  }
+}
+
+.actionSecondaire:hover {
+  box-shadow:
+    var(--elevation-posee),
+    inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond),
+    var(--elevation-levee);
 }
 
 .jetons {

--- a/src/@vitrine/contenu/accueil.ts
+++ b/src/@vitrine/contenu/accueil.ts
@@ -16,7 +16,7 @@ import { SECTIONS_ACCUEIL } from './accueil-sections'
 export const HERO_ACCUEIL = {
   titre: "Je construis, j'exploite, je mesure. Le même interlocuteur, du cadrage au run.",
   chapo:
-    'Ingénieur logiciel à Lille, 9 ans. Celui qui cadre est celui qui code, qui mesure ' +
+    'Ingénieur-conseil indépendant à Lille, 9 ans. Celui qui cadre est celui qui code, qui mesure ' +
     'et qui exploite — et c’est lui qui répond de tout.',
   // Le fil IA se dit dès le seuil, sinon il se découvre au pôle Data et se lit comme une
   // offre. Formulation tenue par les règles de véracité : l'IA instruit et produit, le
@@ -55,7 +55,7 @@ export const THESE_CHAINE = {
 export const PAGE_ACCUEIL: IEditorialPage = {
   route: '/',
   meta: {
-    title: 'Jérôme Marichez — Ingénieur logiciel à Lille',
+    title: 'Jérôme Marichez — Ingénieur-conseil indépendant à Lille',
     description:
       'Ingénierie web, data, IA, SEA & UX : un seul interlocuteur du cadrage au run, ' +
       'qui répond de tout. Conception, développement et pilotage avec l’IA. Lille et ' +


### PR DESCRIPTION
Deux changements approuvés par Jérôme MARICHEZ.

## 1. « Ingénieur-conseil indépendant »

Le libellé vit à un seul endroit (`SITE_IDENTITY.titre`) mais irrigue **huit points** : le `<title>` de chaque page, l'en-tête, le pied de page, l'image Open Graph, le manifeste, l'alternative textuelle OG et le `jobTitle` du JSON-LD. Deux endroits le répétaient en prose — le chapô du seuil et le titre SEO de l'accueil —, ils sont alignés. Le `README.md` suit.

« Ingénieur logiciel » ne disait qu'une moitié du travail : il nommait le code, pas le cadrage, et ne couvrait ni la donnée, ni l'IA, ni le SEA. « Consultant » seul aurait dit l'inverse — le conseil sans la main —, c'est-à-dire exactement la couche commerciale que ce site refuse d'être. « Ingénieur-conseil indépendant » porte les deux moitiés de la thèse en deux mots.

## 2. Le verre — après lecture de l'article de kube.io, confronté au code

**Ce que l'article fait et que le dépôt ne fait pas.** Il construit sa carte de déplacement à partir d'un profil **squircle convexe** (`y = ⁴√(1-(1-x)⁴)`, le profil d'Apple), de ses normales par dérivée, puis de la **loi de Snell** à n = 1,5, avec 127 simulations de rayons par rayon exploitant la symétrie. `GlassRefraction` utilise à la place **deux dégradés linéaires par axe**. L'écart est réel, et il est exactement celui que l'article décrit comme l'approche naïve.

**Pourquoi je ne l'ai pas corrigé.** Deux mesures du dépôt lui-même disent que ça ne se verrait pas :

- `backdrop-filter: url()` **n'est rendu que par Blink**, et `glass-surface.module.css` écarte explicitement WebKit et Gecko par un test de moteur. **En Safari, la réfraction n'existe pas** — donc sur un MacBook, elle n'a jamais été visible.
- Sur ce fond quasi uniforme, l'écart mesuré entre panneau flouté et panneau réfractant plafonne à **2 niveaux sur 255**. Sous le seuil de perception, même dans Chrome.

Raffiner Snell reviendrait à rendre invisible quelque chose de déjà invisible — la même erreur que l'amplitude de la scène, corrigée en #92.

**Ce qui manquait vraiment**, c'est l'autre moitié de l'effet, celle que l'article composite en `feBlend` : le **reflet spéculaire**. `GlassSurface` l'a déjà, et bien — un anneau masqué qui suit les angles, vif en haut, rebond en bas, **en CSS pur donc dans tous les navigateurs**. Deux surfaces ne l'avaient pas :

| Surface | Avant | Après |
|---|---|---|
| Bande de navigation | aucune couronne — ni `box-shadow` ni pseudo-élément | trait de lumière au ras du haut |
| Action principale | aplat d'accent nu | aplat **conservé** + trait vif en haut, rebond en bas |
| Action secondaire | lien texte | pastille de verre : flou, saturation, couronne |

La bande ne reçoit **pas** d'anneau complet : pleine largeur, elle n'a pas d'angle, ses côtés sortent du champ — un anneau y dessinerait deux traits verticaux ne correspondant à aucune tranche. Son bas est déjà tenu par `border-bottom`.

L'action principale **garde son aplat** : c'est le seul élément du seuil dont le contraste texte/fond est critique, et un fond translucide le rendrait dépendant de ce qui passe derrière. Elle ne prend du verre que sa lumière — deux traits d'un pixel, zéro point de contraste perdu. L'action secondaire, dont le texte est en `--encre` sur le fond de page, peut porter la translucidité sans risque ; son flou reste derrière `@supports`.

Le survol **reprend** la couronne au lieu de la remplacer : réécrire `box-shadow` sans elle éteignait la lumière au moment précis où la main arrive.

## Au passage

Corrige un avertissement de **spécificité descendante** que ma PR #89 avait introduit dans `slab-scene.module.css` : l'ordre des deux règles n'avait aucune raison d'être inversé.

## Vérifications

`make lint` (zéro avertissement nouveau — celui de #89 est éliminé), `make type-check`, `make build` verts. Le contrôle `ci-dev-a11y` vérifiera le contraste de la pastille secondaire.

## Tests

Aucun fichier de test écrit par l'assistant. Changement de contenu et de CSS.

**Intention proposée** — *test unitaire* : vérifier que `SITE_IDENTITY.titre` est bien la **source unique** du libellé, c'est-à-dire qu'aucun composant ni contenu ne réécrit un intitulé de poste en dur. C'est la seule régression plausible ici : le libellé vient de changer à huit endroits d'un coup, et un neuvième écrit en dur ne se verrait qu'en production.

https://claude.ai/code/session_01Vz8szo5e81R85kUGnwNftH