### PR TITLE
fix: la marque de pole tient enfin dans sa dalle

### DIFF
--- a/docs/frontend-practices.md
+++ b/docs/frontend-practices.md
@@ -56,6 +56,33 @@ Une **seule** stratégie de style par projet, décidée dans [`design.md`](./des
 - Logique métier hors des composants : dans `hooks/` (état/effets réutilisables) ou
   `services/` (appels, transformations pures).
 
+## SVG : une largeur CSS ne dimensionne pas un `<svg>` imbriqué
+
+Piège relevé en conditions réelles sur ce site (issue #102), à connaître avant de
+construire le prochain visuel en SVG.
+
+Un `<svg>` **racine dans du HTML** se dimensionne très bien en CSS : `width` et `height`
+s'appliquent comme sur n'importe quelle boîte, et un jeton (`--taille-glyphe`) suffit à
+tenir toute une série de marques.
+
+Le même composant **imbriqué dans un autre `<svg>`** ignore cette largeur. L'élément
+interne retombe sur sa valeur par défaut `100 %` du viewport parent, et son `viewBox` est
+mis à l'échelle de la scène entière : mesuré ici **271 px de tracé au lieu de 33**, six
+fois trop grand, dans une scène large de 457 px.
+
+Règles :
+
+- Dans un contexte imbriqué, la taille passe par les **attributs** `width` / `height`,
+  seuls fiables — jamais par le CSS.
+- Ne pas poser les deux « pour être sûr » : une règle CSS l'emporte sur un attribut de
+  présentation, donc la taille demandée serait perdue précisément là où elle est la seule
+  à fonctionner. Un composant servant dans les deux contextes expose une prop de taille
+  optionnelle et **n'applique sa classe de dimensionnement CSS que lorsqu'elle est
+  absente** (voir `PoleGlyph` et `SlabScene`).
+- Une règle CSS rendue morte par ce choix (un `--taille-…` posé sur le parent imbriqué)
+  se supprime : laissée en place, elle se lit comme la source de la taille et fera perdre
+  une heure au prochain lecteur.
+
 ## Accessibilité et tests
 
 L'a11y (WCAG 2.1 AA) est traitée dans [`accessibility.md`](./accessibility.md) et

--- a/src/@shared/components/ChainCanvas/SlabScene.tsx
+++ b/src/@shared/components/ChainCanvas/SlabScene.tsx
@@ -31,6 +31,16 @@
 import { PoleGlyph } from '../PoleGlyph'
 import styles from './slab-scene.module.css'
 
+/**
+ * Côté d'une marque de pôle, en unités du `viewBox` de la scène.
+ *
+ * Il est posé en ATTRIBUT sur chaque marque, et non en CSS : un `<svg>` imbriqué dans un
+ * autre `<svg>` n'honore pas une largeur CSS, il retombe sur `100%` du viewport parent
+ * (issue #102). Un seul nombre pour les quatre — ce sont des sœurs, leurs marques ne
+ * divergent pas.
+ */
+const TAILLE_MARQUE = 44
+
 interface SlabSceneProps {
   /** Rend une image fixe : les dalles gardent leur pose, le mouvement s'arrête. */
   fige?: boolean
@@ -80,7 +90,7 @@ export function SlabScene({ fige = false }: SlabSceneProps) {
             y="18"
           />
           <g className={styles.marque} data-pole="ingenierie-web" transform="translate(146 42)">
-            <PoleGlyph pole="ingenierie-web" />
+            <PoleGlyph pole="ingenierie-web" taille={TAILLE_MARQUE} />
           </g>
         </g>
 
@@ -95,7 +105,7 @@ export function SlabScene({ fige = false }: SlabSceneProps) {
             y="130"
           />
           <g className={styles.marque} data-pole="data" transform="translate(126 154)">
-            <PoleGlyph pole="data" />
+            <PoleGlyph pole="data" taille={TAILLE_MARQUE} />
           </g>
         </g>
 
@@ -113,7 +123,7 @@ export function SlabScene({ fige = false }: SlabSceneProps) {
             y="250"
           />
           <g className={styles.marque} data-pole="ia" transform="translate(46 276)">
-            <PoleGlyph pole="ia" />
+            <PoleGlyph pole="ia" taille={TAILLE_MARQUE} />
           </g>
         </g>
 
@@ -128,7 +138,7 @@ export function SlabScene({ fige = false }: SlabSceneProps) {
             y="262"
           />
           <g className={styles.marque} data-pole="sea-ux" transform="translate(264 288)">
-            <PoleGlyph pole="sea-ux" />
+            <PoleGlyph pole="sea-ux" taille={TAILLE_MARQUE} />
           </g>
         </g>
       </g>

--- a/src/@shared/components/ChainCanvas/slab-scene.module.css
+++ b/src/@shared/components/ChainCanvas/slab-scene.module.css
@@ -130,8 +130,11 @@
    décollée de la plaque qu'elle nomme.
    Une dalle teintée ne dit pas quel pôle elle est ; la couleur seule ne peut pas le
    porter (WCAG 1.4.1), et la scène est de toute façon `role="presentation"` — la marque
-   est un repère visuel, et le texte voisin reste le porteur de l'information. */
+   est un repère visuel, et le texte voisin reste le porteur de l'information.
+   Sa TAILLE ne se règle pas ici : la marque est un `<svg>` imbriqué dans celui de la
+   scène, et un `<svg>` interne n'obéit pas à une largeur CSS — il retombe sur `100%` du
+   viewport parent, soit six fois trop grand (issue #102). Le côté passe donc par la prop
+   `taille` de `PoleGlyph`, qui le pose en attribut, dans `SlabScene.tsx`. */
 .marque {
-  --taille-glyphe: 44px;
   opacity: 0.92;
 }

--- a/src/@shared/components/PoleGlyph/index.tsx
+++ b/src/@shared/components/PoleGlyph/index.tsx
@@ -36,6 +36,18 @@ import styles from './pole-glyph.module.css'
 
 interface PoleGlyphProps {
   pole: PoleId
+  /**
+   * Côté de la marque, en unités du viewport qui l'accueille — porté par les ATTRIBUTS
+   * `width` / `height`, jamais par le CSS.
+   *
+   * À renseigner uniquement quand la marque est imbriquée dans un autre `<svg>` : là, une
+   * largeur CSS n'est pas honorée, le `<svg>` interne retombe sur `100%` du viewport
+   * parent et se dessine plusieurs fois trop grand (issue #102).
+   *
+   * Laissée vide — l'usage racine, dans du HTML — la marque garde le dimensionnement CSS
+   * par `--taille-glyphe` : un seul jeton pour toute la série des marques du site.
+   */
+  taille?: number
 }
 
 /** Le socle : trois dalles portées par deux montants, sur une assise plus épaisse. */
@@ -108,19 +120,26 @@ const TRACES: Record<PoleId, () => React.JSX.Element> = {
  * lecteur d'écran ne perd donc rien à ne pas la rencontrer, et la couleur n'est jamais
  * le seul porteur d'information (WCAG 1.4.1).
  */
-export function PoleGlyph({ pole }: PoleGlyphProps) {
+export function PoleGlyph({ pole, taille }: PoleGlyphProps) {
   const Trace = TRACES[pole]
+  // Deux dimensionnements, un seul valable par contexte : par attribut quand la marque est
+  // imbriquée dans un `<svg>`, par CSS quand elle est racine dans du HTML. Poser les deux
+  // ne serait pas « plus sûr » — le CSS l'emporte sur l'attribut, donc la taille demandée
+  // serait perdue là où elle est justement la seule qui fonctionne.
+  const dimensionneeParAttribut = taille !== undefined
 
   return (
     <svg
       aria-hidden="true"
-      className={styles.glyphe}
+      className={dimensionneeParAttribut ? styles.glyphe : `${styles.glyphe} ${styles.autonome}`}
       fill="none"
       focusable="false"
+      height={taille}
       stroke="currentColor"
       strokeLinecap="round"
       strokeWidth="1.6"
       viewBox="0 0 32 32"
+      width={taille}
       xmlns="http://www.w3.org/2000/svg"
     >
       <Trace />

--- a/src/@shared/components/PoleGlyph/pole-glyph.module.css
+++ b/src/@shared/components/PoleGlyph/pole-glyph.module.css
@@ -1,6 +1,6 @@
 /* pole-glyph.module.css — la marque d'un pôle.
  *
- * Trois règles, et rien d'autre. La marque ne connaît pas la couleur de son pôle : elle
+ * Quatre règles, et rien d'autre. La marque ne connaît pas la couleur de son pôle : elle
  * est tracée en `currentColor`, et `color: var(--accent)` laisse `poles.css` décider sous
  * le `data-pole` de la plaque qui l'accueille. C'est la même mécanique que le dégradé de
  * la scène des quatre dalles, pour la même raison — un module qui nommerait une teinte
@@ -8,13 +8,23 @@
 
 .glyphe {
   flex: none;
-  width: var(--taille-glyphe);
-  height: var(--taille-glyphe);
   color: var(--accent);
   /* Le tracé n'est PAS du texte : c'est un décor, et il tombe sous le seuil non-texte de
      3:1 comme les filets et les arêtes du site. `--accent` reste malgré tout au-dessus de
      4.5:1 dans les quatre pôles et les deux thèmes — la marge est prise, pas dépensée. */
   opacity: 0.9;
+}
+
+/* Le dimensionnement de l'usage RACINE, en HTML, et de lui seul.
+ *
+ * Une largeur CSS ne dimensionne pas un `<svg>` imbriqué dans un autre `<svg>` : l'élément
+ * interne ignore la règle, retombe sur `100%` du viewport parent et se dessine à l'échelle
+ * de la scène entière (issue #102). Dans ce contexte-là, la marque reçoit la prop `taille`
+ * et se dimensionne par attribut — cette classe n'est alors pas posée, sans quoi le CSS,
+ * plus fort qu'un attribut de présentation, reprendrait la main sur elle. */
+.autonome {
+  width: var(--taille-glyphe);
+  height: var(--taille-glyphe);
 }
 
 /* L'assise du socle : le seul trait plus épais de la série. Un socle qui aurait la même


### PR DESCRIPTION
Corrige #102.

## La cause

`PoleGlyph` se dimensionnait en CSS (`width: var(--taille-glyphe)`), et cette largeur
n'est **pas honorée sur un `<svg>` imbriqué dans un autre `<svg>`**. Dans `SlabScene`,
chaque marque est un `<svg>` enfant : elle ignorait la règle, retombait sur la valeur par
défaut `100 %` du viewport de la scène (420 x 360) et voyait son `viewBox="0 0 32 32"`
mis à l'échelle 11,25x au lieu de 1,375x — mesuré 271 px de tracé au lieu de 33.

## La correction

- `PoleGlyph` expose une prop optionnelle `taille?: number`, posée en **attributs**
  `width` / `height` — les seuls fiables dans un contexte imbriqué.
- Le dimensionnement CSS sort de `.glyphe` et passe dans une classe `.autonome`,
  appliquée **uniquement quand `taille` est absente**. Poser les deux ne serait pas plus
  sûr : une règle CSS l'emporte sur un attribut de présentation, donc la taille demandée
  serait justement perdue là où elle est la seule à fonctionner.
- `SlabScene` passe `taille={TAILLE_MARQUE}` (44, un seul nombre pour les quatre sœurs) et
  la règle devenue morte `.marque { --taille-glyphe: 44px }` est retirée de
  `slab-scene.module.css`.
- Le piège est écrit dans `docs/frontend-practices.md`, section « SVG : une largeur CSS ne
  dimensionne pas un `<svg>` imbriqué ».

L'usage HTML racine (les plaques de pôle) est inchangé : il garde `--taille-glyphe` et son
jeton unique pour toute la série des marques du site.

## Vérifié

Dans Chrome, sur `http://localhost:3010/`, scène large de **457 px** :

| Contrôle | Résultat |
|---|---|
| `getBoundingClientRect()` des quatre marques de la scène | 33x26, 36x28, 39x30, 33x35 px — l'écart entre les quatre est celui des tracés eux-mêmes, pas de la boîte |
| Tracé sortant du `viewBox 0 0 420 360` | aucun, sur les quatre |
| Plaques de pôle (usage HTML) | `getComputedStyle().width` = 36px (2.25rem) et rect = 36 px — inchangé |
| Markup rendu | scène : `width="44" height="44"`, classe `glyphe` seule ; plaques : aucun attribut de taille, classes `glyphe autonome` |
| `make lint` | vert (Biome + limite 300 lignes) — seul subsiste l'avertissement `noImgElement` préexistant sur `CertificationList` |
| `npx tsc --noEmit` | vert |

Le thème n'est pas en cause et n'a pas bougé : le diff ne touche aucune déclaration de
couleur, seulement `width` / `height`. Le rendu clair a été contrôlé à l'écran.

## Accessibilité

Inchangée : la scène reste `role="presentation"` et chaque marque reste `aria-hidden` —
c'est un décor, jamais une information.
