### PR TITLE
feat: un article de blog porte sa figure et sa source

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,11 @@ une prestation vendue ou une œuvre détenue.
 Le **blog** n'est pas un quatrième pôle et la navigation le sépare de la chaîne : ce sont
 des notes courtes sur des décisions techniques réelles. Chaque article porte ses propres
 métadonnées, un `schema.org/BlogPosting`, un fil d'Ariane `Accueil → Blog → article` et sa
-**date** — c'est la seule partie du site dont le sitemap publie une date par page. Le
-modèle de l'entité est décrit dans [`docs/data-model.md`](./docs/data-model.md).
+**date** — c'est la seule partie du site dont le sitemap publie une date par page. Chaque
+article porte aussi une **figure construite** — du SVG rendu au serveur, jamais un fichier
+d'image — et, quand il en a une, un lien vers sa **publication d'origine**. Le modèle de
+l'entité est décrit dans [`docs/data-model.md`](./docs/data-model.md), la grammaire des
+figures dans [`docs/design.md`](./docs/design.md).
 
 ## ✅ Contraintes produit
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -74,12 +74,12 @@ Restent hors de portée d'axe, et donc à la charge de l'audit manuel :
 
 ### Pages contrôlées
 
-Les mêmes que les budgets de performance — accueil, page de pôle, page d'article — parce
-qu'un gabarit non mesuré est un gabarit non protégé. La liste vit dans
-`scripts/budgets/pages.mjs`.
+Les mêmes que les budgets de performance — accueil, page de pôle, liste du blog, page
+d'article, index et fiche de réalisation — parce qu'un gabarit non mesuré est un gabarit
+non protégé. La liste vit dans `scripts/budgets/pages.mjs`.
 
 | Parcours | Audit | État |
 |----------|-------|------|
-| Accueil, pôle, article | axe-core (`ci-dev-a11y`) | **0 violation** — première exécution, 2026-08-22 |
+| Accueil, pôle, blog, article, réalisations | axe-core (`ci-dev-a11y`) | **0 violation** — dernière exécution 2026-08-23, avec les figures d'article |
 | Clavier + lecteur d'écran | manuel | _à réaliser_ |
 | WCAG 2.2.2 — pause des animations | manuel | _à réaliser_ |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,6 +128,13 @@ entité par fichier, préfixe `I`) que les composants consomment. Ajouter une ce
 une offre ou un article ne doit pas demander de toucher au rendu. Le détail des entités
 est décrit dans [data-model](./data-model.md).
 
+**Les illustrations sont de la donnée aussi.** Le site ne sert aucune image matricielle :
+l'illustration d'un article n'est pas un chemin de fichier mais une **valeur d'union close**
+(`IArticle.figure`), rendue en SVG au serveur par `@vitrine/components/ArticleFigure`. Un
+article ne peut donc pas réclamer une figure qui n'existe pas — le compilateur le dit avant
+le build, et aucune ressource ne peut manquer à l'exécution. La grammaire de ces figures est
+décrite dans [design](./design.md).
+
 ## Front (Next.js (App Router) + TypeScript)
 
 - **Organisation** : par domaine **métier**, pas par type technique. Quand l'app

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -31,8 +31,9 @@ TypeScript dans `src/@vitrine/contenu/`, et sa forme est tenue par des interface
 | `IRealisationsIndex` | `src/interfaces/IRealisationsIndex.ts` | L'en-tête éditoriale de `/realisations` | — |
 | `ICertification` | `src/interfaces/ICertification.ts` | Une certification obtenue | `ICertificationLogo` |
 | `IBoundary` | `src/interfaces/IBoundary.ts` | Une limite assumée | — |
-| **`IArticle`** | `src/interfaces/IArticle.ts` | **Un article du blog** | contient des `IArticleSection` |
+| **`IArticle`** | `src/interfaces/IArticle.ts` | **Un article du blog** | contient des `IArticleSection`, porte une `IArticleSource` |
 | `IArticleSection` | `src/interfaces/IArticleSection.ts` | Une section d'article | — |
+| `IArticleSource` | `src/interfaces/IArticleSource.ts` | La publication d'origine d'un article | — |
 | `IBlogIndex` | `src/interfaces/IBlogIndex.ts` | L'en-tête éditoriale de `/blog` | — |
 | `IBreadcrumbItem` | `src/interfaces/IBreadcrumbItem.ts` | Un niveau de fil d'Ariane | lu par le rendu **et** par le JSON-LD |
 
@@ -88,6 +89,8 @@ contenu : une page de pôle est vraie ou fausse, un article est vrai **à une da
 | `meta` | `IPageMeta` | oui | `<title>` (60 car. max) et meta description (155 car. max) |
 | `datePublication` | `string` (`AAAA-MM-JJ`) | oui | Date affichée, `datePublished`, **clé de tri** de la liste |
 | `dateRevision` | `string` (`AAAA-MM-JJ`) | non | Révision de fond. `dateModified` et `lastModified` du sitemap |
+| `figure` | `ArticleFigureId` | oui | La figure qui illustre l'article. **Pas un chemin de fichier** : une valeur d'union close, rendue en SVG par `ArticleFigure` |
+| `source` | `IArticleSource` | non | Publication d'origine, quand il y en a une. Un réseau et une URL, rien d'autre |
 | `sections` | `IArticleSection[]` | oui | Corps de l'article : un titre `<h2>` et ses paragraphes |
 
 ### Contraintes d'intégrité
@@ -106,6 +109,15 @@ construction du site, ou elles restent à la charge de l'auteur :
 - **`dateRevision` ≥ `datePublication`** quand elle existe.
 - **Véracité du contenu** : les règles du [`CLAUDE.md`](../CLAUDE.md) s'appliquent mot
   pour mot à un article comme au reste du site.
+- **`source.url` n'est jamais devinée.** C'est la règle des justificatifs de certification,
+  à l'identique : tant que l'adresse n'a pas été fournie par Jérôme MARICHEZ, l'article se
+  publie **sans source**. C'est la raison d'être du caractère optionnel du champ, et non une
+  commodité de saisie. Les trois articles publiés n'en portent aucune.
+- **`figure` est obligatoire, délibérément.** La laisser facultative aurait produit une liste
+  où certains articles ont une figure et d'autres pas, c'est-à-dire un rythme cassé sans
+  qu'aucune information ne le justifie. Deux articles peuvent partager une figure — rien ne
+  l'interdit — mais les trois publiés en ont chacun une, sans quoi elle cesserait de
+  distinguer.
 
 ### Règles portées par le service
 
@@ -123,8 +135,12 @@ un composant :
 - **Pas d'auteur.** Le site n'a qu'un auteur, déclaré une fois pour tout le site par le
   nœud `Person` du layout. Un champ `auteur` par article laisserait croire à une équipe
   de rédaction.
