### PR TITLE
release: v0.8.0 — ingenieur-conseil independant, couronne speculaire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jeromemarichez.fr
 
-Site portfolio et vitrine de services de **Jérôme Marichez**, ingénieur logiciel à Lille :
+Site portfolio et vitrine de services de **Jérôme Marichez**, ingénieur-conseil indépendant à Lille :
 ingénierie web, data, IA, SEA & UX.
 
 **Stack** : TypeScript — Next.js (App Router).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -99,16 +99,16 @@
 /* Deux façons de figer, une seule règle. `paused` et non `none` : la scène garde la
    pose où elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
    quelqu'un qui appuie sur « Figer l'animation » en la regardant. */
-.scene[data-fige="true"] .groupe,
-.scene[data-fige="true"] .groupe > g {
-  animation-play-state: paused;
-}
-
 @media (prefers-reduced-motion: reduce) {
   .groupe,
   .groupe > g {
     animation: none;
   }
+}
+
+.scene[data-fige="true"] .groupe,
+.scene[data-fige="true"] .groupe > g {
+  animation-play-state: paused;
 }
 
 /* La marque du pôle, posée au bord d'attaque de sa dalle. Elle dérive AVEC elle — c'est

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -96,9 +96,18 @@
   }
 }
 
-/* Deux façons de figer, une seule règle. `paused` et non `none` : la scène garde la
-   pose où elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
-   quelqu'un qui appuie sur « Figer l'animation » en la regardant. */
+/* Deux façons de figer, et elles ne figent pas pareil.
+ *
+ * La préférence système d'abord : `animation: none`. Quelqu'un qui demande moins de
+ * mouvement ne demande pas une pause, il demande qu'il n'y en ait pas — la scène doit
+ * donc se poser sur son image de départ et ne plus rien devoir au hasard du moment où
+ * la page s'est chargée.
+ *
+ * L'ORDRE des deux blocs n'est pas indifférent, et il est le seul possible : le
+ * sélecteur `[data-fige]` est plus spécifique (0, 3, 1) que celui de la requête média
+ * (0, 1, 1). Écrit dans l'autre sens, c'était une spécificité descendante — Biome la
+ * relève (`lint/style/noDescendingSpecificity`), et c'est un piège réel dès qu'une
+ * troisième règle s'ajoutera entre les deux. Ne pas les réintervertir. */
 @media (prefers-reduced-motion: reduce) {
   .groupe,
   .groupe > g {
@@ -106,6 +115,11 @@
   }
 }
 
+/* Le contrôle de la page ensuite : `paused` et NON `none`. La scène garde la pose où
+   elle en était plutôt que de sauter à son image de départ — c'est ce qu'attend
+   quelqu'un qui appuie sur « Figer l'animation » en la regardant. C'est le mécanisme
+   de mise en pause qu'exige WCAG 2.2.2, que la préférence système ne remplace pas :
+   elle ne se change pas depuis la page. */
 .scene[data-fige="true"] .groupe,
 .scene[data-fige="true"] .groupe > g {
   animation-play-state: paused;

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -30,6 +30,15 @@
          Voir `GlassSurface/glass-surface.module.css`. */
       -webkit-backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation-bande));
       backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation-bande));
+      /* La couronne spéculaire, réduite à ce qu'une BANDE peut en porter : un seul trait
+         de lumière au ras du haut. Le panneau de verre a un anneau complet, masqué et
+         suivant ses angles ; une bande pleine largeur n'a pas d'angle, et ses côtés
+         sortent du champ — un anneau y dessinerait deux traits verticaux qui ne
+         correspondent à aucune tranche. Reste le haut, qui est justement d'où vient la
+         lumière du site, et le bas, déjà tenu par `border-bottom`.
+         C'est ce liseré qui manquait pour que la bande se lise comme du verre et non
+         comme un fond translucide : sans lui, rien ne marque l'épaisseur. */
+      box-shadow: inset 0 var(--verre-epaisseur-lueur) 0 var(--verre-lueur);
     }
   }
 }

--- a/src/@shared/seo/site.ts
+++ b/src/@shared/seo/site.ts
@@ -7,7 +7,7 @@ export const SITE_URL = 'https://jeromemarichez.fr'
 /** Identité publiée. Reprise à l'identique des CV de référence. */
 export const SITE_IDENTITY = {
   nom: 'Jérôme Marichez',
-  titre: 'Ingénieur logiciel',
+  titre: 'Ingénieur-conseil indépendant',
   ville: 'Lille',
   region: 'Hauts-de-France',
   pays: 'FR',

--- a/src/@vitrine/components/HomeHero/home-hero.module.css
+++ b/src/@vitrine/components/HomeHero/home-hero.module.css
@@ -72,16 +72,62 @@
   color: var(--fond);
   text-decoration: none;
   font-weight: 500;
+  /* La couronne, sur un fond PLEIN. L'action principale garde son aplat d'accent : c'est
+     le seul élément du seuil dont le contraste texte/fond est critique, et un fond
+     translucide le rendrait dépendant de ce qui passe derrière. Ce qu'elle prend du
+     verre, c'est sa lumière — un trait vif au ras du haut, un rebond plus faible au ras
+     du bas. Deux traits d'un pixel suffisent à faire lire une épaisseur ; c'est ce que
+     fait Apple sur ses boutons pleins, et ça ne coûte pas un point de contraste. */
+  box-shadow:
+    var(--elevation-posee),
+    inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond);
   transition: box-shadow var(--duree-micro) ease-out;
 }
 
