### PR TITLE
fix: Truffle Capital etait une mission en independant, pas un poste salarie

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,11 @@ Chaque page de service porte ses propres métadonnées SEO, ses données structu
 MailingVox (2023-2026, salarié), Développeur Full Stack chez Verhoeven Joaillier
 (2019-2022, salarié, poste unique), Développeur web & Chef de projet digital chez Truffle
 Capital (2017-2019, **en auto-entrepreneur** : Truffle Capital était donc un client).
-Artedrone est une **participation du fonds** Truffle, pas un client. Nommer l'espace « cas
-clients » ferait passer dix fiches sur treize pour une relation commerciale qui n'a jamais
-existé, et réécrirait des intitulés de poste que le [`CLAUDE.md`](./CLAUDE.md) impose de
-reprendre à l'identique des CV.
+**Truffle Capital est le seul client cité sur le site.** Artedrone n'en est pas un second :
+c'est une **participation du fonds**, au bénéfice de laquelle l'AMOA a été menée dans le
+cadre de la mission Truffle. Nommer l'espace « cas clients » ferait passer dix fiches sur
+treize pour une relation commerciale qui n'a jamais existé, et réécrirait des intitulés de
+poste que le [`CLAUDE.md`](./CLAUDE.md) impose de reprendre à l'identique des CV.
 
 L'espace s'appelle donc **`/realisations/`**, et **chaque fiche porte son cadre** —
 statut, intitulé exact, période, taille d'équipe. Le cadre est **obligatoire dans le

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ ce qu'il faut réunir pour les quatre logos manquants.
 | `/services/data` | Le passage obligé en détail |
 | `/services/ia` | Une des deux suites en détail |
 | `/services/sea-ux` | L'autre suite en détail |
-| `/realisations` | Liste des réalisations, groupées par cadre d'emploi (employeur, intitulé de poste exact, période, équipe) |
+| `/realisations` | Liste des réalisations, groupées par cadre (statut, organisation, intitulé de poste exact, période, équipe) |
 | `/realisations/<slug>` | Une réalisation. Une page statique par fiche, générée au build par `generateStaticParams` |
 | `/blog` | Liste des articles, du plus récent au plus ancien |
 | `/blog/<slug>` | Un article. Une page statique par article, générée au build par `generateStaticParams` |
@@ -334,18 +334,21 @@ Chaque page de service porte ses propres métadonnées SEO, ses données structu
 
 ### L'espace `/realisations/` — le nom est un arbitrage de véracité
 
-**Aucune des entreprises citées sur le site n'est un client** : ce sont trois postes
-salariés — Lead Tech chez Acetelecom / MailingVox (2023-2026), Développeur Full Stack chez
-Verhoeven Joaillier (2019-2022, poste unique), Développeur web & Chef de projet digital
-chez Truffle Capital (2017-2019). Artedrone est une **participation du fonds** Truffle, pas
-un client. Nommer l'espace « cas clients » affirmerait une relation commerciale qui n'a
-jamais existé, et réécrirait des intitulés de poste que le [`CLAUDE.md`](./CLAUDE.md)
-impose de reprendre à l'identique des CV.
+**Deux postes salariés et une mission en indépendant** — Lead Tech chez Acetelecom /
+MailingVox (2023-2026, salarié), Développeur Full Stack chez Verhoeven Joaillier
+(2019-2022, salarié, poste unique), Développeur web & Chef de projet digital chez Truffle
+Capital (2017-2019, **en auto-entrepreneur** : Truffle Capital était donc un client).
+Artedrone est une **participation du fonds** Truffle, pas un client. Nommer l'espace « cas
+clients » ferait passer dix fiches sur treize pour une relation commerciale qui n'a jamais
+existé, et réécrirait des intitulés de poste que le [`CLAUDE.md`](./CLAUDE.md) impose de
+reprendre à l'identique des CV.
 