-- **Pas d'image.** Aucune illustration n'est servie ; déclarer une image dans le JSON-LD
-  ou dans `og:image` sans la servir serait une affirmation fausse de plus.
+- **Pas de FICHIER d'image**, et c'est différent de « pas d'illustration ». Un article porte
+  une figure depuis l'issue #108, mais c'est du SVG écrit dans le document : il n'existe
+  aucune ressource à servir, donc rien à déclarer dans `image` ni dans `og:image`. Y mettre
+  une URL qui rendrait 404 serait une affirmation fausse de plus. Le jour où une image est
+  réellement servie, le champ s'ajoute ; pas avant. Voir `docs/design.md`, « Les figures
+  d'article ».
 - **Pas de rattachement à un pôle, pas de tags, pas de catégories.** Avec trois articles,
   une taxonomie serait un classement sans classe. Le jour où elle s'impose, le
   rattachement dérivera de `PoleId` et de l'ordre porté par `POLES_NAV` — jamais d'une

--- a/docs/design.md
+++ b/docs/design.md
@@ -691,6 +691,114 @@ Le volume annoncé est **dérivé des listes sources**, jamais écrit à la main
 peut donc pas annoncer un nombre de fiches que l'espace ne tient pas. C'est la même règle
 que pour les chiffres de `preuves.ts`.
 
