### PR TITLE
chore: version 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {


### PR DESCRIPTION
Bump SemVer avant mise en production.

Depuis `v0.8.0`, `dev` a recu la PR #99 : un fond en degrade maille dans les quatre teintes de pole, et la pile d'ombres multi-couches qui manquait au verre de la bande.

Increment **mineur** : deux ajouts, aucune rupture.