+/* Au survol, l'ombre portée s'ajoute — la couronne ne disparaît pas. Réécrire
+   `box-shadow` sans la reprendre éteindrait la lumière au moment précis où la main
+   arrive, c'est-à-dire à l'inverse de ce qu'on attend d'une surface éclairée. */
 .actionPrincipale:hover {
-  box-shadow: var(--elevation-levee);
+  box-shadow:
+    var(--elevation-posee),
+    inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond),
+    var(--elevation-levee);
 }
 
+/* L'action secondaire devient une pastille de verre : c'est elle, et non l'action
+   principale, qui peut porter la translucidité — son texte est en `--encre` sur le fond
+   de la page, donc son contraste ne dépend pas du verre.
+   Le flou et la couronne restent derrière `@supports` : là où `backdrop-filter` n'existe
+   pas, la pastille garde un fond opaque et reste parfaitement lisible. */
 .actionSecondaire {
+  display: inline-block;
+  padding: var(--e-2) var(--e-4);
+  border: var(--verre-epaisseur) solid var(--verre-arete);
+  border-radius: var(--rayon-petit);
+  background: color-mix(in srgb, var(--fond) var(--verre-voile-barre), transparent);
   color: var(--encre);
+  text-decoration: none;
   text-underline-offset: 0.24em;
+  transition: box-shadow var(--duree-micro) ease-out;
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .actionSecondaire {
+    /* Préfixe AVANT le standard : le minifieur ne garde que la dernière des deux.
+       Voir `GlassSurface/glass-surface.module.css`. */
+    -webkit-backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation));
+    backdrop-filter: blur(var(--verre-flou-bande)) saturate(var(--verre-saturation));
+    box-shadow:
+      var(--elevation-posee),
+      inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond);
+  }
+}
+
+.actionSecondaire:hover {
+  box-shadow:
+    var(--elevation-posee),
+    inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond),
+    var(--elevation-levee);
 }
 
 .jetons {

--- a/src/@vitrine/contenu/accueil.ts
+++ b/src/@vitrine/contenu/accueil.ts
@@ -16,7 +16,7 @@ import { SECTIONS_ACCUEIL } from './accueil-sections'
 export const HERO_ACCUEIL = {
   titre: "Je construis, j'exploite, je mesure. Le même interlocuteur, du cadrage au run.",
   chapo:
-    'Ingénieur logiciel à Lille, 9 ans. Celui qui cadre est celui qui code, qui mesure ' +
+    'Ingénieur-conseil indépendant à Lille, 9 ans. Celui qui cadre est celui qui code, qui mesure ' +
     'et qui exploite — et c’est lui qui répond de tout.',
   // Le fil IA se dit dès le seuil, sinon il se découvre au pôle Data et se lit comme une
   // offre. Formulation tenue par les règles de véracité : l'IA instruit et produit, le
@@ -55,7 +55,7 @@ export const THESE_CHAINE = {
 export const PAGE_ACCUEIL: IEditorialPage = {
   route: '/',
   meta: {
-    title: 'Jérôme Marichez — Ingénieur logiciel à Lille',
+    title: 'Jérôme Marichez — Ingénieur-conseil indépendant à Lille',
     description:
       'Ingénierie web, data, IA, SEA & UX : un seul interlocuteur du cadrage au run, ' +
       'qui répond de tout. Conception, développement et pilotage avec l’IA. Lille et ' +


### PR DESCRIPTION
Mise en production de `dev`.

## Ce qui part — PR #95

**Le titre.** « Ingenieur-conseil independant » remplace « Ingenieur logiciel ». Le libelle vit a un seul endroit, `SITE_IDENTITY.titre`, mais irrigue huit points d'affichage publics plus le `jobTitle` du JSON-LD. Verifie : plus aucune occurrence de l'ancien libelle dans `src/` ni dans le `README`, et le `&lt;title&gt;` fait 54 signes, sous la limite de 60.

Le choix porte les deux moities de la these en deux mots — *conseil* pour le cadrage et l'AMOA, *ingenieur* pour celui qui code, mesure et exploite — sans virer au « je fais tout » que la section « Ce que je ne fais pas » existe pour dementir.

**La couronne speculaire** arrive sur la bande d'en-tete et sur les boutons d'action. C'etait le vrai manque : `GlassSurface` l'avait deja, la bande n'avait aucune couronne et les boutons aucun verre. L'action principale garde son aplat d'accent — seul element du seuil dont le contraste est critique — et ne prend que la lumiere.

**Un commentaire remis d'aplomb** dans `slab-scene.module.css` : un reordonnancement de regles avait laisse un paragraphe expliquant `paused` en tete d'un bloc qui pose `none`. Il porte desormais la raison de l'ordre — specificite descendante relevee par Biome, (0,3,1) contre (0,1,1) — et un « ne pas les reintervertir ».

Version **0.8.0** — increment mineur : deux ajouts, aucune rupture.

## Un constat qui merite d'etre consigne

La refraction SVG n'est rendue **que par Blink**. Sur Safari — donc sur le MacBook de Jerome — elle n'a jamais existe. Et l'ecart mesure entre panneau floute et panneau refractant plafonne a **2 niveaux sur 255** sur ce fond quasi uniforme.

L'agent a donc ecarte de raffiner l'implementation vers le modele de l'article de reference (profil squircle, normales par derivee, loi de Snell a n = 1,5) : cela aurait rendu invisible quelque chose de deja invisible. Ce qui manquait etait le **reflet speculaire**, l'autre moitie de l'effet — en CSS pur, donc dans tous les navigateurs. C'est ce qui est livre.

## Reste ouvert

**#80** — 153 Kio de JavaScript inutilise, a ne pas traiter avant l'arbitrage sur les polices.

Non livrables en l'etat : les **formulaires** n'existent pas (zero `&lt;form&gt;`, le contact est un `mailto:`), et le **manque d'images** demande un arbitrage perf sous `output: 'export'`.