+## Les figures d'article
+
+Le blog était entièrement textuel : sur `/blog/` comme sur une fiche, rien ne distinguait
+un article d'un autre à l'œil. Chaque article porte désormais une **figure**
+([`ArticleFigure`](../src/@vitrine/components/ArticleFigure/index.tsx)), et elle obéit à la
+même doctrine que les marques de pôle — c'est ce qui fait que le blog appartient au même
+site que l'accueil.
+
+### Construite, jamais matricielle
+
+Le site n'a **aucune image matricielle** : quatre SVG en tout, `next/image` écarté
+délibérément. Une illustration d'article n'allait pas en introduire la première. Les trois
+figures sont du **SVG rendu au serveur**, elles pèsent quelques centaines d'octets dans le
+document, et le budget Lighthouse — qui ne tient qu'à un point — n'en sait rien.
+
+Elles n'ont **aucun fichier**, ce qui a une conséquence en dehors du design : le JSON-LD
+d'un article ne déclare toujours pas de champ `image`. La raison a changé — le site sert
+désormais une illustration — mais il n'existe aucune ressource qu'un moteur puisse aller
+chercher, et déclarer une URL qui rendrait 404 serait un mensonge de plus.
+
+### Rien qui simule une donnée
+
+C'est la règle des marques de pôle, appliquée mot pour mot. Le site vend la mesure : un
+pictogramme qui mimerait un graphique — une courbe qui monte, des barres qui progressent —
+afficherait un chiffre inventé, ce que les règles de véracité du `CLAUDE.md` interdisent.
+Ce sont des **figures de structure**, pas des visualisations.
+
+Le cas le plus tendu est celui de « Mesurer avant d'arbitrer », dont la figure est une
+balance : son **fléau est strictement horizontal**, et ce n'est pas un détail de dessin. Une
+balance qui penche affiche un verdict, c'est-à-dire un chiffre. Ce qui est dessiné, c'est
+qu'un arbitrage repose sur une collecte — jamais lequel des deux plateaux l'emporte.
+
+### La grammaire, reprise trait pour trait
+
+| Signe | Sens | Où on l'a déjà vu |
+|-------|------|-------------------|
+| trait plein | ce qui est retenu | les quatre marques de pôle |
+| trait tireté, opacité 0.65 | ce qui est écarté | `PoleGlyph` — l'IA et le SEA & UX |
+| croix | une voie fermée | `PoleGlyph` — la branche écartée de l'IA |
+| point plein | un aboutissement | les quatre marques de pôle |
+| trait épais (2.4) | une assise | le socle de l'ingénierie web |
+
+Une seule chose diffère, et elle corrige une lecture : **la croix n'est pas tiretée**. Ses
+branches mesurent 5,1 unités, soit à peine deux tirets ; tiretées, elles ne rendent que leur
+amorce et la croix se lit comme une **coche** — l'exact contraire de ce qu'elle dit. Mesuré
+au rendu, pas supposé.
+
+| Article | Figure | Ce qu'elle dessine |
+|---------|--------|--------------------|
+| Pourquoi ce site est un export statique | `borne` | Trois plaques écrites, un aboutissement, une ligne que rien ne franchit ; au-delà, tireté, le serveur applicatif qui n'existe plus |
+| Le test avant le code, même avec un agent | `anteriorite` | Deux temps sur un axe — le point posé d'abord, la boîte ouverte ensuite ; dessous, tiretée et fermée d'une croix, la voie inverse |
+| Mesurer avant d'arbitrer | `appui` | Un fléau à l'horizontale et deux plateaux identiques, la décision au sommet du mât, portés par une assise et sa trame de mesure |
+
+### Deux registres, un seul jeton
+
+`--taille-figure-article` vaut **3rem** partout, et la fiche d'article le redéfinit chez elle
+à `clamp(6.5rem, 22vw, 9rem)` — le même geste que `--decalage-ancre` sur les pages de pôle.
+La hauteur n'a **pas** de jeton : elle suit le `viewBox` (48 × 32), et deux valeurs à tenir
+d'accord divergent à la première retouche.
+
+Le registre de liste tient à une contrainte posée ailleurs : la liste du blog est « une
+liste, pas une grille » ([`BlogIndexView`](../src/@vitrine/views/BlogIndexView/index.tsx)).
+Une vignette pleine largeur en ferait un magazine et promettrait des catégories qui
+n'existent pas. La figure partage donc la **ligne de la date** au lieu de s'empiler dessus :
+elle distingue les articles à l'œil sans ajouter une seule ligne au rythme de la liste.
+
+Le registre est aussi ce qui distingue la figure d'une marque de pôle : une marque est
+carrée (32 × 32), une figure d'article est **couchée** (48 × 32). Une page de pôle vend, un
+article raconte — et une figure large se pose au-dessus d'un texte sans prétendre à l'insigne.
+
+### Décor, jamais information
+
+La figure est `aria-hidden` et ne porte rien que le titre et le chapô ne disent déjà en
+toutes lettres, juste à côté (WCAG 1.1.1 et 1.4.1). C'est aussi ce qui autorise à la répéter
+à l'identique sur la carte de la liste : un décor se répète, une information non.
+
+Aucune couleur n'est nommée dans le module : le tracé est en `currentColor` et le module pose
+`color: var(--accent)`. Le blog n'est sous aucun `data-pole`, donc `--accent` y vaut le cuivre
+de la racine — la teinte de la maison, exactement ce que doit prendre un contenu qui
+n'appartient à aucun pôle. Les deux thèmes suivent sans qu'une ligne y soit consacrée.
+
+## La note de publication d'origine
+
+Un article peut reprendre un texte d'abord paru sur un réseau
+([`ArticleSource`](../src/@vitrine/components/ArticleSource/index.tsx)). Le champ est
+**optionnel** et le restera : les trois articles publiés ont été écrits pour ce site et
+n'ont pas de post d'origine. **Une URL absente ne se devine pas** — c'est déjà la règle des
+justificatifs de certification. Sans source, rien n'est rendu : ni ligne vide, ni filet
+orphelin.
+
+Le lien sort du site, et **son caractère externe ne repose pas sur la couleur** (WCAG 1.4.1).
+Trois porteurs, dont chacun survit à la disparition des deux autres :
+
+| Porteur | Ce qu'il couvre |
+|---------|-----------------|
+| le soulignement du lien | tient même sans images et sans CSS de couleur |
+| une flèche sortante **dessinée**, en `currentColor` | tient pour qui ne distingue pas la teinte du lien de l'encre |
+| « (nouvel onglet) », retiré du flux visuel | tient pour les technologies d'assistance, où la flèche ne dit rien |
+
+La flèche est dessinée plutôt qu'écrite en caractère (« ↗ ») : le glyphe manque à plusieurs
+polices système et s'y remplace par un rectangle, et son dessin varie assez d'une fonte à
+l'autre pour ne plus faire série avec les figures du site. Elle redéclare `display:
+inline-block` — c'est le **seul `svg` du site à vivre dans une ligne de texte**, et le
+`display: block` global de `globals.css` la poussait seule à la ligne.
+
+`rel="noopener noreferrer"`, comme le lien de justificatif d'une certification : un lien
+sortant est traité pareil partout, ou il finit par ne l'être nulle part.
+
 ## La maille de fond
 
 Le fond était un lavis radial unique, une trame de 32 px et un grain. Correct, sobre —

--- a/scripts/budgets/pages.mjs
+++ b/scripts/budgets/pages.mjs
@@ -60,6 +60,14 @@ export const PAGES = [
     pourquoi: 'gabarit de pôle : sections, preuves chiffrées, palette dédiée',
   },
   {
+    id: 'blog',
+    chemin: '/blog/',
+    pourquoi:
+      "gabarit de liste d'articles : cartes datées, figures construites, JSON-LD de blog. " +
+      "Ajouté avec les figures d'article (issue #108) — un gabarit non mesuré est un gabarit " +
+      'non protégé',
+  },
+  {
     id: 'article',
     chemin: '/blog/pourquoi-ce-site-est-un-export-statique/',
     pourquoi: "gabarit d'article : corps long, typographie, fil d'Ariane, JSON-LD",

--- a/src/@shared/seo/structured-data.ts
+++ b/src/@shared/seo/structured-data.ts
@@ -93,9 +93,18 @@ export function buildBreadcrumbSchema(fil: IBreadcrumbItem[]): Record<string, un
  * Un article du blog.
  *
  * `BlogPosting` plutôt qu'`Article` : c'est le sous-type exact, et l'annoncer permet à
- * un moteur de rattacher l'article au blog qui le contient. Pas de champ `image` — le
- * site ne sert aucune illustration d'article, et déclarer une image absente serait
- * précisément le genre de JSON-LD gonflé que ce fichier s'interdit.
+ * un moteur de rattacher l'article au blog qui le contient.
+ *
+ * **Toujours pas de champ `image`, et la raison a changé.** Un article porte désormais une
+ * illustration (`IArticle.figure`), mais c'est une figure SVG écrite dans le document par
+ * `ArticleFigure` : il n'existe aucun fichier à servir, donc aucune URL à déclarer.
+ * `image` attend une ressource qu'un moteur puisse aller chercher — la remplir d'une adresse
+ * qui rendrait 404 serait exactement le genre de JSON-LD gonflé que ce fichier s'interdit.
+ * Le jour où une image est réellement servie, le champ s'ajoute ; pas avant.
+ *
+ * Rien non plus sur `IArticle.source`. Aucun article publié n'en porte, et déclarer la
+ * republication d'un texte demande de trancher entre `sameAs` et `isBasedOn`, qui
+ * n'affirment pas la même chose. Cet arbitrage se fera devant un cas réel.
  *
  * `author` et `publisher` pointent les nœuds déjà publiés par le layout : la personne et
  * l'activité sont décrites une fois pour tout le site, jamais redéclarées par page.

--- a/src/@vitrine/components/ArticleCard/article-card.module.css
+++ b/src/@vitrine/components/ArticleCard/article-card.module.css
@@ -10,7 +10,12 @@
   border-top: 1px solid color-mix(in srgb, var(--encre) 12%, transparent);
 }
 
+/* La figure partage la ligne de la date au lieu de s'empiler dessus : la liste garde son
+   rythme au pixel près, et aucune carte ne devient plus haute que les autres. */
 .date {
+  display: flex;
+  align-items: center;
+  gap: var(--e-2);
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   letter-spacing: 0.06em;

--- a/src/@vitrine/components/ArticleCard/index.tsx
+++ b/src/@vitrine/components/ArticleCard/index.tsx
@@ -1,10 +1,11 @@
 // ArticleCard/index.tsx — jeromemarichez-fr
-// Un article vu depuis une liste : sa date, son titre, son chapô.
+// Un article vu depuis une liste : sa figure, sa date, son titre, son chapô.
 
 import Link from 'next/link'
 import { toArticleRoute } from '@/@shared/routes'
 import type { IArticle } from '@/interfaces/IArticle'
 import { formatDateFr } from '@/utils/format-date'
+import { ArticleFigure } from '../ArticleFigure'
 import styles from './article-card.module.css'
 
 interface ArticleCardProps {
@@ -20,6 +21,12 @@ interface ArticleCardProps {
  * la piloter en JavaScript : dans les deux cas, un lecteur d'écran annonce un lien sans
  * intitulé ou une zone qu'aucune touche n'atteint. Un titre cliquable dit exactement où
  * l'on va, au clavier comme à la souris.
+ *
+ * **La figure tient sur la ligne de date, et pas au-dessus.** La liste du blog est « une
+ * liste, pas une grille » (`BlogIndexView`) : lui poser une vignette pleine largeur en
+ * ferait un magazine et promettrait des catégories qui n'existent pas. Rangée à côté de la
+ * date, la figure distingue les articles à l'œil sans ajouter une seule ligne au rythme de
+ * la liste. Elle reste un décor `aria-hidden` : le titre cliquable dit tout.
  */
 export function ArticleCard({ article, headingLevel = 'h2' }: ArticleCardProps) {
   const Heading = headingLevel
@@ -27,6 +34,7 @@ export function ArticleCard({ article, headingLevel = 'h2' }: ArticleCardProps) 
   return (
     <article className={styles.carte}>
       <p className={styles.date}>
+        <ArticleFigure figure={article.figure} />
         <time dateTime={article.datePublication}>{formatDateFr(article.datePublication)}</time>
       </p>
 

--- a/src/@vitrine/components/ArticleFigure/article-figure.module.css
+++ b/src/@vitrine/components/ArticleFigure/article-figure.module.css
@@ -1,0 +1,51 @@
+/* article-figure.module.css — la figure d'un article.
+ *
+ * Aucune teinte n'est nommée ici, et c'est la même mécanique que `pole-glyph.module.css` :
+ * le tracé est en `currentColor`, et `color: var(--accent)` laisse le contexte décider. Le
+ * blog n'est sous aucun `data-pole`, donc `--accent` y vaut le cuivre de la racine — la
+ * teinte de la maison. Le jour où un article serait rattaché à un pôle, la figure prendrait
+ * sa teinte sans qu'une ligne d'ici change. */
+
+.figure {
+  flex: none;
+  /* Un seul jeton pour toute la série, redéfini localement par la fiche d'article — c'est
+     déjà la convention de `--decalage-ancre` sur les pages de pôle. La hauteur suit le
+     `viewBox` (48 × 32) : la poser ici la ferait diverger du tracé à la première retouche. */
+  width: var(--taille-figure-article);
+  height: auto;
+  color: var(--accent);
+  /* Le tracé n'est PAS du texte : c'est un décor, il tombe sous le seuil non-texte de 3:1,
+     comme les filets et les arêtes du site. `--accent` reste malgré tout au-dessus de 4.5:1
+     dans les deux thèmes hors `data-pole` — la marge est prise, pas dépensée. */
+  opacity: 0.9;
+}
+
+/* La convention des marques de pôle, reprise telle quelle : ce qui est écarté est tireté.
+   Elle vaut ici pour le serveur applicatif que l'export statique supprime et pour l'ordre
+   inverse du test — deux choses écartées, un seul traitement de trait. */
+.ecarte {
+  stroke-dasharray: 2.6 2.6;
+  opacity: 0.65;
+}
+
+/* La croix qui ferme une voie. Elle porte l'atténuation de `.ecarte`, jamais son tiretage —
+   et c'est une correction de lecture, pas une coquetterie : ses deux branches mesurent 5,1
+   unités, soit à peine deux tirets. Tiretées, elles ne rendent que leur amorce, et la croix
+   se lit comme une coche, c'est-à-dire l'exact contraire de ce qu'elle dit. */
+.ferme {
+  opacity: 0.65;
+}
+
+/* L'assise de l'appui : le seul trait plus épais de la série, exactement comme le socle de
+   la marque « ingénierie web ». Une assise qui aurait l'épaisseur de ce qu'elle porte ne se
+   lirait pas comme une assise. */
+.assise {
+  stroke-width: 2.4;
+}
+
+/* La trame de la mesure, sous l'assise. Le point est un tracé de longueur nulle à bout rond,
+   donc son diamètre EST son épaisseur — la même astuce que la marque de la donnée, et la
+   seule façon d'obtenir des points sans autant d'éléments `circle`. */
+.point {
+  stroke-width: 2.6;
+}

--- a/src/@vitrine/components/ArticleFigure/index.tsx
+++ b/src/@vitrine/components/ArticleFigure/index.tsx
@@ -1,0 +1,141 @@
+// ArticleFigure/index.tsx — jeromemarichez-fr
+// Une figure par article. Construite, jamais trouvée — comme les marques de pôle.
+//
+// Le site n'a AUCUNE image matricielle : quatre SVG en tout, et `next/image` est écarté
+// délibérément (voir `@vitrine/components/CertificationList`). Une illustration d'article
+// n'allait pas en introduire la première : ces figures sont du SVG rendu au serveur, elles
+// pèsent quelques centaines d'octets dans le document, et le budget Lighthouse — qui ne
+// tient qu'à un point — n'en sait rien.
+//
+// ## Ce que ces figures ont le droit de dire
+//
+// Exactement ce que `PoleGlyph` s'autorise, et rien de plus : **rien qui simule une
+// donnée**. Le site vend la mesure ; un pictogramme qui mimerait un graphique — une courbe
+// qui monte, des barres qui progressent — afficherait un chiffre inventé, ce que les règles
+// de véracité du CLAUDE.md interdisent. Ce sont des FIGURES DE STRUCTURE : elles dessinent
+// la forme de l'arbitrage dont l'article parle, jamais son résultat.
+//
+// ## La grammaire est celle des marques de pôle
+//
+// Elle est reprise trait pour trait, et c'est ce qui fait que le blog appartient au même
+// site que l'accueil : trait plein pour ce qui est retenu, **trait tireté pour ce qui est
+// écarté**, croix pour une voie fermée, point plein pour un aboutissement, trait plus
+// épais pour une assise. Un lecteur qui a vu les quatre marques lit ces trois figures sans
+// qu'on lui explique rien.
+//
+// Le registre, lui, diffère : une marque de pôle est carrée (32 × 32), une figure d'article
+// est **couchée** (48 × 32). Une page de pôle vend, un article raconte — et une figure large
+// se pose au-dessus d'un texte sans prétendre à l'insigne.
+//
+// La couleur n'est écrite nulle part ici : le tracé est en `currentColor`, et le module pose
+// `color: var(--accent)`. Le blog n'est sous aucun `data-pole`, donc `--accent` y vaut le
+// cuivre — la teinte de la maison, exactement ce que doit prendre un contenu qui n'appartient
+// à aucun pôle.
+
+import type { ArticleFigureId } from '@/interfaces/types'
+import styles from './article-figure.module.css'
+
+interface ArticleFigureProps {
+  figure: ArticleFigureId
+}
+
+/**
+ * La borne — « Pourquoi ce site est un export statique ».
+ *
+ * Trois plaques écrites, un aboutissement, puis une ligne que rien ne franchit ; au-delà,
+ * tireté, ce qui n'existe plus : le serveur applicatif. C'est l'article en une forme —
+ * le build produit un dossier, et ce qui tournait derrière a disparu, pas été désactivé.
+ */
+function Borne() {
+  return (
+    <>
+      <path d="M6 10h13M6 16h13M6 22h13" />
+      <circle cx="22.4" cy="16" fill="currentColor" r="2.4" stroke="none" />
+      <path d="M28 4v24" />
+      <path className={styles.ecarte} d="M33 10h9v12h-9z" />
+    </>
+  )
+}
+
+/**
+ * L'antériorité — « Le test avant le code, même avec un agent ».
+ *
+ * Un axe, deux temps : le point plein est posé le premier, la boîte ouverte vient après et
+ * se remplit. Dessous, tiretée et fermée d'une croix, la voie inverse — écrire le test
+ * après. La figure ne dit pas qu'écrire le test après est impossible, elle dit qu'ici c'est
+ * écarté, ce qui est exactement la position de l'article.
+ */
+function Anteriorite() {
+  return (
+    <>
+      <path d="M4 12h26" />
+      <circle cx="13" cy="12" fill="currentColor" r="2.8" stroke="none" />
+      <path d="M30 7h10v10H30z" />
+      <path className={styles.ecarte} d="M30 20c-3 4-8 5-13 4" />
+      <path className={styles.ferme} d="M11.5 21.9l3.6 3.6M15.1 21.9l-3.6 3.6" />
+    </>
+  )
+}
+
+/**
+ * L'appui — « Mesurer avant d'arbitrer ».
+ *
+ * Un fléau **strictement horizontal**, deux plateaux identiques, et la décision au sommet du
+ * mât ; en dessous, l'assise épaisse et la trame de points qui la porte. Le fléau ne penche
+ * d'aucun côté, et ce n'est pas un détail de dessin : une balance inclinée afficherait un
+ * verdict, c'est-à-dire un chiffre que le site n'a pas. Ce qui est dessiné, c'est qu'un
+ * arbitrage repose sur une collecte — jamais lequel des deux plateaux l'emporte.
+ */
+function Appui() {
+  return (
+    <>
+      <path d="M8 9h32" />
+      <path d="M8 9v3M40 9v3" />
+      <path d="M4 12h8M36 12h8" />
+      <path d="M24 6.5v15" />
+      <circle cx="24" cy="5" fill="currentColor" r="2.4" stroke="none" />
+      <path className={styles.assise} d="M8 22h32" />
+      <path className={styles.point} d="M12 27v.01M24 27v.01M36 27v.01" />
+    </>
+  )
+}
+
+const TRACES: Record<ArticleFigureId, () => React.JSX.Element> = {
+  borne: Borne,
+  anteriorite: Anteriorite,
+  appui: Appui,
+}
+
+/**
+ * Décor, jamais information.
+ *
+ * La figure est `aria-hidden` et ne porte rien que l'article ne dise déjà en toutes lettres,
+ * juste à côté : son titre et son chapô sont du texte. Un lecteur d'écran ne perd donc rien
+ * à ne pas la rencontrer, et la couleur n'est nulle part le seul porteur d'information
+ * (WCAG 1.1.1 et 1.4.1). C'est aussi ce qui autorise à la répéter à l'identique sur la carte
+ * de la liste : un décor peut se répéter, une information non.
+ *
+ * Le dimensionnement est CSS, et il peut l'être : cette figure est toujours **racine dans du
+ * HTML**, jamais imbriquée dans un autre `<svg>` — le cas où seuls les attributs `width` et
+ * `height` sont honorés (issue #102, `docs/frontend-practices.md`). Elle n'a donc pas la prop
+ * `taille` de `PoleGlyph`, et n'en aura pas tant qu'elle ne sera pas imbriquée.
+ */
+export function ArticleFigure({ figure }: ArticleFigureProps) {
+  const Trace = TRACES[figure]
+
+  return (
+    <svg
+      aria-hidden="true"
+      className={styles.figure}
+      fill="none"
+      focusable="false"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="1.6"
+      viewBox="0 0 48 32"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <Trace />
+    </svg>
+  )
+}

--- a/src/@vitrine/components/ArticleSource/article-source.module.css
+++ b/src/@vitrine/components/ArticleSource/article-source.module.css
@@ -1,0 +1,43 @@
+/* article-source.module.css — la note de publication d'origine.
+ * Registre de note : la mention referme l'article, elle ne le relance pas. */
+
+.source {
+  max-width: var(--mesure-texte);
+  font-size: var(--t-note);
+  line-height: 1.55;
+  color: var(--encre-douce);
+}
+
+/* Le lien garde son soulignement — c'est le premier des trois porteurs du caractère externe,
+   et le seul qui tienne encore quand les images sont désactivées. Rien n'est déclaré ici sur
+   la couleur : `globals.css` pose déjà `--accent` sur tout `a`. */
+.lien {
+  white-space: nowrap;
+}
+
+/* La flèche sortante suit le texte du lien à la même chasse, jamais à une taille en pixels :
+   dimensionnée en `em`, elle grandit avec le texte si le visiteur agrandit la page. */
+.marque {
+  /* `globals.css` pose `display: block` sur tout `svg` — la règle qui empêche l'espace
+     fantôme sous une image. Ici elle poussait la flèche à la ligne, seule sous le mot
+     qu'elle accompagne : c'est le seul `svg` du site à vivre DANS une ligne de texte, et il
+     redéclare donc son display plutôt que d'affaiblir la règle globale pour les autres. */
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  margin-inline-start: 0.25em;
+  vertical-align: -0.08em;
+}
+
+/* Retiré du flux visuel, jamais du flux d'accessibilité : `display: none` et
+   `visibility: hidden` sortiraient aussi ce texte de l'arbre lu par les lecteurs d'écran, et
+   l'annonce « nouvel onglet » se perdrait — précisément ce qu'on veut dire ici. La recette
+   est celle du substitut de la scène des dalles (`chain-canvas.module.css`). */
+.horsEcran {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/src/@vitrine/components/ArticleSource/index.tsx
+++ b/src/@vitrine/components/ArticleSource/index.tsx
@@ -1,0 +1,82 @@
+// ArticleSource/index.tsx — jeromemarichez-fr
+// « Ce texte a d'abord paru ailleurs » — la seule mention de republication du site.
+//
+// Un article du blog peut reprendre un post déjà publié sur un réseau. Le taire reviendrait
+// à s'attribuer la primeur d'un texte republié, ce qui est exactement le genre d'affirmation
+// que les règles de véracité du CLAUDE.md interdisent.
+//
+// **Aucune URL n'est devinée.** Les trois articles publiés n'ont pas de post d'origine connu
+// et ne portent donc pas de source : ce composant n'est alors jamais rendu, et la fiche n'a
+// ni ligne vide ni filet orphelin. C'est la même règle que les justificatifs de certification
+// — tant que l'adresse n'a pas été fournie par Jérôme MARICHEZ, rien n'est publié.
+
+import type { IArticleSource } from '@/interfaces/IArticleSource'
+import type { ArticleSourceReseau } from '@/interfaces/types'
+import styles from './article-source.module.css'
+
+interface ArticleSourceProps {
+  source: IArticleSource
+}
+
+/**
+ * Le nom du réseau, écrit une fois pour tout le site.
+ *
+ * Recopier « LinkedIn » dans chaque article aurait suffi à voir apparaître un « Linkedin »
+ * au troisième — et une capitale fausse sur un nom de marque se lit comme de la négligence.
+ */
+const LIBELLES_RESEAU: Record<ArticleSourceReseau, string> = {
+  linkedin: 'LinkedIn',
+}
+
+/**
+ * La marque du lien sortant : une flèche qui quitte son cadre.
+ *
+ * Elle est dessinée plutôt qu'écrite en caractère (« ↗ ») pour deux raisons : le glyphe
+ * manque à plusieurs polices système et s'y remplace par un rectangle, et son dessin varie
+ * assez d'une fonte à l'autre pour ne plus faire série avec les figures du site. Tracé en
+ * `currentColor`, elle prend donc la couleur du lien sans qu'un module la nomme.
+ */
+function MarqueExterne() {
+  return (
+    <svg
+      aria-hidden="true"
+      className={styles.marque}
+      fill="none"
+      focusable="false"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="1.6"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M7 3H3v10h10V9" />
+      <path d="M9.5 2.5H14v4.5M14 2.5L7.5 9" />
+    </svg>
+  )
+}
+
+/**
+ * La publication d'origine, en note de fin d'article.
+ *
+ * **Le caractère externe du lien ne repose pas sur la couleur** (WCAG 1.4.1) : il est porté
+ * par trois choses qui survivent chacune à la disparition des deux autres — le soulignement
+ * du lien, la flèche sortante dessinée à sa suite, et le texte « nouvel onglet » énoncé aux
+ * technologies d'assistance mais retiré du flux visuel, où la flèche le dit déjà.
+ *
+ * `rel="noopener noreferrer"` : `noopener` interdit à la page ouverte de reprendre la main
+ * sur celle-ci par `window.opener`, `noreferrer` lui retire l'adresse d'où vient le visiteur.
+ * Les deux sont posées à l'identique sur le lien de justificatif d'une certification — un
+ * lien sortant du site est traité pareil partout, ou il finit par ne l'être nulle part.
+ */
+export function ArticleSource({ source }: ArticleSourceProps) {
+  return (
+    <p className={styles.source}>
+      Ce texte a d’abord paru sur{' '}
+      <a className={styles.lien} href={source.url} rel="noopener noreferrer" target="_blank">
+        {LIBELLES_RESEAU[source.reseau]}
+        <MarqueExterne />
+        <span className={styles.horsEcran}> (nouvel onglet)</span>
+      </a>
+    </p>
+  )
+}

--- a/src/@vitrine/contenu/blog/export-statique.ts
+++ b/src/@vitrine/contenu/blog/export-statique.ts
@@ -22,6 +22,9 @@ export const ARTICLE_EXPORT_STATIQUE: IArticle = {
       'ISR, formulaire), ce qu’il ouvre, et quand il ne faut pas le choisir.',
   },
   datePublication: '2026-08-21',
+  // La figure « borne » : ce qui est produit s'arrête à une ligne, et au-delà — tireté —
+  // le serveur applicatif qui n'existe plus. C'est le sujet de l'article, en une forme.
+  figure: 'borne',
   sections: [
     {
       id: 'ce-que-ca-ferme',

--- a/src/@vitrine/contenu/blog/mesurer-avant-arbitrer.ts
+++ b/src/@vitrine/contenu/blog/mesurer-avant-arbitrer.ts
@@ -23,6 +23,9 @@ export const ARTICLE_MESURER_AVANT_ARBITRER: IArticle = {
       'dans le code, consentement conforme, et décisions prises sur un chiffre tenable.',
   },
   datePublication: '2026-08-14',
+  // La figure « appui » : un arbitrage en équilibre, porté par une assise de mesure. Le fléau
+  // est strictement horizontal — une balance qui penche afficherait un verdict, donc un chiffre.
+  figure: 'appui',
   sections: [
     {
       id: 'la-collecte-avant-le-tableau-de-bord',

--- a/src/@vitrine/contenu/blog/test-avant-code.ts
+++ b/src/@vitrine/contenu/blog/test-avant-code.ts
@@ -22,6 +22,9 @@ export const ARTICLE_TEST_AVANT_CODE: IArticle = {
       'avant, ce que les tests de mutation vérifient, et ce que ça change côté client.',
   },
   datePublication: '2026-08-18',
+  // La figure « antériorité » : deux temps sur un axe, et le sens inverse fermé d'une croix.
+  // Elle dit l'ordre, jamais un résultat — aucune mesure de qualité n'y est affichée.
+  figure: 'anteriorite',
   sections: [
     {
       id: 'le-volume-est-le-probleme',

--- a/src/@vitrine/views/ArticleView/article-view.module.css
+++ b/src/@vitrine/views/ArticleView/article-view.module.css
@@ -21,6 +21,12 @@
   display: flex;
   flex-direction: column;
   gap: var(--e-3);
+  /* Le registre de FICHE pour la figure de l'article : elle ouvre la page, elle a donc le
+     droit d'occuper de la place. Le jeton est redéfini ici et non sur `.page`, parce que la
+     même page porte des cartes d'articles liés dont les figures doivent, elles, rester au
+     registre de liste. La figure reste bornée sous la mesure de texte : au-delà, elle
+     concurrencerait le titre au lieu de l'annoncer. */
+  --taille-figure-article: clamp(6.5rem, 22vw, 9rem);
 }
 
 .date {

--- a/src/@vitrine/views/ArticleView/index.tsx
+++ b/src/@vitrine/views/ArticleView/index.tsx
@@ -8,6 +8,8 @@ import type { IArticle } from '@/interfaces/IArticle'
 import type { IBlogIndex } from '@/interfaces/IBlogIndex'
 import { formatDateFr } from '@/utils/format-date'
 import { ArticleCard } from '../../components/ArticleCard'
+import { ArticleFigure } from '../../components/ArticleFigure'
+import { ArticleSource } from '../../components/ArticleSource'
 import styles from './article-view.module.css'
 
 interface ArticleViewProps {
@@ -36,6 +38,7 @@ export function ArticleView({ article, index, autres }: ArticleViewProps) {
               { nom: article.titre, route: toArticleRoute(article.slug) },
             ]}
           />
+          <ArticleFigure figure={article.figure} />
           <p className={styles.date}>
             <time dateTime={article.datePublication}>{formatDateFr(article.datePublication)}</time>
           </p>
@@ -62,6 +65,10 @@ export function ArticleView({ article, index, autres }: ArticleViewProps) {
             </section>
           ))}
         </div>
+
+        {/* Rien n'est rendu quand la source est absente : c'est le cas des trois articles
+            publiés, et une note « publié nulle part ailleurs » n'aurait aucun sens. */}
+        {article.source ? <ArticleSource source={article.source} /> : null}
       </article>
 
       {autres.length > 0 ? (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,6 +132,12 @@
      éditorial sur sa carte. Un seul jeton pour les six : elles forment une série, et une
      série dont les tailles divergent n'en est plus une. */
   --taille-glyphe: 2.25rem;
+  /* Largeur d'une figure d'article. Sa hauteur suit son `viewBox` (48 × 32) et n'a donc
+     pas de jeton : deux valeurs à tenir d'accord divergent à la première retouche. La
+     valeur posée ici est celle du registre de LISTE, où la figure reste une annotation à
+     côté de la date ; la fiche d'article redéfinit le jeton chez elle, comme les pages de
+     pôle redéfinissent `--decalage-ancre`. */
+  --taille-figure-article: 3rem;
 
   /* — Repères d'empilement collant — */
   /* Hauteur nominale de l'en-tête, en un seul endroit : la barre de pôle s'y accroche,

--- a/src/interfaces/IArticle.ts
+++ b/src/interfaces/IArticle.ts
@@ -7,7 +7,9 @@
 // close au build par `generateStaticParams`, pas à un schéma.
 
 import type { IArticleSection } from './IArticleSection'
+import type { IArticleSource } from './IArticleSource'
 import type { IPageMeta } from './IEditorialPage'
+import type { ArticleFigureId } from './types'
 
 /**
  * Un article publié.
@@ -35,6 +37,29 @@ export interface IArticle {
    * correction. Une révision de forme (coquille) ne la déplace pas.
    */
   dateRevision?: string
+  /**
+   * La figure qui illustre l'article. Obligatoire, et c'est délibéré.
+   *
+   * Rendue à l'identique sur la fiche et sur la carte de la liste, elle est ce qui
+   * distingue un article d'un autre à l'œil. La laisser facultative aurait produit une
+   * liste où certains articles ont une figure et d'autres pas, c'est-à-dire un rythme
+   * cassé sans qu'aucune information ne le justifie.
+   *
+   * Ce n'est **pas** un chemin de fichier : le site ne sert aucune image matricielle, et
+   * cette valeur désigne un tracé SVG rendu au serveur (voir `ArticleFigureId`). Deux
+   * articles peuvent partager une figure — rien ne l'interdit ici — mais les trois
+   * articles publiés en ont chacun une, sans quoi la figure cesserait de distinguer.
+   */
+  figure: ArticleFigureId
+  /**
+   * Publication d'origine de l'article, quand il en a une.
+   *
+   * Optionnelle, et elle le restera : les trois premiers articles ont été écrits pour ce
+   * site et n'ont pas de post d'origine. **Une URL absente ne se devine pas** — un
+   * article sans source fournie se publie sans source, et la fiche n'affiche alors
+   * simplement rien. Voir `IArticleSource`.
+   */
+  source?: IArticleSource
   /** Corps de l'article, découpé en sections titrées. */
   sections: IArticleSection[]
 }

--- a/src/interfaces/IArticleSource.ts
+++ b/src/interfaces/IArticleSource.ts
@@ -1,0 +1,32 @@
+// IArticleSource.ts — jeromemarichez-fr
+// La publication d'origine d'un article, quand il en a une.
+//
+// Un article du blog peut reprendre un texte d'abord paru ailleurs — un post LinkedIn.
+// Le dire est une exigence d'honnêteté élémentaire : sans ce champ, le site s'attribuait
+// implicitement la primeur d'un contenu qu'il republie.
+
+import type { ArticleSourceReseau } from './types'
+
+/**
+ * Le post d'origine d'un article.
+ *
+ * **L'URL ne s'invente ni ne s'approxime.** C'est la règle déjà appliquée aux
+ * justificatifs de certification dans le `CLAUDE.md`, et elle vaut ici à l'identique :
+ * un article dont l'adresse d'origine n'a pas été fournie par Jérôme MARICHEZ se publie
+ * **sans source**, jamais avec un lien deviné. C'est la raison d'être du caractère
+ * optionnel du champ `source` d'`IArticle` — pas une commodité de saisie.
+ *
+ * Aucun libellé n'est porté ici : il se déduit de `reseau` au rendu, pour que le nom du
+ * réseau soit écrit une fois pour tout le site.
+ */
+export interface IArticleSource {
+  /** Le réseau où le texte a d'abord paru. Décide du libellé affiché. */
+  reseau: ArticleSourceReseau
+  /**
+   * URL absolue du post d'origine, telle que fournie.
+   *
+   * Elle sort du site : le rendu lui pose `rel="noopener noreferrer"` et signale son
+   * caractère externe autrement que par la couleur (WCAG 1.4.1).
+   */
+  url: string
+}

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -40,3 +40,29 @@ export type PoleTemps = 1 | 2 | 3
  * offre de plus, alors qu'il décrit la façon de tenir les autres.
  */
 export type SectionKind = 'pole' | 'chapitre' | 'charniere' | 'fil' | 'preuves'
+
+/**
+ * La figure qui illustre un article — un tracé nommé, jamais un fichier.
+ *
+ * Le site ne sert aucune image matricielle, et une illustration d'article n'allait pas
+ * en introduire la première : chaque valeur de cette union désigne un tracé SVG rendu au
+ * serveur par `@vitrine/components/ArticleFigure`. L'union est close, donc un article ne
+ * peut pas réclamer une figure qui n'existe pas — le compilateur le dit avant le build.
+ *
+ * Les trois noms disent la STRUCTURE dessinée, pas le sujet de l'article : c'est la même
+ * règle que les marques de pôle, dont aucune ne simule une donnée chiffrée.
+ * `borne`        : ce qui est produit s'arrête à une ligne, et au-delà rien ne tourne.
+ * `anteriorite`  : deux temps sur un axe, et le sens inverse écarté.
+ * `appui`        : une décision en équilibre, portée par une assise mesurée.
+ */
+export type ArticleFigureId = 'borne' | 'anteriorite' | 'appui'
+
+/**
+ * Le réseau où un article a d'abord paru.
+ *
+ * Union close plutôt que texte libre : le libellé affiché (« LinkedIn », capitale et
+ * casse comprises) se déduit de cette valeur au lieu d'être recopié dans chaque article,
+ * où il finirait par varier. Un autre réseau s'ajoute ici, avec son libellé, jamais dans
+ * un contenu.
+ */
+export type ArticleSourceReseau = 'linkedin'

--- a/tests/fixtures/article.fixture.json
+++ b/tests/fixtures/article.fixture.json
@@ -1,10 +1,12 @@
 {
-  "_lisezmoi": "Jeu de données d'articles (jeromemarichez-fr) — PAS un mock. Les vrais services (find-article, buildSitemapEntries, buildArticleSchema, formatDateFr) tournent sur ces articles réalistes ; aucune doublure de module n'est utilisée. Voir docs/testing.md et docs/data-model.md.",
+  "_lisezmoi": "Jeu de données d'articles (jeromemarichez-fr) — PAS un mock. Les vrais services (find-article, buildSitemapEntries, buildArticleSchema, formatDateFr) et les vrais composants (ArticleCard, ArticleFigure, ArticleSource, ArticleView) tournent sur ces articles réalistes ; aucune doublure de module n'est utilisée. Voir docs/testing.md et docs/data-model.md.",
   "_cas": {
     "articles": "Trois articles dans un ordre de déclaration volontairement différent de l'ordre chronologique : le plus récent est déclaré en deuxième position. Un tri absent ou inversé se voit immédiatement.",
     "articleRevise": "Porte une dateRevision postérieure à sa publication — c'est la date que le sitemap et dateModified doivent publier, alors que le tri de la liste doit continuer à s'appuyer sur datePublication.",
     "articleSeul": "Liste réduite à un article : findArticle doit rendre un tableau 'autres' vide, et la page ne propose alors aucune suite de lecture.",
-    "slugInconnu": "Slug absent de la liste : findArticle doit lever, jamais rendre undefined."
+    "slugInconnu": "Slug absent de la liste : findArticle doit lever, jamais rendre undefined.",
+    "figures": "Les trois articles portent trois figures distinctes — c'est la règle appliquée au blog réel. Un rendu qui servirait toujours le même tracé, ou qui retomberait sur un tracé par défaut, se voit sur cette liste.",
+    "articleAvecSource": "Article portant une source externe : la fiche doit afficher la note de republication, son lien en rel=\"noopener noreferrer\" et sa marque de lien sortant. Les trois articles de « articles » n'en ont AUCUN — c'est le cas nominal du site, et il doit rester silencieux. L'URL est en .invalid, un domaine réservé qui ne résoudra jamais : aucune adresse réelle n'est inventée dans un jeu de données, pas plus que dans le contenu publié."
   },
   "articles": [
     {
@@ -16,6 +18,7 @@
         "description": "Article de jeu de données, publié le 3 mars 2026."
       },
       "datePublication": "2026-03-03",
+      "figure": "borne",
       "sections": [
         {
           "id": "une-section",
@@ -33,6 +36,7 @@
         "description": "Article de jeu de données, publié le 1er septembre 2026."
       },
       "datePublication": "2026-09-01",
+      "figure": "anteriorite",
       "sections": [
         {
           "id": "une-section",
@@ -56,6 +60,7 @@
       },
       "datePublication": "2026-06-12",
       "dateRevision": "2026-08-20",
+      "figure": "appui",
       "sections": [
         {
           "id": "une-section",
@@ -75,6 +80,7 @@
         "description": "Article de jeu de données, seul de sa liste."
       },
       "datePublication": "2026-01-15",
+      "figure": "borne",
       "sections": [
         {
           "id": "une-section",
@@ -84,10 +90,41 @@
       ]
     }
   ],
+  "articleAvecSource": {
+    "slug": "article-republie",
+    "titre": "Article republié",
+    "chapo": "Repris d'un post publié ailleurs : la fiche doit le dire, avec un lien sortant.",
+    "meta": {
+      "title": "Article republié",
+      "description": "Article de jeu de données portant une source externe."
+    },
+    "datePublication": "2026-07-04",
+    "figure": "anteriorite",
+    "source": {
+      "reseau": "linkedin",
+      "url": "https://exemple.invalid/post-d-origine"
+    },
+    "sections": [
+      {
+        "id": "une-section",
+        "titre": "Une section",
+        "paragraphes": ["Un paragraphe."]
+      }
+    ]
+  },
   "slugInconnu": "article-qui-n-existe-pas",
   "datesAFormater": [
-    { "iso": "2026-08-21", "attendu": "21 août 2026" },
-    { "iso": "2026-01-01", "attendu": "1 janvier 2026" },
-    { "iso": "2026-12-31", "attendu": "31 décembre 2026" }
+    {
+      "iso": "2026-08-21",
+      "attendu": "21 août 2026"
+    },
+    {
+      "iso": "2026-01-01",
+      "attendu": "1 janvier 2026"
+    },
+    {
+      "iso": "2026-12-31",
+      "attendu": "31 décembre 2026"
+    }
   ]
 }


### PR DESCRIPTION
Répond à l'issue #108 (`Refs #108` — la PR vise `dev`, la branche par défaut est `main`, la référence ne fermera donc rien toute seule).

