### PR TITLE
release: v0.9.0 — un fond maille, et le verre a enfin de la matiere

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -690,3 +690,75 @@ doit le dire sans qu'un mot ait à l'expliquer.
 Le volume annoncé est **dérivé des listes sources**, jamais écrit à la main : l'accueil ne
 peut donc pas annoncer un nombre de fiches que l'espace ne tient pas. C'est la même règle
 que pour les chiffres de `preuves.ts`.
+
+## La maille de fond
+
+Le fond était un lavis radial unique, une trame de 32 px et un grain. Correct, sobre —
+et **sans matière**. C'est ce qui explique l'échec des trois tentatives de verre
+réfractant : un verre ne montre rien par lui-même, il montre **ce qu'il déforme**. Sur un
+lavis uniforme, la réfraction a été mesurée à **2 niveaux sur 255**, c'est-à-dire rien.
+
+La maille ajoute quatre lavis larges, **un par pôle**, posés en descendant : ingénierie en
+haut à gauche, donnée à droite, puis les deux suites plus bas. Le fond raconte la même
+chaîne que la page, sans qu'aucun mot ne le dise — et il donne au verre de quoi travailler.
+
+### Ce qui est repris d'ailleurs, et ce qui ne l'est pas
+
+Le **procédé** vient d'une référence dont la signature visuelle est un fond maillé pastel.
+Ses **couleurs**, non : la direction du site est « L'Établi » — papier chaud, cuivre, trame
+technique — et copier un pastel vert-jaune aurait fait perdre l'identité que tout le reste
+défend. La maille se construit donc dans les quatre teintes de pôle, déjà mesurées.
+
+### Contraintes tenues
+
+| Contrainte | Comment |
+|---|---|
+| Zéro octet téléchargé | Uniquement des `radial-gradient`. Aucune image. |
+| Aucune couche de compositing plein document | Ni `filter` ni `will-change` sur `.fond-atelier`, qui dépasse 9 000 px de haut sur l'accueil |
+| Pas de rasterisation géante | Les quatre lavis sont dimensionnés en **pixels**, jamais en pourcentage — chacun reste un disque de la taille d'un écran |
+
+### Contraste — mesuré, pas supposé
+
+L'alpha est de **5,5 %** par lavis en thème clair, **3,5 %** en sombre. La part descend en
+sombre parce que les teintes de pôle y sont choisies claires pour porter du texte : à part
+égale, la même maille y serait deux fois plus présente.
+
+Pire cas, deux lavis superposés à pleine intensité, contre le fond le plus sombre du
+dégradé :
+
+| Thème | Paire la plus défavorable | `--encre-douce` | `--encre` |
+|---|---|---|---|
+| clair | ingénierie + data | **5.70:1** (nu : 6.65) | 12.72:1 |
+| sombre | IA + SEA & UX | **6.92:1** (nu : 7.57) | 14.37:1 |
+
+Le seuil AA du texte est à 4.5:1 : les deux tiennent avec de la marge.
+
+> **Un écart relevé au passage.** Les ratios des tableaux de jetons plus haut sont mesurés
+> sur `--fond` (`#F2EFE8`), alors que le fond réellement peint est le dégradé de
+> `.fond-atelier`, qui descend à `#EDE9E0`. Les vrais ratios sont donc légèrement plus bas
+> que ceux affichés — `--encre-douce` est à 6.65:1 et non 7.02:1. Tous restent au-dessus du
+> seuil, mais la documentation est optimiste d'environ un tiers de point.
+
+## Le verre de la bande
+
+La bande avait déjà flou, saturation et un trait de lumière au ras du haut. Il lui
+manquait ce qui fait lire du **verre** plutôt qu'un fond translucide : la **pile
+d'ombres**.
+
+Trois couches, et chacune dit une chose :
+
+1. la **lumière** au ras du haut — la tranche qui prend le jour ;
+2. le **rebond** au ras du bas — la face inférieure, qui ne reçoit que ce que le papier lui
+   renvoie : plus faible, et jamais blanche ;
+3. l'**ombre portée** sous la bande — sans elle, le verre est dans le plan de la page au
+   lieu de flotter au-dessus. C'est ce décollement qui manquait.
+
+L'ombre portée est large et très diluée : une ombre courte et dense se lirait comme une
+bordure, pas comme de la distance.
+
+La **réfraction** arrive aussi sur la bande, sous le même verrou que les panneaux — Blink
+seul, Safari et Firefox exclus par une clause `not (…)` qui survit à la minification. Le
+gate est recopié plutôt que factorisé : une classe partagée entre un panneau et une bande
+obligerait l'une à porter les réglages de l'autre, et c'est exactement ce qui produit les
+traînées colorées. Elle n'a de sens que depuis que le fond porte une maille.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.5.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeromemarichez-fr",
-      "version": "0.5.0",
+      "version": "0.8.0",
       "dependencies": {
         "next": "^16.0.0",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -38,7 +38,37 @@
          lumière du site, et le bas, déjà tenu par `border-bottom`.
          C'est ce liseré qui manquait pour que la bande se lise comme du verre et non
          comme un fond translucide : sans lui, rien ne marque l'épaisseur. */
-      box-shadow: inset 0 var(--verre-epaisseur-lueur) 0 var(--verre-lueur);
+      /* La PILE d'ombres, et c'est elle qui fait lire du verre plutôt qu'un fond
+         translucide. Un seul trait de lumière marquait l'épaisseur ; trois couches
+         disent la matière :
+           1. la lumière au ras du haut — la tranche qui prend le jour ;
+           2. le rebond au ras du bas — la face inférieure, qui ne reçoit que ce que le
+              papier lui renvoie, donc plus faible et jamais blanche ;
+           3. l'ombre portée SOUS la bande — sans elle, le verre est dans le plan de la
+              page au lieu de flotter au-dessus, et c'est ce décollement qui manquait.
+         L'ombre portée est large et très diluée : une ombre courte et dense lirait
+         comme une bordure, pas comme de la distance. */
+      box-shadow:
+        inset 0 var(--verre-epaisseur-lueur) 0 var(--verre-lueur),
+        inset 0 calc(-1 * var(--verre-epaisseur-lueur)) 0 var(--verre-rebond),
+        0 10px 30px -22px color-mix(in srgb, var(--encre) 60%, transparent);
+    }
+  }
+
+  /* La réfraction sur la bande, sous le MÊME verrou que les panneaux — Blink seul.
+     Le gate est recopié plutôt que factorisé : une classe partagée entre un panneau et
+     une bande obligerait l'une des deux à porter les réglages de l'autre, et c'est
+     exactement ce qui produit les traînées colorées quand les valeurs d'un panneau
+     tombent sur une bande.
+     Elle n'a de sens que depuis que le fond porte une maille : sur le lavis uniforme
+     d'avant, la réfraction a été mesurée à 2 niveaux sur 255 — invisible. Ce qu'elle
+     courbe désormais, ce sont les lavis de pôle qui passent dessous au défilement. */
+  @supports (backdrop-filter: url("#verre-refraction")) and
+    (not (-webkit-backdrop-filter: blur(1px))) and
+    (not (-moz-appearance: none)) {
+    .entete {
+      backdrop-filter: var(--verre-refraction) blur(var(--verre-flou-bande))
+        saturate(var(--verre-saturation-bande));
     }
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,26 @@
      document. Ici, rien n'est promis au compositeur.
      L'alpha moyen est volontairement sous 4 % : au-delà, le grain cesse d'être une
      texture et devient un voile qui déplace les contrastes documentés. */
+  /* — La maille de fond — */
+  /* Quatre lavis larges, un par pôle, posés en descendant : ingénierie en haut à gauche,
+     donnée à droite, puis les deux suites plus bas. Le fond raconte donc la même chaîne
+     que la page, sans qu'aucun mot ne le dise.
+
+     Ce n'est PAS de la décoration. Un verre ne montre rien par lui-même — il montre ce
+     qu'il déforme. Sur un lavis uniforme, la réfraction du verre a été mesurée à 2
+     niveaux sur 255, c'est-à-dire rien. La maille est ce qui lui donne enfin de la
+     matière à courber, et c'est pour ça qu'elle arrive avec le verre de la bande.
+
+     L'alpha est délibérément TRÈS bas — de l'ordre du grain, sous 6 %. Au-delà, la
+     maille cesse d'être une lumière et devient un fond coloré : elle déplacerait les
+     ratios de contraste documentés, et le texte du site est posé dessus. La vérification
+     est mesurée, pas supposée : voir `docs/design.md`. */
+  --maille-part: 5.5%;
+  --maille-a: color-mix(in srgb, var(--pole-ingenierie-web) var(--maille-part), transparent);
+  --maille-b: color-mix(in srgb, var(--pole-data) var(--maille-part), transparent);
+  --maille-c: color-mix(in srgb, var(--pole-ia) var(--maille-part), transparent);
+  --maille-d: color-mix(in srgb, var(--pole-sea-ux) var(--maille-part), transparent);
+
   --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.07 0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23g)'/%3E%3C/svg%3E");
   --grain-tuile: 128px;
 