-L'espace s'appelle donc **`/realisations/`**, et **chaque fiche porte son cadre d'emploi** —
-intitulé exact, période, taille d'équipe. Le cadre est **obligatoire dans le type**
-(`IRealisationCadre`, aucun champ optionnel) : c'est le compilateur, et non la relecture,
-qui interdit qu'une fiche paraisse sans dire d'où elle vient.
+L'espace s'appelle donc **`/realisations/`**, et **chaque fiche porte son cadre** —
+statut, intitulé exact, période, taille d'équipe. Le cadre est **obligatoire dans le
+type** (`IRealisationCadre`, aucun champ optionnel, `statut` compris) : c'est le
+compilateur, et non la relecture, qui interdit qu'une fiche paraisse sans dire d'où elle
+vient ni à quel titre. Le `statut` a été ajouté après coup : sans lui, l'espace a publié
+« trois postes salariés » pendant plusieurs versions (issue #107).
 
 **Deux gabarits, et c'est structurant.** Trois fiches seulement portent un chiffre : ce
 sont les trois du mur de preuves — +50 % de panier moyen, 98/100 Lighthouse, 100 000 € de

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,7 +24,7 @@ TypeScript dans `src/@vitrine/contenu/`, et sa forme est tenue par des interface
 | `IProof` | `src/interfaces/IProof.ts` | Une preuve chiffrée | `fiche` référence une `IRealisationChiffree` |
 | **`IRealisation`** | `src/interfaces/IRealisation.ts` | **Une réalisation** : un travail mené, son cadre, sa décision | contient un `IRealisationCadre` et des `IRealisationEtape` ; `poles` référence des `PoleId` |
 | `IRealisationChiffree` | `src/interfaces/IRealisationChiffree.ts` | Une `IRealisation` dont le `chiffre` est **obligatoire** | étend `IRealisation` |
-| `IRealisationCadre` | `src/interfaces/IRealisationCadre.ts` | Le cadre d'emploi : employeur, poste, période, équipe | — |
+| `IRealisationCadre` | `src/interfaces/IRealisationCadre.ts` | Le cadre : statut, organisation, poste, période, équipe | — |
 | `IRealisationChiffre` | `src/interfaces/IRealisationChiffre.ts` | Un résultat chiffré, et ce qu'il ne dit pas | — |
 | `IRealisationEtape` | `src/interfaces/IRealisationEtape.ts` | Une étape du travail mené | — |
 | `IRealisationGroupe` | `src/interfaces/IRealisationGroupe.ts` | Vue dérivée : un cadre et ses fiches | calculée par `find-realisation`, jamais déclarée |
@@ -135,8 +135,10 @@ un composant :
 ## La réalisation (`IRealisation`)
 
 C'est l'entité la plus exposée du site : le format « portfolio » dérive de lui-même vers
-« mon client X », et les entreprises citées sont des **employeurs**. Le modèle tient cette
-frontière par le **type**, pas par la relecture.
+« mon client X ». Le modèle tient cette frontière par le **type**, pas par la relecture —
+chaque fiche porte le **statut** sous lequel elle a été menée, et ce statut n'est pas
+uniforme : deux postes salariés (Acetelecom / MailingVox, Verhoeven Joaillier) et une
+mission en indépendant (Truffle Capital, 2017-2019).
 
 | Champ | Type | Obligatoire | Rôle |
 |-------|------|-------------|------|
@@ -144,7 +146,7 @@ frontière par le **type**, pas par la relecture.
 | `titre` | `string` | oui | `<h1>`, `name` du JSON-LD, dernier niveau du fil d'Ariane. À l'infinitif : un travail, pas une offre |
 | `chapo` | `string` | oui | Résumé. Teaser sur la liste, `description` du JSON-LD |
 | `meta` | `IPageMeta` | oui | `<title>` (60 car. max) et meta description (155 car. max) |
-| **`cadre`** | `IRealisationCadre` | **oui** | Employeur, intitulé de poste exact, période, équipe |
+| **`cadre`** | `IRealisationCadre` | **oui** | Statut, organisation, intitulé de poste exact, période, équipe |
 | `poles` | `readonly PoleId[]` | oui | Pôles réellement mobilisés. **Non contraint** |
 | `probleme` | `string` | oui | Le problème posé au départ, dans les termes de l'époque |
 | `etapes` | `readonly IRealisationEtape[]` | oui | Ce qui a été fait, étape par étape |
@@ -159,6 +161,11 @@ frontière par le **type**, pas par la relecture.
   compilateur qui ferme cette porte, parce que c'est le seul garde-fou qui ne s'oublie pas
   en relecture. Le champ `equipe` existe pour la même raison : il empêche « j'ai managé N
   développeurs », en obligeant à écrire ce qui a réellement été encadré.
+- **`statut` est obligatoire au même titre, et c'est lui qui manquait.** Tant que le cadre
+  ne portait que l'organisation, le poste, la période et l'équipe, l'espace pouvait
+  annoncer « trois postes salariés » sans que rien ne le contredise — alors que Truffle
+  Capital était une mission menée en auto-entrepreneur (issue #107). Un champ facultatif
+  aurait laissé revenir la même ambiguïté fiche par fiche.
 - **Le chiffre n'a qu'une porte d'entrée.** `IRealisationChiffre` est une entité à part,
   avec une `portee` obligatoire — ce que le chiffre **ne** dit **pas**. Un chiffre publié
   sans sa portée se fait élargir tout seul par celui qui le lit : « +50 % de panier moyen »
@@ -185,8 +192,8 @@ Elles vivent dans `src/@vitrine/services/find-realisation.ts` :
 | Règle | Comportement |
 |-------|--------------|
 | `listRealisations()` | Rend la liste **dans l'ordre déclaré**. Aucun tri : une réalisation n'est pas datée, il n'existe pas de clé de tri qui ne soit pas inventée |
-| `groupRealisationsByCadre()` | Groupe par employeur, dans l'ordre de `CADRES` (du poste le plus récent au plus ancien). Un cadre sans fiche ne produit pas de groupe vide |
-| `findRealisation(slug)` | Rend la fiche et jusqu'à `MAX_REALISATIONS_LIEES` (2) autres, choisies sur les **pôles partagés** — la liste groupe déjà par employeur, proposer trois fois le même employeur en bas de page n'apprendrait rien. **Lève** sur un slug inconnu |
+| `groupRealisationsByCadre()` | Groupe par organisation, dans l'ordre de `CADRES` (du poste le plus récent au plus ancien). Un cadre sans fiche ne produit pas de groupe vide |
+| `findRealisation(slug)` | Rend la fiche et jusqu'à `MAX_REALISATIONS_LIEES` (2) autres, choisies sur les **pôles partagés** — la liste groupe déjà par organisation, proposer trois fois la même organisation en bas de page n'apprendrait rien. **Lève** sur un slug inconnu |
 | `listPoles(ids)` (`find-pole`) | Ordonne les pôles selon `POLES_NAV`, jamais selon l'ordre déclaré par la fiche |
 
 ## Où vivent les données
@@ -202,8 +209,8 @@ src/@vitrine/contenu/blog/
 src/@vitrine/contenu/realisations/
 ├── realisations.ts        ← la liste publiée : SOURCE UNIQUE de l'espace
 ├── realisations-index.ts  ← l'en-tête éditoriale de /realisations
-├── cadres.ts              ← les trois cadres d'emploi, partagés par les fiches
-├── mailingvox-produits.ts ← les fiches, groupées par employeur
+├── cadres.ts              ← les trois cadres, partagés par les fiches
+├── mailingvox-produits.ts ← les fiches, groupées par organisation
 ├── mailingvox-donnee.ts   ←   (MailingVox est scindé en deux : limite de 300 lignes)
 ├── verhoeven.ts
 └── truffle.ts

--- a/src/@vitrine/components/EmploymentFrame/employment-frame.module.css
+++ b/src/@vitrine/components/EmploymentFrame/employment-frame.module.css
@@ -1,4 +1,4 @@
-/* employment-frame.module.css — le cadre d'emploi d'une réalisation.
+/* employment-frame.module.css — le cadre d'une réalisation.
  * Registre documentaire : monospace et capitales pour les termes, comme les étiquettes
  * du reste du site. Ce bloc est un état civil, pas un argument. */
 
@@ -8,7 +8,7 @@
   gap: var(--e-2);
 }
 
-.employeur {
+.organisation {
   margin: 0;
   max-width: var(--mesure-texte);
   font-family: var(--police-titre-pile);

--- a/src/@vitrine/components/EmploymentFrame/index.tsx
+++ b/src/@vitrine/components/EmploymentFrame/index.tsx
@@ -1,5 +1,5 @@
 // EmploymentFrame/index.tsx — jeromemarichez-fr
-// Le cadre d'emploi d'une réalisation : employeur, intitulé de poste, période, équipe.
+// Le cadre d'une réalisation : organisation, statut, intitulé de poste, période, équipe.
 
 import type { IRealisationCadre } from '@/interfaces/IRealisationCadre'
 import styles from './employment-frame.module.css'
@@ -7,8 +7,9 @@ import styles from './employment-frame.module.css'
 interface EmploymentFrameProps {
   cadre: IRealisationCadre
   /**
-   * Balise portant l'employeur. `h2` sur la liste, où chaque cadre ouvre un groupe ;
-   * `p` sur une fiche, où le titre de niveau 2 appartient déjà aux sections du récit.
+   * Balise portant le nom de l'organisation. `h2` sur la liste, où chaque cadre ouvre un
+   * groupe ; `p` sur une fiche, où le titre de niveau 2 appartient déjà aux sections du
+   * récit.
    */
   niveau?: 'h2' | 'p'
   /** Identifiant du titre, pour le `aria-labelledby` de la section qui l'englobe. */
@@ -18,25 +19,34 @@ interface EmploymentFrameProps {
 /**
  * Rendu en liste de définitions, et pas en suite de phrases.
  *
- * Trois informations de nature différente — un poste, une période, une équipe — dont
- * chacune répond à une question précise. Une liste de définitions dit laquelle répond à
- * quoi, pour un lecteur d'écran comme à l'œil, là où « Développeur Full Stack, 2019-2022,
- * poste unique » demande de deviner.
+ * Quatre informations de nature différente — un statut, un poste, une période, une équipe
+ * — dont chacune répond à une question précise. Une liste de définitions dit laquelle
+ * répond à quoi, pour un lecteur d'écran comme à l'œil, là où « Développeur Full Stack,
+ * 2019-2022, poste unique » demande de deviner.
  *
- * Ce bloc est le garde-fou éditorial de tout l'espace : c'est lui qui empêche une fiche de
- * se lire comme une prestation vendue à un client. Il apparaît donc au-dessus du titre sur
- * une fiche, pas en bas de page.
+ * **Le statut est un terme à part entière, en tête de la liste**, jamais une mention
+ * glissée dans une autre valeur : c'est lui qui distingue les deux postes salariés de la
+ * mission menée en indépendant chez Truffle Capital, et une information de ce rang doit
+ * être atteignable comme les autres à la navigation par définitions (issue #107).
+ *
+ * Ce bloc est le garde-fou éditorial de tout l'espace : c'est lui qui dit à quel titre
+ * chaque travail a été mené. Il apparaît donc au-dessus du titre sur une fiche, pas en bas
+ * de page.
  */
 export function EmploymentFrame({ cadre, niveau = 'p', titreId }: EmploymentFrameProps) {
-  const Employeur = niveau
+  const Organisation = niveau
 
   return (
     <div className={styles.cadre}>
-      <Employeur className={styles.employeur} id={titreId}>
-        {cadre.employeur}
-      </Employeur>
+      <Organisation className={styles.organisation} id={titreId}>
+        {cadre.organisation}
+      </Organisation>
 
       <dl className={styles.details}>
+        <div className={styles.ligne}>
+          <dt className={styles.terme}>Statut</dt>
+          <dd className={styles.valeur}>{cadre.statut}</dd>
+        </div>
         <div className={styles.ligne}>
           <dt className={styles.terme}>Poste</dt>
           <dd className={styles.valeur}>{cadre.poste}</dd>

--- a/src/@vitrine/contenu/espaces.ts
+++ b/src/@vitrine/contenu/espaces.ts
@@ -11,9 +11,10 @@
 // devant treize est un défaut de véracité, pas une coquille.
 //
 // Ce que ces accroches n'ont PAS le droit de faire : élargir. Elles reprennent ce que
-// chaque espace dit déjà de lui-même dans son propre chapô — les réalisations ne sont pas
-// des cas clients, et trois fiches seulement portent un chiffre. Une accroche d'accueil
-// qui laisserait croire à treize références chiffrées vendrait ce qui n'existe pas.
+// chaque espace dit déjà de lui-même dans son propre chapô — les réalisations portent
+// chacune leur cadre, deux postes salariés et une mission en indépendant, et trois fiches
+// seulement portent un chiffre. Une accroche d'accueil qui laisserait croire à treize
+// références chiffrées vendrait ce qui n'existe pas.
 
 import { ROUTES } from '@/@shared/routes'
 import type { IEspaceEditorial } from '@/interfaces/IEspaceEditorial'
@@ -28,8 +29,8 @@ export const ESPACES_EDITORIAUX: IEspaceEditorial[] = [
     titre: 'Réalisations',
     route: ROUTES.realisations,
     accroche:
-      'Ce que j’ai construit, et dans quel cadre : intitulé de poste exact, période, équipe. ' +
-      'Pas des cas clients.',
+      'Ce que j’ai construit, et dans quel cadre : statut, intitulé de poste exact, ' +
+      'période, équipe.',
     volume: `${REALISATIONS.length} fiches, dont ${CHIFFREES} portent un chiffre`,
   },
   {

--- a/src/@vitrine/contenu/realisations/cadres.ts
+++ b/src/@vitrine/contenu/realisations/cadres.ts
@@ -2,10 +2,11 @@
 // Les trois cadres sous lesquels toutes les réalisations du site ont été menées.
 //
 // **Deux postes salariés et une mission en indépendant.** Acetelecom / MailingVox et
-// Verhoeven Joaillier sont des employeurs ; Truffle Capital est un client, pour qui le
-// travail a été mené en auto-entrepreneur entre 2017 et 2019. Chaque cadre porte donc son
-// `statut`, au même rang que le poste, la période et l'équipe : c'est ce qui manquait, et
-// c'est ce qui a laissé publier « trois postes salariés » (issue #107).
+// Verhoeven Joaillier sont des employeurs ; Truffle Capital est un client — le seul cité
+// sur le site, Artedrone étant une participation du fonds et non un second client — pour
+// qui le travail a été mené en auto-entrepreneur entre 2017 et 2019. Chaque cadre porte
+// donc son `statut`, au même rang que le poste, la période et l'équipe : c'est ce qui
+// manquait, et c'est ce qui a laissé publier « trois postes salariés » (issue #107).
 //
 // L'espace continue de s'appeler « réalisations » et non « cas clients » : sur treize
 // fiches, dix ont été menées en poste salarié, et le nom de l'espace doit décrire

--- a/src/@vitrine/contenu/realisations/cadres.ts
+++ b/src/@vitrine/contenu/realisations/cadres.ts
@@ -1,20 +1,26 @@
 // cadres.ts — jeromemarichez-fr
-// Les trois cadres d'emploi sous lesquels toutes les réalisations du site ont été menées.
+// Les trois cadres sous lesquels toutes les réalisations du site ont été menées.
 //
-// **Aucune de ces trois entreprises n'est un client.** Ce sont trois postes salariés, et
-// c'est la raison pour laquelle l'espace s'appelle « réalisations » et non « cas
-// clients » : nommer autrement affirmerait une relation commerciale qui n'a jamais
-// existé. Les intitulés de poste sont repris à l'identique des CV de référence
+// **Deux postes salariés et une mission en indépendant.** Acetelecom / MailingVox et
+// Verhoeven Joaillier sont des employeurs ; Truffle Capital est un client, pour qui le
+// travail a été mené en auto-entrepreneur entre 2017 et 2019. Chaque cadre porte donc son
+// `statut`, au même rang que le poste, la période et l'équipe : c'est ce qui manquait, et
+// c'est ce qui a laissé publier « trois postes salariés » (issue #107).
+//
+// L'espace continue de s'appeler « réalisations » et non « cas clients » : sur treize
+// fiches, dix ont été menées en poste salarié, et le nom de l'espace doit décrire
+// l'ensemble. Les intitulés de poste sont repris à l'identique des CV de référence
 // (`CLAUDE.md`), sans réécriture pour coller à une offre de service.
 //
-// L'ORDRE DE CE TABLEAU EST L'ORDRE D'AFFICHAGE de la liste : du poste le plus récent au
-// plus ancien. C'est le seul classement qui ne raconte rien d'autre que la chronologie.
+// L'ORDRE DE CE TABLEAU EST L'ORDRE D'AFFICHAGE de la liste : du plus récent au plus
+// ancien. C'est le seul classement qui ne raconte rien d'autre que la chronologie.
 
 import type { IRealisationCadre } from '@/interfaces/IRealisationCadre'
 
 /** 2023-2026. Ni QA ni équipe data dédiées : la qualité et la donnée ont été outillées. */
 export const CADRE_MAILINGVOX: IRealisationCadre = {
-  employeur: 'Acetelecom / MailingVox',
+  statut: 'Poste salarié',
+  organisation: 'Acetelecom / MailingVox',
   poste: 'Lead Tech · Ingénieur full stack, mobile & IA',
   periode: '2023-2026',
   equipe:
@@ -24,7 +30,8 @@ export const CADRE_MAILINGVOX: IRealisationCadre = {
 
 /** 2019-2022. Poste unique : aucun développeur à encadrer, et rien qui le laisse croire. */
 export const CADRE_VERHOEVEN: IRealisationCadre = {
-  employeur: 'Verhoeven Joaillier',
+  statut: 'Poste salarié',
+  organisation: 'Verhoeven Joaillier',
   poste: 'Développeur Full Stack · E-commerce de luxe',
   periode: '2019-2022',
   equipe:
@@ -32,9 +39,14 @@ export const CADRE_VERHOEVEN: IRealisationCadre = {
     'SEA, SEO et SMA.',
 }
 
-/** 2017-2019. L'équipe coordonnée est marketing, jamais technique. */
+/**
+ * 2017-2019. **Le seul cadre qui ne soit pas un poste salarié** : mission menée en
+ * auto-entrepreneur, Truffle Capital était donc un client. L'équipe coordonnée est
+ * marketing, jamais technique.
+ */
 export const CADRE_TRUFFLE: IRealisationCadre = {
-  employeur: 'Truffle Capital',
+  statut: 'Mission en indépendant',
+  organisation: 'Truffle Capital',
   poste: 'Développeur web & Chef de projet digital',
   periode: '2017-2019',
   equipe:

--- a/src/@vitrine/contenu/realisations/realisations-index.ts
+++ b/src/@vitrine/contenu/realisations/realisations-index.ts
@@ -8,10 +8,12 @@ import type { IRealisationsIndex } from '@/interfaces/IRealisationsIndex'
  * Le libellé « Réalisations » est repris à l'identique dans la navigation, le fil
  * d'Ariane, le titre de la page et l'URL — même règle que pour le blog.
  *
- * Le chapô porte l'arbitrage de nom, et il le porte en clair plutôt qu'en note de bas de
- * page : un visiteur qui arrive ici cherche des références clients, et il doit apprendre
- * en deux phrases que ce n'en sont pas. Le dire franchement vaut mieux que le laisser
- * découvrir fiche par fiche.
+ * Le chapô porte le cadre, et il le porte en clair plutôt qu'en note de bas de page : un
+ * visiteur qui arrive ici cherche des références clients, et il doit apprendre en deux
+ * phrases à quel titre chaque travail a été mené — deux postes salariés, une mission en
+ * indépendant. Le dire franchement vaut mieux que le laisser découvrir fiche par fiche, et
+ * mieux que l'ancienne formule « trois postes salariés », qui était fausse pour Truffle
+ * Capital (issue #107).
  */
 export const REALISATIONS_INDEX: IRealisationsIndex = {
   route: ROUTES.realisations,
@@ -19,12 +21,12 @@ export const REALISATIONS_INDEX: IRealisationsIndex = {
   meta: {
     title: 'Réalisations — ce que j’ai construit, et dans quel cadre',
     description:
-      'Treize réalisations avec leur cadre d’emploi réel : intitulé de poste, période, ' +
+      'Treize réalisations avec leur cadre réel : statut, intitulé de poste, période, ' +
       'équipe. Trois portent un chiffre, les autres n’en portent aucun.',
   },
   chapo:
-    'Ce ne sont pas des cas clients : ce sont trois postes salariés, et chaque fiche porte le ' +
-    'cadre dans lequel elle a été menée — intitulé exact, période, équipe. Trois fiches ' +
+    'Deux postes salariés et une mission en indépendant. Chaque fiche porte le cadre dans ' +
+    'lequel elle a été menée — statut, intitulé exact, période, équipe. Trois fiches ' +
     'portent un chiffre ; les autres n’en portent aucun, parce que je ne publie que les ' +
     'chiffres que je peux tenir.',
 }

--- a/src/@vitrine/contenu/realisations/truffle.ts
+++ b/src/@vitrine/contenu/realisations/truffle.ts
@@ -3,8 +3,10 @@
 //
 // Trois précautions valent pour tout ce fichier :
 //
-// - **Artedrone est une participation du fonds**, pas un client de Jérôme. La fiche le
-//   dit, et le rôle tenu y est l'AMOA — rien n'est affirmé sur le dispositif médical.
+// - **Artedrone est une participation du fonds**, jamais un second client. Le client est
+//   Truffle Capital, et l'AMOA a été menée au bénéfice d'Artedrone **dans le cadre de la
+//   mission Truffle**. La fiche le dit, et le rôle tenu y est l'AMOA — rien n'est affirmé
+//   sur le dispositif médical. (Arbitré par Jérôme MARICHEZ le 2026-08-23, issue #107.)
 // - Le **100 000 €** est un budget **piloté**, jamais un résultat. Aucun retour sur
 //   investissement, aucun coût d'acquisition, aucun volume de trafic n'existe en source.
 // - L'équipe coordonnée est **marketing**, et Google Tag Manager n'appartient pas à cette

--- a/src/@vitrine/contenu/realisations/truffle.ts
+++ b/src/@vitrine/contenu/realisations/truffle.ts
@@ -20,7 +20,7 @@ export const REALISATION_BUDGET_ADS: IRealisationChiffree = {
   titre: 'Piloter un budget d’acquisition et le justifier devant des dirigeants',
   chapo:
     'Un budget d’acquisition se pilote dans les interfaces des régies, et se justifie devant ' +
-    'des gens qui ne les ouvrent jamais. Les deux moitiés du travail étaient sur le même poste.',
+    'des gens qui ne les ouvrent jamais. Les deux moitiés du travail tenaient dans la même mission.',
   meta: {
     title: 'Piloter un budget ADS / SEO de 100 000 €',
     description:

--- a/src/@vitrine/services/find-realisation.ts
+++ b/src/@vitrine/services/find-realisation.ts
@@ -24,20 +24,24 @@ export function listRealisations(): IRealisation[] {
 }
 
 /**
- * Les réalisations groupées par cadre d'emploi, du poste le plus récent au plus ancien.
+ * Les réalisations groupées par cadre, du plus récent au plus ancien.
+ *
+ * Le groupement se fait sur le **nom de l'organisation**, qui identifie le cadre à lui
+ * seul : les trois cadres ne partagent ni organisation ni période, et le statut varie
+ * entre eux sans les distinguer — deux d'entre eux sont des postes salariés.
  *
  * L'ordre des groupes est celui de `CADRES`, jamais celui d'apparition dans la liste des
- * fiches : c'est la chronologie des postes qui classe, et elle n'a aucune raison de
- * dépendre de l'ordre dans lequel les fiches ont été écrites.
+ * fiches : c'est la chronologie qui classe, et elle n'a aucune raison de dépendre de
+ * l'ordre dans lequel les fiches ont été écrites.
  *
- * Un cadre sans fiche ne produit pas de groupe vide — un employeur annoncé sans rien à
- * montrer se lit comme une omission.
+ * Un cadre sans fiche ne produit pas de groupe vide — une organisation annoncée sans rien
+ * à montrer se lit comme une omission.
  */
 export function groupRealisationsByCadre(): IRealisationGroupe[] {
   return CADRES.map((cadre) => ({
     cadre,
     realisations: REALISATIONS.filter(
-      (realisation) => realisation.cadre.employeur === cadre.employeur,
+      (realisation) => realisation.cadre.organisation === cadre.organisation,
     ),
   })).filter((groupe) => groupe.realisations.length > 0)
 }
@@ -45,10 +49,10 @@ export function groupRealisationsByCadre(): IRealisationGroupe[] {
 /**
  * Rend la fiche demandée et jusqu'à deux autres à lire ensuite.
  *
- * Le voisinage se calcule sur les **pôles partagés**, et non sur le cadre d'emploi : la
- * liste groupe déjà par employeur, et proposer trois fois le même employeur en bas de
+ * Le voisinage se calcule sur les **pôles partagés**, et non sur le cadre : la liste
+ * groupe déjà par organisation, et proposer trois fois la même organisation en bas de
  * page n'apprendrait rien. Passer par les pôles montre au contraire qu'un même pôle a été
- * mobilisé sous trois postes différents, ce qui est exactement l'argument de l'espace.
+ * mobilisé sous trois cadres différents, ce qui est exactement l'argument de l'espace.
  *
  * Si moins de deux fiches partagent un pôle, la liste est complétée dans l'ordre déclaré :
  * un bloc « à voir aussi » à moitié rempli se remarque plus que son absence.

--- a/src/@vitrine/views/RealisationsIndexView/index.tsx
+++ b/src/@vitrine/views/RealisationsIndexView/index.tsx
@@ -15,16 +15,18 @@ interface RealisationsIndexViewProps {
 }
 
 /**
- * **Le regroupement par cadre d'emploi n'est pas un classement, c'est l'argument.**
+ * **Le regroupement par cadre n'est pas un classement, c'est l'argument.**
  *
  * Une liste plate de treize fiches se lirait comme un portfolio d'agence, et le lecteur
- * supposerait treize commanditaires. Groupées sous trois employeurs, avec l'intitulé de
- * poste et la période en tête de chaque groupe, les mêmes fiches disent ce qu'elles sont :
- * du travail salarié, mené sur trois postes en neuf ans. Le cadre est donc rendu **avant**
- * les fiches qu'il porte, jamais en note sous chacune d'elles.
+ * supposerait treize commanditaires. Groupées sous trois organisations, avec le statut,
+ * l'intitulé de poste et la période en tête de chaque groupe, les mêmes fiches disent ce
+ * qu'elles sont : deux postes salariés et une mission en indépendant, sur neuf ans. Le
+ * cadre est donc rendu **avant** les fiches qu'il porte, jamais en note sous chacune
+ * d'elles.
  *
- * Chaque groupe est une `<section>` étiquetée par le nom de l'employeur : au clavier comme
- * au lecteur d'écran, on peut passer d'un poste au suivant sans traverser ses fiches.
+ * Chaque groupe est une `<section>` étiquetée par le nom de l'organisation : au clavier
+ * comme au lecteur d'écran, on peut passer d'un cadre au suivant sans traverser ses
+ * fiches.
  */
 export function RealisationsIndexView({ index, groupes }: RealisationsIndexViewProps) {
   return (

--- a/src/interfaces/IProof.ts
+++ b/src/interfaces/IProof.ts
@@ -6,7 +6,7 @@ import type { IRealisationChiffree } from './IRealisationChiffree'
 /**
  * Un chiffre sans contexte est un chiffre invérifiable.
  *
- * Chaque preuve porte donc l'employeur et la période où elle a été obtenue : c'est ce
+ * Chaque preuve porte donc l'organisation et la période où elle a été obtenue : c'est ce
  * qui la distingue d'un argument de plaquette, et ce qui permet à un prospect de la
  * recouper avec le parcours.
  */

--- a/src/interfaces/IRealisationCadre.ts
+++ b/src/interfaces/IRealisationCadre.ts
@@ -1,14 +1,15 @@
 // IRealisationCadre.ts — jeromemarichez-fr
-// Le cadre d'emploi d'une réalisation : sous quel statut, quand, et avec qui.
+// Le cadre d'une réalisation : sous quel statut, pour qui, quand, et avec qui.
 
 /**
  * Le cadre réel dans lequel une réalisation a été menée.
  *
  * **Aucun champ n'est optionnel, et c'est tout l'objet de cette entité.** Un espace de
- * réalisations dérive de lui-même vers « mon client X » : les entreprises citées ici sont
- * des **employeurs**, jamais des clients, et le `CLAUDE.md` impose de reprendre les
- * intitulés de poste à l'identique des CV de référence, sans réécriture pour coller à une
- * offre de service.
+ * réalisations dérive de lui-même vers « mon client X » : il faut donc dire de chaque
+ * fiche sous quel statut elle a été menée — deux postes salariés et une mission en
+ * indépendant — plutôt que de laisser le lecteur le supposer dans un sens ou dans l'autre.
+ * Le `CLAUDE.md` impose par ailleurs de reprendre les intitulés de poste à l'identique des
+ * CV de référence, sans réécriture pour coller à une offre de service.
  *
  * Rendre ce cadre facultatif reviendrait à autoriser une fiche à paraître sans dire d'où
  * elle vient — et une fiche sans provenance se lit comme une prestation vendue. Le
@@ -16,11 +17,21 @@
  * relecture.
  */
 export interface IRealisationCadre {
-  /** Employeur, nommé tel quel. Jamais présenté comme un client. */
-  employeur: string
+  /**
+   * Statut sous lequel le travail a été mené : « Poste salarié », « Mission en
+   * indépendant ».
+   *
+   * Obligatoire au même titre que les trois autres, et pour la même raison : un cadre sans
+   * statut redevient ambigu. C'est le champ qui manquait, et son absence a laissé publier
+   * « trois postes salariés » alors que Truffle Capital (2017-2019) était une mission
+   * menée en indépendant.
+   */
+  statut: string
+  /** L'organisation, nommée telle quelle. C'est le statut qui dit à quel titre. */
+  organisation: string
   /** Intitulé de poste, repris à l'identique du CV de référence. Jamais réécrit. */
   poste: string
-  /** Période d'occupation du poste, au format `AAAA-AAAA`. */
+  /** Période, au format `AAAA-AAAA`. */
   periode: string
   /**
    * Taille et nature de l'équipe, et ce qui y était encadré.

--- a/tests/fixtures/realisation.fixture.json
+++ b/tests/fixtures/realisation.fixture.json
@@ -1,8 +1,9 @@
 {
   "_lisezmoi": "Jeu de données de réalisations (jeromemarichez-fr) — PAS un mock. Les vrais services (find-realisation, listPoles, buildSitemapEntries, buildCollectionPageSchema, buildRealisationSchema) tournent sur ces fiches réalistes ; aucune doublure de module n'est utilisée. Voir docs/testing.md et docs/data-model.md.",
   "_cas": {
-    "cadres": "Trois cadres d'emploi, du plus récent au plus ancien. Le troisième ne porte AUCUNE fiche : groupRealisationsByCadre ne doit pas produire de groupe vide.",
-    "ordreDeclaration": "Les fiches sont déclarées dans un ordre volontairement mêlé entre employeurs — la deuxième appartient au second cadre. Un regroupement qui suivrait l'ordre de déclaration au lieu de celui de CADRES se voit immédiatement.",
+    "cadres": "Trois cadres, du plus récent au plus ancien. Le troisième ne porte AUCUNE fiche : groupRealisationsByCadre ne doit pas produire de groupe vide.",
+    "statuts": "Les statuts ne sont pas uniformes — deux postes salariés et une mission en indépendant, comme dans le contenu publié. Le statut ne distingue donc PAS les cadres entre eux : un regroupement qui s'appuierait sur lui au lieu de l'organisation fondrait deux groupes en un.",
+    "ordreDeclaration": "Les fiches sont déclarées dans un ordre volontairement mêlé entre organisations — la deuxième appartient au second cadre. Un regroupement qui suivrait l'ordre de déclaration au lieu de celui de CADRES se voit immédiatement.",
     "ficheChiffree": "« refonte-parcours » porte un chiffre, avec sa portée. C'est le gabarit chiffré, et le seul de ce jeu : les trois autres fiches n'ont pas de champ chiffre du tout.",
     "polesSansIa": "« refonte-parcours » porte ['ingenierie-web', 'data', 'sea-ux'] — la chaîne complète SANS l'IA. Un type qui exigerait l'IA après la donnée rendrait cette fiche inexprimable.",
     "poleDataSeul": "« cadrage-metier » porte ['data'] seul : la donnée se livre pour elle-même. Aucune autre fiche du jeu ne partage ce pôle sans en partager un autre.",
@@ -13,19 +14,22 @@
   },
   "cadres": [
     {
-      "employeur": "Employeur Récent",
+      "statut": "Poste salarié",
+      "organisation": "Organisation Récente",
       "poste": "Lead Tech · Ingénieur full stack",
       "periode": "2023-2026",
       "equipe": "Équipe technique de trois — deux développeurs et un product owner."
     },
     {
-      "employeur": "Employeur Intermédiaire",
+      "statut": "Mission en indépendant",
+      "organisation": "Organisation Intermédiaire",
       "poste": "Développeur Full Stack · E-commerce",
       "periode": "2019-2022",
       "equipe": "Poste unique, en autonomie complète. Encadrement de prestataires."
     },
     {
-      "employeur": "Employeur Sans Fiche",
+      "statut": "Poste salarié",
+      "organisation": "Organisation Sans Fiche",
       "poste": "Développeur web & Chef de projet digital",
       "periode": "2017-2019",
       "equipe": "Coordination d’une équipe marketing de 5 à 10 personnes."
@@ -41,7 +45,8 @@
         "description": "Fiche de jeu de données : migration menée sans coupure, sous le cadre le plus récent."
       },
       "cadre": {
-        "employeur": "Employeur Récent",
+        "statut": "Poste salarié",
+        "organisation": "Organisation Récente",
         "poste": "Lead Tech · Ingénieur full stack",
         "periode": "2023-2026",
         "equipe": "Équipe technique de trois — deux développeurs et un product owner."
@@ -67,7 +72,8 @@
         "description": "Fiche de jeu de données : seule fiche chiffrée, chaîne complète sans l’IA."
       },
       "cadre": {
-        "employeur": "Employeur Intermédiaire",
+        "statut": "Mission en indépendant",
+        "organisation": "Organisation Intermédiaire",
         "poste": "Développeur Full Stack · E-commerce",
         "periode": "2019-2022",
         "equipe": "Poste unique, en autonomie complète. Encadrement de prestataires."
@@ -101,7 +107,8 @@
         "description": "Fiche de jeu de données : pôle data seul, aucune suite achetée."
       },
       "cadre": {
-        "employeur": "Employeur Récent",
+        "statut": "Poste salarié",
+        "organisation": "Organisation Récente",
         "poste": "Lead Tech · Ingénieur full stack",
         "periode": "2023-2026",
         "equipe": "Équipe technique de trois — deux développeurs et un product owner."
@@ -127,7 +134,8 @@
         "description": "Fiche de jeu de données : aucun résultat mesuré, et la fiche l’écrit."
       },
       "cadre": {
-        "employeur": "Employeur Récent",
+        "statut": "Poste salarié",
+        "organisation": "Organisation Récente",
         "poste": "Lead Tech · Ingénieur full stack",
         "periode": "2023-2026",
         "equipe": "Équipe technique de trois — deux développeurs et un product owner."


### PR DESCRIPTION
Corrige l'issue #107.

## Ce qui était faux

Le site affirmait, en clair et à plusieurs endroits, que **les trois entreprises citées
sont des employeurs salariés et qu'aucune n'est un client** :

- chapô publié de `/realisations/` : « Ce ne sont pas des cas clients : ce sont trois
  postes salariés » ;
- `README.md`, section « L'espace `/realisations/` » : « **Aucune des entreprises citées
  sur le site n'est un client** » ;
- l'en-tête de `cadres.ts`, l'interface `IRealisationCadre` et les commentaires de
  `find-realisation` / `RealisationsIndexView`, qui justifiaient tout le modèle sur cette
  prémisse.

C'est faux pour **Truffle Capital** : la mission 2017-2019 a été menée en
**auto-entrepreneur**. Truffle Capital était donc un client.

**Pourquoi ce n'était pas détectable depuis le dépôt** : les CV de référence ne portent
pas le statut. Ils s'arrêtent à l'intitulé « Développeur web & Chef de projet digital » et
à la période « 2017 à 2019 ». Aucune source du dépôt ne contredisait « trois postes
salariés » — c'est exactement le trou que le nouveau champ obligatoire ferme.

## Ce qui change

**`IRealisationCadre` gagne un champ `statut`, obligatoire.** Même garde-fou que les trois
autres champs : c'est le compilateur, pas la relecture, qui interdit qu'une fiche paraisse
sans dire à quel titre elle a été menée. Un champ optionnel aurait laissé revenir la même
ambiguïté fiche par fiche.

**`employeur` devient `organisation`.** Le nom d'une entreprise ne dit plus à lui seul le
lien juridique — c'est `statut` qui le dit. Le groupement de la liste continue de se faire
sur ce nom, qui identifie un cadre à lui seul (les trois cadres ne partagent ni
organisation ni période, alors que deux d'entre eux partagent le statut).

**Les trois cadres :**

| Organisation | Statut |
|---|---|
| Acetelecom / MailingVox | Poste salarié |
| Verhoeven Joaillier | Poste salarié |
| Truffle Capital | Mission en indépendant |

**`EmploymentFrame`** rend `Statut` comme un **terme à part entière**, en tête de la liste
de définitions — jamais glissé dans une autre valeur. Une information de ce rang doit être
atteignable comme les autres à la navigation par définitions (RGAA / WCAG AA).

**Textes publiés** : le chapô devient « Deux postes salariés et une mission en
indépendant. Chaque fiche porte le cadre dans lequel elle a été menée — statut, intitulé
exact, période, équipe. […] ». Les métadonnées SEO de `/realisations/` et l'accroche
d'accueil (`espaces.ts`) suivent. Le chapô de la fiche `truffle-budget-ads-seo` disait
« sur le même poste » : devenu « dans la même mission ».

**Commentaires d'en-tête corrigés**, pas seulement les chaînes affichées : `cadres.ts`,
`truffle.ts`, `IRealisationCadre`, `IProof`, `find-realisation`, `RealisationsIndexView`,
`EmploymentFrame`, `espaces.ts`, `realisations-index.ts`, et le `_lisezmoi` du jeu de
données.

**Deux erreurs de comptage corrigées** au passage, dans la reprise du travail déjà posé :
Truffle porte **trois** fiches sur treize, pas une. Le `README.md` dit désormais « dix
fiches sur treize » et `cadres.ts` « sur treize fiches, dix ont été menées en poste
salarié ».

## Artedrone — tranché par Jérôme MARICHEZ le 2026-08-23

La question a été posée et **répondue** : Truffle Capital est un fonds d'investissement,
Artedrone une de ses startups en portefeuille, et l'AMOA y a été menée **dans le cadre de
la mission Truffle**, en indépendant.

**Artedrone n'était donc pas un client.** La conclusion du `README.md` reste juste sur le
fond, mais sa **justification** ne tenait plus : elle s'appuyait sur « aucune des
entreprises citées n'est un client », affirmation que cette PR démolit. La phrase est donc
réécrite plutôt que laissée en l'état — un lecteur qui l'aurait relue plus tard en aurait
tiré la mauvaise conclusion.

Le `README.md` et l'en-tête de `truffle.ts` disent désormais : **Truffle Capital est le
seul client cité sur le site**, et Artedrone est une **participation du fonds** au bénéfice
de laquelle l'AMOA a été menée. Artedrone ne devient ni un second client ni une référence
commerciale.

## Garde-fous tenus

- Les **intitulés de poste** ne bougent pas d'un caractère : « Développeur web & Chef de
  projet digital » est repris à l'identique du CV.
- L'espace **ne devient pas « cas clients »** : le nom et la raison d'être sont inchangés,
  et l'argument est réécrit pour tenir avec le nouveau décompte.
- Aucune formulation restante n'affirme que les trois entreprises sont des employeurs ni
  qu'aucune n'est un client. Vérifié :
  `grep -rn "salari\|n'est un client\|employeur" src/ README.md docs/`.
- `README.md` : seule la section « L'espace `/realisations/` » et une ligne du tableau
  d'arborescence sont touchées, pour garder trivial le conflit avec
  `feature/accueil-vitrine` (#103).

## Vérification

- `make lint` : vert (le seul avertissement, `noImgElement` sur `CertificationList`, est
  antérieur à cette branche).
- `npx tsc --noEmit` : vert.
- `make test` : vert.
- `npx next build` : les 13 fiches et `/realisations/` se prérendent.
- Rendu contrôlé dans la sortie statique : le groupe Truffle porte « Statut / Mission en
  indépendant », les groupes MailingVox et Verhoeven « Statut / Poste salarié ».

## Tests — intention proposée, à poser par Jérôme MARICHEZ

Aucun fichier de test n'est créé par l'assistant (règle `CLAUDE.md`). Le jeu de données
`tests/fixtures/realisation.fixture.json` est en revanche mis à jour : le champ devenant
obligatoire, les cadres et les fiches du jeu le portent, avec des statuts **volontairement
non uniformes** (deux « Poste salarié », une « Mission en indépendant ») — pour que le
statut ne puisse pas servir de clé de groupement par accident.

Intentions proposées, niveau **unitaire** (`tests/unitaire/`) :

1. **`groupRealisationsByCadre` groupe sur l'organisation, pas sur le statut.** Le jeu
   contient deux cadres de statut identique et un troisième distinct ; un groupement fondé
   sur le statut fondrait deux groupes en un. Assertion : autant de groupes que de cadres
   portant au moins une fiche, chacun avec sa propre organisation. Cas limite : le cadre
   sans fiche ne produit pas de groupe vide (déjà couvert par le jeu).
2. **`EmploymentFrame` rend le statut comme un terme de la liste de définitions.**
   Assertion : un `<dt>` de texte exact « Statut » existe, et son `<dd>` associé porte la
   valeur du cadre — pas une sous-chaîne d'une autre valeur. C'est l'exigence
   d'accessibilité, et c'est ce qui empêche la régression « statut collé dans le poste ».
3. **Véracité du contenu publié.** Sur le contenu réel : `CADRE_TRUFFLE.statut` vaut
   « Mission en indépendant », les deux autres « Poste salarié », et le chapô de
   `REALISATIONS_INDEX` ne contient ni « trois postes salariés » ni « ne sont pas des cas
   clients ». C'est le test qui aurait attrapé #107.
4. **`CADRE_TRUFFLE.poste` vaut exactement `Développeur web & Chef de projet digital`.**
   Verrouille la règle « intitulé repris à l'identique du CV ».

Refs #107 — l'issue n'est pas fermée automatiquement (PR vers `dev`, branche par défaut
`main`), à clore à la main.