## Le modèle

`IArticle` gagne deux champs, documentés dans le style des commentaires existants :

| Champ | Type | Obligatoire |
|---|---|---|
| `figure` | `ArticleFigureId` (`'borne' \| 'anteriorite' \| 'appui'`) | **oui** |
| `source` | `IArticleSource` (`{ reseau, url }`) | non |

- **`figure` n'est pas un chemin de fichier**, c'est une valeur d'union close. Le site ne sert aucune image matricielle et n'en gagne pas une ici : la figure est du SVG rendu au serveur. Un article ne peut pas réclamer une figure inexistante — le compilateur le dit avant le build.
- **`figure` est obligatoire, délibérément.** Facultative, elle aurait produit une liste où certains articles ont une figure et d'autres pas : un rythme cassé sans qu'aucune information ne le justifie.
- **`source` est optionnelle et le restera.** Une URL ne s'invente ni ne s'approxime — c'est déjà la règle des justificatifs de certification. **Aucune URL LinkedIn n'a été inventée** : les trois articles publiés se publient sans source, et la fiche n'affiche alors ni ligne vide ni filet orphelin.

## Les trois figures

Grammaire reprise trait pour trait des marques de pôle : trait plein pour ce qui est retenu, **tireté pour ce qui est écarté**, croix pour une voie fermée, point plein pour un aboutissement, trait épais pour une assise.