@@ -148,6 +168,11 @@
     --verre-lueur: rgba(255, 255, 255, 0.14);
     --fond-degrade-haut: #14181d;
     --fond-degrade-bas: #0b0e11;
+    /* La maille descend en thème sombre, et ce n'est pas une préférence : les teintes de
+       pôle y sont choisies claires pour porter du texte sur un fond à 6 % de luminance —
+       `--pole-data` passe de #00697b à #01b6d4. À part égale, la même maille y serait
+       deux fois plus présente et virerait au fond coloré. */
+    --maille-part: 3.5%;
     /* Même tuile, speckles clairs : du grain noir sur un fond à 6 % de luminance ne
        se voit pas, il ne fait qu'assombrir encore. */
     --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23g)'/%3E%3C/svg%3E");
@@ -217,12 +242,24 @@ body {
   background-image:
     var(--grain), linear-gradient(to right, var(--trame) 0 1px, transparent 1px),
     linear-gradient(to bottom, var(--trame) 0 1px, transparent 1px),
+    /* La maille : quatre lavis en TAILLE FIXE, jamais en pourcentage. `.fond-atelier`
+       fait plus de 9 000 px de haut sur l'accueil — un `radial-gradient` dimensionné en
+       pourcentage y serait rasterisé à cette hauteur. En pixels, chacun reste un disque
+       de la taille d'un écran, et leur position en pourcentage suffit à les répartir. */
+    radial-gradient(1100px 800px at 12% 4%, var(--maille-a), transparent),
+    radial-gradient(1000px 750px at 88% 14%, var(--maille-b), transparent),
+    radial-gradient(900px 700px at 8% 34%, var(--maille-c), transparent),
+    radial-gradient(950px 700px at 92% 46%, var(--maille-d), transparent),
     radial-gradient(1200px 900px at 22% 8%, var(--fond-degrade-haut), var(--fond-degrade-bas));
-  background-repeat: repeat, repeat, repeat, no-repeat;
+  background-repeat: repeat, repeat, repeat, no-repeat, no-repeat, no-repeat, no-repeat, no-repeat;
   background-size:
     var(--grain-tuile) var(--grain-tuile),
     32px 32px,
     32px 32px,
+    1100px 800px,
+    1000px 750px,
+    900px 700px,
+    950px 700px,
     100% 100%;
 }
 


