### PR TITLE
chore: version 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {


### PR DESCRIPTION
Bump SemVer avant mise en production.

Depuis `v0.7.1`, `dev` a recu la PR #95 : le titre « Ingenieur-conseil independant » remplace « Ingenieur logiciel » partout, et la couronne speculaire du verre arrive sur la bande d'en-tete et sur les boutons d'action.

Increment **mineur** : deux ajouts, aucune rupture.