| Article | Figure | Ce qu'elle dessine |
|---|---|---|
| Pourquoi ce site est un export statique | `borne` | Trois plaques écrites, un aboutissement, une ligne que rien ne franchit ; au-delà, tireté, le serveur applicatif qui n'existe plus |
| Le test avant le code, même avec un agent | `anteriorite` | Deux temps sur un axe — le point posé d'abord, la boîte ouverte ensuite ; dessous, tiretée et fermée d'une croix, la voie inverse |
| Mesurer avant d'arbitrer | `appui` | Un fléau à l'horizontale et deux plateaux identiques, la décision au sommet du mât, portés par une assise et sa trame de mesure |

**Aucune ne simule une donnée.** Le cas le plus tendu est la balance : son **fléau est strictement horizontal**, et ce n'est pas un détail de dessin — une balance qui penche affiche un verdict, c'est-à-dire un chiffre que le site n'a pas.

**Un écart assumé avec `PoleGlyph` :** la croix n'est pas tiretée. Ses branches font 5,1 unités, soit à peine deux tirets ; tiretée, elle ne rend que son amorce et **se lit comme une coche** — l'exact contraire de ce qu'elle dit. Constaté au rendu, corrigé par une classe locale (`.ferme`, opacité seule), sans toucher à `PoleGlyph`.