### PR DESCRIPTION
Mise en production de `dev`.

## PR #99 — la maille, et pourquoi elle arrive avec le verre

Trois tentatives de verre refractant ont echoue sur ce site. La cause n'etait ni la technique ni les reglages : **il n'y avait rien a courber**. Les references citees posent toutes leur verre au-dessus d'une photographie a fort contraste — c'est de la que vient l'effet. Le fond d'ici etait un lavis quasi uniforme, d'ou les **2 niveaux sur 255** mesures.

Le fond porte desormais **quatre lavis larges, un par pole**, poses en descendant : ingenierie en haut a gauche, donnee a droite, puis les deux suites plus bas. Le fond raconte la meme chaine que la page, sans qu'aucun mot ne le dise.

Le **procede** vient de la reference `getminds.ai`, enfin consultee ; ses **couleurs**, non — la direction du site est « L'Etabli », et copier un pastel vert-jaune aurait fait perdre l'identite que tout le reste defend.

**Zero octet telecharge** : uniquement des `radial-gradient`, dimensionnes en pixels et non en pourcentage — `.fond-atelier` depasse 9 000 px de haut sur l'accueil.

## Le verre de la bande

La pile d'ombres multi-couches qui manquait, et que la reference Tahoe nomme explicitement : lumiere au ras du haut, rebond au ras du bas, et **ombre portee sous la bande** — sans elle, le verre est dans le plan de la page au lieu de flotter au-dessus. La refraction arrive aussi, sous le meme verrou Blink que les panneaux, verifie dans l'artefact minifie.

## Contraste — mesure

Pire cas, deux lavis superposes a pleine intensite : `--encre-douce` a **5.70:1** en clair et **6.92:1** en sombre, pour un seuil AA de 4.5:1.

**Un ecart anterieur releve au passage** : les tableaux de jetons mesuraient leurs ratios sur `--fond` (`#F2EFE8`), alors que le fond peint est le degrade qui descend a `#EDE9E0`. Les vrais ratios sont plus bas d'environ un tiers de point. Tous restent au-dessus du seuil ; c'est desormais ecrit dans `docs/design.md` plutot que tu.

## Mesures

`make budgets` sur une machine a 15,4 de charge : accueil **96**, les quatre autres gabarits **97**, axe **zero violation**. Budget inchange — ajouter un fond entier n'a rien coute.

Version **0.9.0** — increment mineur.

## Reste ouvert

**#80** — 153 Kio de JavaScript inutilise, a ne pas traiter avant l'arbitrage sur les polices.