## Le rendu

- **Fiche** : la figure ouvre l'en-tête, au registre `clamp(6.5rem, 22vw, 9rem)`.
- **Carte de la liste** : la figure **tient la ligne de la date**, jamais au-dessus. La liste du blog est « une liste, pas une grille » : une vignette pleine largeur en ferait un magazine et promettrait des catégories qui n'existent pas. Le rythme ne bouge pas d'un pixel.
- Un seul jeton, `--taille-figure-article`, redéfini localement par la fiche — le geste de `--decalage-ancre` sur les pages de pôle. La hauteur suit le `viewBox` et n'a pas de jeton.
- **Aucune couleur écrite en dur** : tracé en `currentColor`, module en `color: var(--accent)`. Le blog n'est sous aucun `data-pole`, donc le cuivre de la racine. Les deux thèmes suivent par construction.
- La figure est **`aria-hidden`** et ne porte rien que le titre et le chapô ne disent déjà (WCAG 1.1.1 et 1.4.1).

## Le lien de source

Le **caractère externe ne repose jamais sur la seule couleur** (WCAG 1.4.1) — trois porteurs, chacun survivant à la disparition des deux autres : le soulignement du lien, une flèche sortante **dessinée** en `currentColor`, et « (nouvel onglet) » retiré du flux visuel mais lu par les technologies d'assistance. `rel="noopener noreferrer"`, comme le lien de justificatif d'une certification.

La flèche redéclare `display: inline-block` : c'est le seul `svg` du site à vivre dans une ligne de texte, et le `display: block` global de `globals.css` la poussait seule à la ligne (constaté au rendu).

## JSON-LD

`buildArticleSchema` ne déclare **toujours pas** de champ `image`, et la raison a changé : le site sert désormais une illustration, mais elle est écrite dans le document — aucune ressource à servir, donc aucune URL à déclarer. Le commentaire du fichier, devenu faux, a été réécrit. Rien n'est ajouté pour `source` non plus : aucun article publié n'en porte, et trancher entre `sameAs` et `isBasedOn` se fera devant un cas réel.

## Vérifié

- `make lint` (Biome + limite 300 lignes) ✓, `make type-check` ✓, `make test` ✓, `npx next build` ✓
- Rendu réel sur `npx next dev -p 3040` : `/blog/` et les trois fiches, **thèmes clair et sombre** tous les deux.
- **Budgets exécutables** (`node scripts/budgets.mjs`), export statique servi, mobile bridé :

| Page | Perf | A11y | Bonnes prat. | SEO |
|---|---|---|---|---|
| accueil | 96 | 100 | 100 | 100 |
| pôle | 97 | 100 | 100 | 100 |
| **blog** | **97** | **100** | **100** | **100** |
| **article** | **97** | **100** | **100** | **100** |
| réalisations | 97 | 100 | 100 | 100 |
| réalisation | 99 | 100 | 100 | 100 |

axe-core : **0 violation** sur les cinq pages contrôlées.

**`/blog/` entre dans les pages mesurées** (`scripts/budgets/pages.mjs`) : c'est le gabarit que les figures changent le plus, et un gabarit non mesuré est un gabarit non protégé. **Aucun seuil n'est touché** — c'est un ajout de couverture, pas un assouplissement.

## Jeu de données

`tests/fixtures/article.fixture.json` reçoit les figures (trois distinctes) et un cas `articleAvecSource`. Son URL est en `.invalid`, un domaine réservé qui ne résoudra jamais : aucune adresse réelle n'est inventée dans un jeu de données, pas plus que dans le contenu publié.

**Aucun fichier de test n'a été écrit** — les intentions sont proposées à Jérôme MARICHEZ dans le rapport de la tâche.

## Hors périmètre

Les deux nouveaux articles qui utiliseront ces champs font l'objet de l'issue #109 : rien n'a été écrit ici.
