### PR TITLE
feat: chaque pole pose son lavis pastel sur le fond papier

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -72,6 +72,52 @@ Restent hors de portée d'axe, et donc à la charge de l'audit manuel :
   `--accent-vif` y est déclaré **non-texte uniquement**. axe ne peut pas connaître cette
   intention.
 
+### Le lavis de pôle — contrastes relevés
+
+Depuis l'issue #104, le fond papier porte un **lavis pastel de la teinte du pôle** sous
+tout bloc qui parle d'un pôle : les quatre pages `/services/<pole>/` sur toute leur
+hauteur, les quatre portes de l'accueil. Le texte du site est posé dessus, donc le fond de
+référence n'est plus `--fond` : c'est la couleur **composée** papier + lavis + grain +
+trame. Le détail du mécanisme et le calcul analytique sont dans
+[`design.md`](./design.md) ; ce qui suit est la **lecture au pixel du rendu servi**, dans
+les deux thèmes, sur le lavis le plus dense de chaque pôle.
+
+| Thème | Surface | `--encre-douce` (texte) | `--encre` (texte) |
+|---|---|---|---|
+| clair | les quatre portes de l'accueil | **5.59 → 5.70:1** | 12.48 → 12.72:1 |
+| clair | les quatre pages de pôle | **5.85 → 5.86:1** | 13.06 → 13.09:1 |
+| sombre | les quatre portes de l'accueil | **6.49 → 6.71:1** | 13.48 → 13.92:1 |
+| sombre | les quatre pages de pôle | **6.74 → 6.80:1** | 14.00 → 14.12:1 |
+
+Éléments **non-texte** (`--accent-vif` : filets, arêtes, flèches), pire cas calculé sur le
+fond le plus défavorable du dégradé d'atelier :
+
+| Thème | Pôle le plus serré | `--accent-vif` sur le lavis | Seuil |
+|---|---|---|---|
+| clair | data | **3.02:1** | 3:1 (WCAG 1.4.11) |
+| clair | SEA & UX | 3.03:1 | 3:1 |
+| sombre | IA | 7.79:1 | 3:1 |
+
+C'est cette marge de 0,02 point qui **fixe la densité du lavis**, et non un choix
+d'apparence : à 9 % de teinte, `--pole-data-vif` passe sous 3:1. Toute augmentation
+future du lavis demande de rouvrir d'abord la palette des `-vif`.
+
+Trois points relevés, à garder en tête :
+
+- le **verre** (`GlassSurface`) floute ce lavis : un fond plus coloré change ce qu'il
+  rend. Contrôlé sur les quatre teintes — `--encre-douce` sur un panneau posé sur le
+  lavis le plus dense vaut **6.79 à 6.82:1** en clair, **5.23 à 5.28:1** en sombre ;
+- le lavis est un **décor** : aucune information n'y est portée par la seule couleur
+  (WCAG 1.4.1). Le nom du pôle, son libellé de place et son temps restent écrits en
+  toutes lettres à côté. Le survol d'une porte, lui, ne se dit plus par le fond — celui-ci
+  est au plafond de contraste — mais par l'arête qui se ferme **et** l'invite qui se
+  souligne ;
+- **`--accent` dilué à 45 %** — le chiffre de place de `PoleHero`, le filet de preuve de
+  `PoleEntries` — est à **1,9 à 2,5:1** sur le fond, et l'était déjà avant le lavis (qui
+  lui coûte 0,07 point, la teinte et le fond bougeant ensemble). Les deux sont décoratifs
+  et l'information qu'ils accompagnent est écrite à côté, mais le point est **ouvert** et
+  n'a pas été traité par ce lot.
+
 ### Pages contrôlées
 
 Les mêmes que les budgets de performance — accueil, page de pôle, liste du blog, page
@@ -80,6 +126,7 @@ non protégé. La liste vit dans `scripts/budgets/pages.mjs`.
 
 | Parcours | Audit | État |
 |----------|-------|------|
-| Accueil, pôle, blog, article, réalisations | axe-core (`ci-dev-a11y`) | **0 violation** — dernière exécution 2026-08-23, avec les figures d'article |
+| Accueil, pôle, blog, article, réalisations | axe-core (`ci-dev-a11y`) | **0 violation** — dernière exécution 2026-08-23, avec le lavis de pôle |
+| Contrastes sur le lavis de pôle | mesure au pixel, deux thèmes | **tenu** — 2026-08-23, voir le tableau ci-dessus |
 | Clavier + lecteur d'écran | manuel | _à réaliser_ |
 | WCAG 2.2.2 — pause des animations | manuel | _à réaliser_ |

--- a/docs/design.md
+++ b/docs/design.md
@@ -806,53 +806,164 @@ inline-block` — c'est le **seul `svg` du site à vivre dans une ligne de texte
 `rel="noopener noreferrer"`, comme le lien de justificatif d'une certification : un lien
 sortant est traité pareil partout, ou il finit par ne l'être nulle part.
 
-## La maille de fond
+## Le lavis de pôle
 
 Le fond était un lavis radial unique, une trame de 32 px et un grain. Correct, sobre —
 et **sans matière**. C'est ce qui explique l'échec des trois tentatives de verre
 réfractant : un verre ne montre rien par lui-même, il montre **ce qu'il déforme**. Sur un
 lavis uniforme, la réfraction a été mesurée à **2 niveaux sur 255**, c'est-à-dire rien.
 
-La maille ajoute quatre lavis larges, **un par pôle**, posés en descendant : ingénierie en
-haut à gauche, donnée à droite, puis les deux suites plus bas. Le fond raconte la même
-chaîne que la page, sans qu'aucun mot ne le dise — et il donne au verre de quoi travailler.
+La première réponse fut une **maille** : quatre lavis larges, un par pôle, posés en
+descendant dans `.fond-atelier` — ingénierie en haut à gauche, donnée à droite, les deux
+suites plus bas. Elle a été **remplacée** (issue #104), pour deux défauts qui n'étaient
+pas des réglages :
 
-### Ce qui est repris d'ailleurs, et ce qui ne l'est pas
+1. **Ses coordonnées étaient fixes et le document ne les connaissait pas.** Sur
+   `/services/ia/`, le haut de page recevait le lavis d'ingénierie — non parce qu'on y
+   parlait d'ingénierie, mais parce que c'est le haut du document. Le fond racontait la
+   chaîne à un lecteur qui, lui, lisait une page.
+2. **Étalés sur plus de 9 000 px, les quatre lavis n'atteignaient nulle part leur propre
+   densité.** À 5,5 % au centre d'ellipses de la taille d'un écran, chaque point du fond
+   n'en recevait qu'une fraction. Le résultat à l'écran était un beige uniforme du haut
+   en bas de l'accueil.
 
-Le **procédé** vient d'une référence dont la signature visuelle est un fond maillé pastel.
-Ses **couleurs**, non : la direction du site est « L'Établi » — papier chaud, cuivre, trame
-technique — et copier un pastel vert-jaune aurait fait perdre l'identité que tout le reste
-défend. La maille se construit donc dans les quatre teintes de pôle, déjà mesurées.
+**Le lavis suit désormais le contenu.** Il n'a plus de coordonnées : il est peint par le
+bloc qui parle du pôle, c'est-à-dire par celui qui porte déjà `data-pole`. La section qui
+parle de Data porte le lavis Data ; `/services/ia/` porte le lavis IA sur toute sa
+hauteur ; les quatre portes de l'accueil sont quatre taches de couleur côte à côte.
+
+### Le mécanisme
+
+`poles.css` mappe `--accent` sous `data-pole`. `lavis.css` en dérive quatre jetons —
+`--lavis-fond`, `--lavis-tache`, et leurs équivalents d'échelle bloc — **déclarés sur
+`[data-pole]` lui-même**, jamais seulement sur `:root` : une propriété personnalisée est
+substituée au *computed-value time*, sur l'élément qui la déclare. Déclarés à la racine,
+ils figeraient le cuivre et descendraient tels quels dans les quatre pages de pôle. C'est
+le piège déjà documenté pour `--verre-arete`, et c'est le même remède.
+
+**Aucun composant ne nomme une teinte de pôle.** Deux classes globales suffisent, et elles
+ne connaissent que les jetons :
+
+| Classe | Échelle | Porteur | Recette |
+|---|---|---|---|
+| `.lavis-pole` | une page de pôle, plusieurs milliers de pixels | `PolePageView` | tuile de 1600 × 1100 px répétée en Y, `farthest-side` centré |
+| `.lavis-bloc` | une carte, quelques centaines de pixels | `PoleEntries` | tache ancrée en haut à gauche, dimensionnée sur le bloc |
+
+### Deux couches, et pourquoi pas trois
+
+Le lavis est un **fond plat translucide** plus une **tache dégradée** par-dessus. Le fond
+plat garantit que le bloc du pôle est teinté *partout* — c'est lui qui fait qu'on lit une
+couleur et non une éclaircie, et c'est exactement ce qui manquait à la maille. La tache
+fait le dégradé et empêche l'aplat.
+
+Deux couches et pas plus, parce que **les alphas se composent** : là où deux taches se
+recouvrent, la densité vaut `1-(1-a)(1-b)` et non `a`. Un troisième calque rendrait le
+pire cas dépendant de la géométrie, donc de la hauteur du bloc, donc invérifiable. Ici il
+est fixe et calculable — et c'est ce nombre-là qui est mesuré.
+
+La **répartition** entre les deux change avec la surface, le plafond jamais. À l'échelle
+d'une page, la tache a mille pixels pour s'installer et porte la moitié du plafond. À
+l'échelle d'un bloc — une porte de l'accueil fait 160 px de haut — une tache qui décroît
+sur cette hauteur laisse le bas de la carte au fond plat seul : mesuré à l'écran, les
+quatre portes se lisaient alors quasiment beiges. La part constante monte donc à 6 %, et
+la tache se réduit à une modulation.
+
+| Échelle | Clair | Sombre |
+|---|---|---|
+| page (`.lavis-pole`) | 4 % + 4 % → **7,84 %** | 3,5 % + 3,5 % → **6,88 %** |
+| bloc (`.lavis-bloc`) | 6 % + 2 % → **7,88 %** | 5 % + 2 % → **6,90 %** |
+
+### Le plafond, et d'où il vient
+
+**Il ne vient pas du texte.** `--encre-douce` tient encore 5,95:1 à 7,88 %, très au-dessus
+du seuil AA de 4,5:1. Il vient des jetons `--accent-vif`, qui portent les filets et les
+arêtes et doivent tenir **3:1** (WCAG 1.4.11). Sur le fond réellement peint — `#EDE9E0`,
+le bas du dégradé d'atelier et non `--fond` — `--pole-data-vif` n'est déjà qu'à **3,29:1**
+nu. Il reste 0,29 point de marge, et le lavis en consomme la quasi-totalité : à 9 % il
+passe sous 3:1.
+
+**7,84 % est donc un plafond mesuré, pas un réglage d'apparence.** Le monter demanderait
+d'abord de rouvrir la palette des `-vif`, dont les seize valeurs sont plus haut.
+
+En thème sombre le plafond change de nature : tout y tient au-dessus de 6:1, et la
+contrainte n'est plus le contraste mais la teinte elle-même. Les couleurs de pôle y sont
+choisies **claires** pour porter du texte sur un fond à 6 % de luminance — `--pole-data`
+passe de `#00697B` à `#01B6D4`. À part égale, le même lavis y serait deux fois plus
+présent et virerait au fond coloré.
+
+### Ce qui reste dans `.fond-atelier`
+
+Le calque plein document ne porte plus aucune couleur de pôle. Il garde le grain, la
+trame, le dégradé d'atelier, et **une seule tache** en haut du document, dans
+`--lavis-tache` — c'est-à-dire, hors de tout `data-pole`, dans le cuivre : la couleur de
+la maison. Ce n'est pas la maille par une autre porte. La maille prétendait dire quel pôle
+on lisait, à des coordonnées qui ne le savaient pas ; celle-ci ne dit rien d'un pôle, elle
+éclaire l'entrée du document et donne au verre de l'en-tête de la matière à courber.
 
 ### Contraintes tenues
 
 | Contrainte | Comment |
 |---|---|
-| Zéro octet téléchargé | Uniquement des `radial-gradient`. Aucune image. |
-| Aucune couche de compositing plein document | Ni `filter` ni `will-change` sur `.fond-atelier`, qui dépasse 9 000 px de haut sur l'accueil |
-| Pas de rasterisation géante | Les quatre lavis sont dimensionnés en **pixels**, jamais en pourcentage — chacun reste un disque de la taille d'un écran |
+| Zéro octet téléchargé | Uniquement des `radial-gradient` et une couleur de fond. Aucune image. |
+| Aucune couche de compositing | Deux propriétés de fond sur un élément déjà peint. Ni `filter`, ni `will-change`, ni `transform`. Rien n'est repeint au défilement. |
+| Pas de rasterisation géante | `.lavis-pole` dimensionne sa tache en **pixels** et la répète en Y : elle est rasterisée une fois, sur 1600 × 1100 px, jamais à la hauteur d'un gabarit de 6 000 px. `.lavis-bloc` ne sert que des blocs de la taille d'une carte. |
+| Aucune animation | Le lavis est statique. `prefers-reduced-motion` n'a rien à couper. |
+| Aucune information portée par la seule couleur | Le lavis est un décor : le nom du pôle, son libellé de place et son temps restent écrits en toutes lettres (WCAG 1.4.1). |
+| Lighthouse ≥ 95 | Mesuré après le lot : accueil 96, page de pôle 96, blog / article / réalisations 97 ; A11y, bonnes pratiques et SEO à 100. |
 
 ### Contraste — mesuré, pas supposé
 
-L'alpha est de **5,5 %** par lavis en thème clair, **3,5 %** en sombre. La part descend en
-sombre parce que les teintes de pôle y sont choisies claires pour porter du texte : à part
-égale, la même maille y serait deux fois plus présente.
+Deux mesures indépendantes, et les deux sont dans le dépôt de la PR #104 : le calcul
+analytique sur la couleur composée, puis la **lecture au pixel du rendu réel** — grain,
+trame et lueur de seuil compris — dans les deux thèmes.
 
-Pire cas, deux lavis superposés à pleine intensité, contre le fond le plus sombre du
-dégradé :
+Calcul, pire cas : lavis à sa densité maximale, sur le fond le plus défavorable du dégradé
+d'atelier (`#EDE9E0` en clair, `#14181D` en sombre).
 
-| Thème | Paire la plus défavorable | `--encre-douce` | `--encre` |
+| Thème | Pôle | Fond composé | `--encre` | `--encre-douce` | `--accent` (texte) | `--accent-vif` (non-texte) |
+|---|---|---|---|---|---|---|
+| clair | ingénierie web | `#E6DCD1` | 13.30:1 | **5.95:1** | 5.10:1 | 3.27:1 |
+| clair | data | `#DADFD8` | 13.30:1 | **5.96:1** | 4.70:1 | **3.02:1** |
+| clair | IA | `#E2DDDA` | 13.34:1 | **5.98:1** | 5.11:1 | 3.30:1 |
+| clair | SEA & UX | `#E0DFD1` | 13.39:1 | **6.00:1** | 4.72:1 | 3.03:1 |
+| sombre | ingénierie web | `#222020` | 13.16:1 | **6.34:1** | 6.15:1 | 7.89:1 |
+| sombre | data | `#13232A` | 13.12:1 | **6.32:1** | 6.65:1 | 8.44:1 |
+| sombre | IA | `#1F202B` | 13.11:1 | **6.31:1** | 6.08:1 | 7.79:1 |
+| sombre | SEA & UX | `#1C2321` | 13.04:1 | **6.28:1** | 6.59:1 | 8.33:1 |
+
+Lecture au pixel, sur le rendu servi. Les valeurs sont légèrement **plus basses** que le
+calcul : le grain et la lueur de seuil s'y ajoutent, et c'est bien ce qu'un lecteur a sous
+les yeux.
+
+| Thème | Surface | `--encre-douce` | `--encre` |
 |---|---|---|---|
-| clair | ingénierie + data | **5.70:1** (nu : 6.65) | 12.72:1 |
-| sombre | IA + SEA & UX | **6.92:1** (nu : 7.57) | 14.37:1 |
+| clair | les quatre portes de l'accueil | **5.59 → 5.70:1** | 12.48 → 12.72:1 |
+| clair | les quatre pages de pôle | **5.85 → 5.86:1** | 13.06 → 13.09:1 |
+| sombre | les quatre portes de l'accueil | **6.49 → 6.71:1** | 13.48 → 13.92:1 |
+| sombre | les quatre pages de pôle | **6.74 → 6.80:1** | 14.00 → 14.12:1 |
 
-Le seuil AA du texte est à 4.5:1 : les deux tiennent avec de la marge.
+Le seuil AA du texte est à 4.5:1, celui des éléments non-texte à 3:1 : les deux tiennent,
+le second de justesse et par construction.
 
-> **Un écart relevé au passage.** Les ratios des tableaux de jetons plus haut sont mesurés
-> sur `--fond` (`#F2EFE8`), alors que le fond réellement peint est le dégradé de
-> `.fond-atelier`, qui descend à `#EDE9E0`. Les vrais ratios sont donc légèrement plus bas
-> que ceux affichés — `--encre-douce` est à 6.65:1 et non 7.02:1. Tous restent au-dessus du
-> seuil, mais la documentation est optimiste d'environ un tiers de point.
+**Le verre par-dessus.** Le lavis est ce que `GlassSurface` floute : un fond plus coloré
+change ce qu'il rend. Contrôlé sur les quatre teintes, dans les deux thèmes —
+`--encre-douce` sur un panneau posé sur le lavis le plus dense vaut **6.79 à 6.82:1** en
+clair et **5.23 à 5.28:1** en sombre. Le panneau *améliore* le contraste en clair (son
+voile blanc éclaircit le fond) et le réduit en sombre sans jamais l'approcher du seuil.
+
+> **Un écart relevé au passage, toujours valable.** Les ratios des tableaux de jetons plus
+> haut sont mesurés sur `--fond` (`#F2EFE8`), alors que le fond réellement peint est le
+> dégradé de `.fond-atelier`, qui descend à `#EDE9E0`. Les vrais ratios sont donc
+> légèrement plus bas que ceux affichés — `--encre-douce` est à 6.65:1 et non 7.02:1.
+> Tous restent au-dessus du seuil, mais la documentation est optimiste d'environ un tiers
+> de point. C'est cet écart qui rend le plafond du lavis si serré : la marge des `-vif`
+> est comptée sur `#EDE9E0`, pas sur `#F2EFE8`.
+
+> **Un filet non conforme, antérieur au lavis.** `--accent` dilué à 45 % — le chiffre de
+> place de `PoleHero`, le filet de preuve de `PoleEntries` — est à **1,9 à 2,5:1** sur le
+> fond, et l'était déjà avant ce lot (le lavis lui coûte 0,07 point, teinte et fond
+> bougeant ensemble). Les deux sont décoratifs et l'information qu'ils accompagnent est
+> écrite à côté, mais le point est ouvert et n'est pas traité ici.
 
 ## Le verre de la bande
 
@@ -875,5 +986,6 @@ La **réfraction** arrive aussi sur la bande, sous le même verrou que les panne
 seul, Safari et Firefox exclus par une clause `not (…)` qui survit à la minification. Le
 gate est recopié plutôt que factorisé : une classe partagée entre un panneau et une bande
 obligerait l'une à porter les réglages de l'autre, et c'est exactement ce qui produit les
-traînées colorées. Elle n'a de sens que depuis que le fond porte une maille.
+traînées colorées. Elle n'a de sens que depuis que le fond porte de la couleur — le lavis
+du pôle qu'on lit, désormais, plus la lueur de seuil de `.fond-atelier`.
 

--- a/src/@shared/components/SiteHeader/site-header.module.css
+++ b/src/@shared/components/SiteHeader/site-header.module.css
@@ -60,9 +60,11 @@
      une bande obligerait l'une des deux à porter les réglages de l'autre, et c'est
      exactement ce qui produit les traînées colorées quand les valeurs d'un panneau
      tombent sur une bande.
-     Elle n'a de sens que depuis que le fond porte une maille : sur le lavis uniforme
+     Elle n'a de sens que depuis que le fond porte de la couleur : sur le lavis uniforme
      d'avant, la réfraction a été mesurée à 2 niveaux sur 255 — invisible. Ce qu'elle
-     courbe désormais, ce sont les lavis de pôle qui passent dessous au défilement. */
+     courbe désormais, ce sont les lavis de pôle qui passent dessous au défilement — non
+     plus quatre taches à coordonnées fixes, mais celui du bloc qu'on lit (`lavis.css`,
+     issue #104), plus la lueur de seuil de `.fond-atelier`. */
   @supports (backdrop-filter: url("#verre-refraction")) and
     (not (-webkit-backdrop-filter: blur(1px))) and
     (not (-moz-appearance: none)) {

--- a/src/@vitrine/components/PoleEntries/index.tsx
+++ b/src/@vitrine/components/PoleEntries/index.tsx
@@ -54,7 +54,7 @@ import styles from './pole-entries.module.css'
  */
 function Porte({ pole }: { pole: IPole }) {
   return (
-    <a className={styles.plaque} data-pole={pole.id} href={pole.route}>
+    <a className={`${styles.plaque} lavis-bloc`} data-pole={pole.id} href={pole.route}>
       <span aria-hidden="true" className={styles.marque}>
         <PoleGlyph pole={pole.id} />
       </span>

--- a/src/@vitrine/components/PoleEntries/index.tsx
+++ b/src/@vitrine/components/PoleEntries/index.tsx
@@ -31,7 +31,11 @@
 // existe pour éviter.
 //
 // Chaque plaque porte `data-pole` : sa marque et son filet prennent `--accent` sans
-// qu'aucune règle d'ici ne nomme une couleur (voir `poles.css`).
+// qu'aucune règle d'ici ne nomme une couleur (voir `poles.css`). Depuis l'issue #104,
+// elle prend aussi le lavis pastel de son pôle sur le fond papier — d'où la classe
+// globale `lavis-bloc`, qui ne connaît pas davantage la couleur : elle consomme
+// `--lavis-fond` et `--lavis-tache`, posés par `data-pole` sur la plaque elle-même. Les
+// quatre portes sont donc quatre taches de couleur côte à côte, une par pôle.
 
 import { PoleGlyph } from '@/@shared/components/PoleGlyph'
 import type { IPole } from '@/interfaces/IPole'

--- a/src/@vitrine/components/PoleEntries/pole-entries.module.css
+++ b/src/@vitrine/components/PoleEntries/pole-entries.module.css
@@ -52,17 +52,22 @@
   padding: var(--e-3);
   border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
   border-radius: var(--rayon-petit);
-  background: color-mix(in srgb, var(--accent) 4%, transparent);
   color: inherit;
   text-decoration: none;
-  transition:
-    border-color var(--duree-micro) var(--courbe-poser),
-    background-color var(--duree-micro) var(--courbe-poser);
+  transition: border-color var(--duree-micro) var(--courbe-poser);
+  /* Le fond n'est PAS déclaré ici : la plaque porte la classe globale `lavis-bloc`, qui
+     lui pose le lavis pastel de son pôle (issue #104). Elle avait un aplat d'accent à
+     4 %, qui disait « teinté » sans qu'on puisse nommer la teinte. */
 }
 
+/* Le survol ne monte plus le fond, et c'est une contrainte mesurée, pas un choix
+   d'apparence : le lavis est déjà au plafond de contraste (7,84 % en clair, voir
+   `lavis.css`), et un aplat de plus par-dessus ferait passer `--accent-vif` sous 3:1
+   pour la donnée et le SEA & UX. L'état est déjà porté par deux choses visibles —
+   l'arête qui se ferme et l'invite qui se souligne — dont aucune ne repose sur la seule
+   couleur (WCAG 1.4.1). */
 .plaque:hover {
   border-color: color-mix(in srgb, var(--accent) 55%, transparent);
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .marque {

--- a/src/@vitrine/views/PolePageView/index.tsx
+++ b/src/@vitrine/views/PolePageView/index.tsx
@@ -39,7 +39,13 @@ export function PolePageView({ pole, page, suites }: PolePageViewProps) {
     // `data-pole` est le porteur de la teinte : le bloc CSS qui mappe `--accent` sur
     // l'identifiant du pôle s'y accroche, et tout ce qui est dessous en hérite. Aucun
     // composant ne connaît la couleur d'un pôle, il ne connaît que `--accent`.
-    <div className={styles.page} data-pole={pole.id}>
+    //
+    // `lavis-pole` est ce qui fait que la page PORTE sa teinte au lieu de s'en servir en
+    // filets : le fond papier reçoit le lavis pastel du pôle sur toute la hauteur du
+    // gabarit (issue #104). Classe globale, comme `.fond-atelier`, parce que la recette
+    // est la même pour les quatre pôles et qu'elle ne nomme aucune couleur — elle
+    // consomme `--lavis-fond` et `--lavis-tache`, que `data-pole` vient de poser ici même.
+    <div className={`${styles.page} lavis-pole`} data-pole={pole.id}>
       <PoleHero pole={pole} suites={suites} />
       <PoleStickyBar pole={pole} />
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,16 +34,7 @@
   --fond-degrade-haut: #f7f5f0;
   --fond-degrade-bas: #ede9e0;
 
-  /* Grain de papier : une TUILE de 128 px, comme la trame en est une de 32 px. Le
-     `feTurbulence` n'est rasterisé qu'une fois, sur 128×128 px, puis répété — même
-     raisonnement que pour la trame, et pour la même raison : `.fond-atelier` fait plus
-     de 9 000 px de haut sur l'accueil.
-     Deux tuiles distinctes plutôt qu'une seule inversée par un filtre : `filter` sur un
-     calque plein document forcerait une couche de compositing de la hauteur du
-     document. Ici, rien n'est promis au compositeur.
-     L'alpha moyen est volontairement sous 4 % : au-delà, le grain cesse d'être une
-     texture et devient un voile qui déplace les contrastes documentés. */
-  /* — La couleur du fond ne se déclare plus ici — */
+  /* — La couleur de pôle du fond ne se déclare plus ici — */
   /* Le fond portait une « maille » : quatre lavis de pôle posés à des coordonnées FIXES
      dans `.fond-atelier`, une fois pour tout le document. Ils ne disaient donc rien de la
      section qu'on lit — sur `/services/ia/`, le haut de page recevait le lavis
@@ -55,6 +46,15 @@
      et ses jetons vivent dans `lavis.css` (issue #104). Ne restent ici que les calques
      qui appartiennent vraiment au document entier — grain, trame, dégradé d'atelier. */
 
+  /* Grain de papier : une TUILE de 128 px, comme la trame en est une de 32 px. Le
+     `feTurbulence` n'est rasterisé qu'une fois, sur 128×128 px, puis répété — même
+     raisonnement que pour la trame, et pour la même raison : `.fond-atelier` fait plus
+     de 9 000 px de haut sur l'accueil.
+     Deux tuiles distinctes plutôt qu'une seule inversée par un filtre : `filter` sur un
+     calque plein document forcerait une couche de compositing de la hauteur du
+     document. Ici, rien n'est promis au compositeur.
+     L'alpha moyen est volontairement sous 4 % : au-delà, le grain cesse d'être une
+     texture et devient un voile qui déplace les contrastes documentés. */
   --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.07 0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23g)'/%3E%3C/svg%3E");
   --grain-tuile: 128px;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,25 +43,17 @@
      document. Ici, rien n'est promis au compositeur.
      L'alpha moyen est volontairement sous 4 % : au-delà, le grain cesse d'être une
      texture et devient un voile qui déplace les contrastes documentés. */
-  /* — La maille de fond — */
-  /* Quatre lavis larges, un par pôle, posés en descendant : ingénierie en haut à gauche,
-     donnée à droite, puis les deux suites plus bas. Le fond raconte donc la même chaîne
-     que la page, sans qu'aucun mot ne le dise.
+  /* — La couleur du fond ne se déclare plus ici — */
+  /* Le fond portait une « maille » : quatre lavis de pôle posés à des coordonnées FIXES
+     dans `.fond-atelier`, une fois pour tout le document. Ils ne disaient donc rien de la
+     section qu'on lit — sur `/services/ia/`, le haut de page recevait le lavis
+     d'ingénierie parce que c'est le haut du document — et, étalés sur plus de 9 000 px,
+     ils n'atteignaient nulle part leur propre densité : le résultat à l'écran était un
+     beige uniforme.
 
-     Ce n'est PAS de la décoration. Un verre ne montre rien par lui-même — il montre ce
-     qu'il déforme. Sur un lavis uniforme, la réfraction du verre a été mesurée à 2
-     niveaux sur 255, c'est-à-dire rien. La maille est ce qui lui donne enfin de la
-     matière à courber, et c'est pour ça qu'elle arrive avec le verre de la bande.
-
-     L'alpha est délibérément TRÈS bas — de l'ordre du grain, sous 6 %. Au-delà, la
-     maille cesse d'être une lumière et devient un fond coloré : elle déplacerait les
-     ratios de contraste documentés, et le texte du site est posé dessus. La vérification
-     est mesurée, pas supposée : voir `docs/design.md`. */
-  --maille-part: 5.5%;
-  --maille-a: color-mix(in srgb, var(--pole-ingenierie-web) var(--maille-part), transparent);
-  --maille-b: color-mix(in srgb, var(--pole-data) var(--maille-part), transparent);
-  --maille-c: color-mix(in srgb, var(--pole-ia) var(--maille-part), transparent);
-  --maille-d: color-mix(in srgb, var(--pole-sea-ux) var(--maille-part), transparent);
+     Le lavis suit désormais le CONTENU : il est peint par le bloc qui porte `data-pole`,
+     et ses jetons vivent dans `lavis.css` (issue #104). Ne restent ici que les calques
+     qui appartiennent vraiment au document entier — grain, trame, dégradé d'atelier. */
 
   --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.07 0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23g)'/%3E%3C/svg%3E");
   --grain-tuile: 128px;
@@ -168,11 +160,6 @@
     --verre-lueur: rgba(255, 255, 255, 0.14);
     --fond-degrade-haut: #14181d;
     --fond-degrade-bas: #0b0e11;
-    /* La maille descend en thème sombre, et ce n'est pas une préférence : les teintes de
-       pôle y sont choisies claires pour porter du texte sur un fond à 6 % de luminance —
-       `--pole-data` passe de #00697b à #01b6d4. À part égale, la même maille y serait
-       deux fois plus présente et virerait au fond coloré. */
-    --maille-part: 3.5%;
     /* Même tuile, speckles clairs : du grain noir sur un fond à 6 % de luminance ne
        se voit pas, il ne fait qu'assombrir encore. */
     --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='128' height='128' filter='url(%23g)'/%3E%3C/svg%3E");
@@ -242,24 +229,25 @@ body {
   background-image:
     var(--grain), linear-gradient(to right, var(--trame) 0 1px, transparent 1px),
     linear-gradient(to bottom, var(--trame) 0 1px, transparent 1px),
-    /* La maille : quatre lavis en TAILLE FIXE, jamais en pourcentage. `.fond-atelier`
-       fait plus de 9 000 px de haut sur l'accueil — un `radial-gradient` dimensionné en
-       pourcentage y serait rasterisé à cette hauteur. En pixels, chacun reste un disque
-       de la taille d'un écran, et leur position en pourcentage suffit à les répartir. */
-    radial-gradient(1100px 800px at 12% 4%, var(--maille-a), transparent),
-    radial-gradient(1000px 750px at 88% 14%, var(--maille-b), transparent),
-    radial-gradient(900px 700px at 8% 34%, var(--maille-c), transparent),
-    radial-gradient(950px 700px at 92% 46%, var(--maille-d), transparent),
+    /* La lueur de seuil. Une SEULE tache, en taille fixe, en haut du document, dans
+       `--lavis-tache` — c'est-à-dire, hors de tout `data-pole`, dans le cuivre : la
+       couleur de la maison. Ce n'est pas le retour de la maille par une autre porte. La
+       maille prétendait dire quel pôle on lisait, à des coordonnées qui ne le savaient
+       pas ; celle-ci ne dit rien d'un pôle, elle éclaire l'entrée du document et donne au
+       verre de l'en-tête un peu de matière à courber. Tout ce qui parle d'un pôle est
+       peint par le bloc du pôle (`lavis.css`).
+
+       Taille FIXE, jamais en pourcentage : `.fond-atelier` fait plus de 9 000 px de haut
+       sur l'accueil, et un `radial-gradient` dimensionné en pourcentage y serait rasterisé
+       à cette hauteur. */
+    radial-gradient(1200px 820px at 22% 6%, var(--lavis-tache), transparent),
     radial-gradient(1200px 900px at 22% 8%, var(--fond-degrade-haut), var(--fond-degrade-bas));
-  background-repeat: repeat, repeat, repeat, no-repeat, no-repeat, no-repeat, no-repeat, no-repeat;
+  background-repeat: repeat, repeat, repeat, no-repeat, no-repeat;
   background-size:
     var(--grain-tuile) var(--grain-tuile),
     32px 32px,
     32px 32px,
-    1100px 800px,
-    1000px 750px,
-    900px 700px,
-    950px 700px,
+    1200px 820px,
     100% 100%;
 }
 

--- a/src/app/lavis.css
+++ b/src/app/lavis.css
@@ -1,0 +1,128 @@
+/* lavis.css — le lavis pastel d'un pôle, posé sur le fond papier.
+ *
+ * Extrait de `globals.css` pour la même raison que `poles.css` et `verre.css` : la
+ * limite de 300 lignes du projet. Ces jetons sont des jetons de design comme les autres,
+ * et ce fichier est le voisin immédiat des deux autres.
+ *
+ * ## Ce que ce fichier remplace
+ *
+ * Le fond portait une « maille » : quatre `radial-gradient`, un par pôle, posés une fois
+ * pour tout le document dans `.fond-atelier`, à des coordonnées fixes — ingénierie en
+ * haut à gauche, donnée à droite, les deux suites plus bas. Le fond racontait donc la
+ * chaîne, mais il ne disait rien de la section qu'on est en train de LIRE : sur
+ * `/services/ia/`, le haut de page recevait le lavis d'ingénierie, parce que c'est le
+ * haut du document. Et étalés sur plus de 9 000 px, les quatre lavis n'atteignaient
+ * nulle part leur propre densité : le résultat à l'écran était un beige uniforme.
+ *
+ * Le lavis suit désormais le CONTENU (issue #104). Il n'a plus de coordonnées : il est
+ * peint par le bloc qui parle du pôle, donc par celui qui porte `data-pole`.
+ *
+ * ## Le mécanisme
+ *
+ * `poles.css` mappe déjà `--accent` sous `data-pole`. Les deux jetons ci-dessous en sont
+ * DÉRIVÉS, et ils sont déclarés sur `[data-pole]` lui-même : une propriété personnalisée
+ * est substituée au *computed-value time*, sur l'élément qui la déclare. `var(--accent)`
+ * y vaut donc la teinte du pôle, celle que le bloc `[data-pole="…"]` de `poles.css` vient
+ * de poser sur ce même élément. Déclarés une seule fois sur `:root`, ils figeraient le
+ * cuivre et descendraient tels quels dans les quatre pages de pôle — c'est exactement le
+ * piège déjà documenté pour `--verre-arete`.
+ *
+ * **Aucun composant ne nomme une teinte de pôle.** Il ne connaît que `--lavis-fond` et
+ * `--lavis-tache`, comme il ne connaît que `--accent`.
+ *
+ * ## Deux couches, et pourquoi pas trois
+ *
+ * Le lavis est un **fond plat translucide** plus **une tache dégradée** par-dessus :
+ *
+ *   `--lavis-fond`  : la part constante. Elle garantit que le bloc du pôle est teinté
+ *                     PARTOUT — c'est elle qui fait qu'on lit une couleur et non une
+ *                     éclaircie. C'est ce qui manquait à la maille.
+ *   `--lavis-tache` : la modulation. C'est elle qui fait le « légèrement dégradé » de la
+ *                     demande, et qui empêche l'aplat.
+ *
+ * Deux couches et pas plus, parce que les alphas se COMPOSENT : là où deux taches se
+ * recouvrent, la densité vaut `1-(1-a)(1-b)`, pas `a`. Un troisième calque rendrait le
+ * pire cas dépendant de la géométrie, donc de la hauteur du bloc, donc invérifiable. Ici
+ * le pire cas est connu et fixe : `1-(1-4%)(1-4%) = 7.84 %` en clair,
+ * `1-(1-3.5%)(1-3.5%) = 6.88 %` en sombre. C'est ce nombre-là qui est mesuré.
+ *
+ * ## Le plafond, et d'où il vient
+ *
+ * Il ne vient pas du texte : `--encre-douce` tient encore 5.96:1 à 7.84 %, très
+ * au-dessus du seuil AA. Il vient des jetons `--accent-vif`, qui portent les filets et
+ * les arêtes et doivent tenir **3:1** (WCAG 1.4.11). Sur le fond réellement peint
+ * (`#ede9e0`, le bas du dégradé d'atelier), `--pole-data-vif` n'est déjà qu'à 3.29:1 nu :
+ * il ne reste que 0,29 point de marge, et le lavis en consomme la quasi-totalité. À 9 %
+ * il passe sous 3:1. **7,84 % est donc un plafond mesuré, pas un réglage d'apparence** —
+ * le monter demanderait d'abord de rouvrir la palette des `-vif`. Les seize valeurs sont
+ * dans `docs/design.md`.
+ *
+ * En sombre, le plafond n'est plus le contraste (tout y tient au-dessus de 6:1) mais la
+ * teinte elle-même : les couleurs de pôle y sont choisies CLAIRES pour porter du texte
+ * sur un fond à 6 % de luminance. À part égale, le même lavis y serait deux fois plus
+ * présent et virerait au fond coloré. La part descend donc, comme celle de la maille
+ * avant elle.
+ *
+ * ## Coût
+ *
+ * Zéro octet téléchargé, aucune animation, aucune couche de compositing : deux propriétés
+ * de fond sur un élément déjà peint. Rien n'est repeint au défilement. La règle de
+ * `.fond-atelier` reste valable partout — **ce qu'on pose sur un élément haut comme le
+ * document doit être une tuile** —, d'où `.lavis-pole` : sa tache est dimensionnée en
+ * PIXELS et répétée en Y, jamais dimensionnée en pourcentage d'un bloc de 6 000 px.
+ * `.lavis-bloc`, lui, ne sert que des blocs de la taille d'une carte : à cette échelle,
+ * un fond en pourcentage ne rasterise rien de notable et suit exactement la carte.
+ */
+
+:root {
+  /* Les deux parts, et non la densité composée : c'est ce que le CSS applique. La
+     densité composée qui en découle est le nombre mesuré (voir plus haut). */
+  --lavis-fond-part: 4%;
+  --lavis-tache-part: 4%;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --lavis-fond-part: 3.5%;
+    --lavis-tache-part: 3.5%;
+  }
+}
+
+/* Déclarés sur `[data-pole]` ET sur `:root` : hors de tout pôle, `--accent` vaut le
+   cuivre, la couleur de la maison — c'est ce que `.fond-atelier` consomme pour sa lueur
+   de seuil. */
+:root,
+[data-pole] {
+  --lavis-fond: color-mix(in srgb, var(--accent) var(--lavis-fond-part), transparent);
+  --lavis-tache: color-mix(in srgb, var(--accent) var(--lavis-tache-part), transparent);
+}
+
+/* Échelle PAGE — un gabarit de pôle, haut de plusieurs milliers de pixels.
+ *
+ * `farthest-side` centré sur la tuile décrit une ellipse qui touche exactement ses quatre
+ * côtés : la tache est donc entièrement contenue dans sa tuile, et deux tuiles voisines
+ * ne se recouvrent jamais. C'est ce qui rend le pire cas calculable — sans quoi il
+ * faudrait le mesurer sur chaque hauteur de page.
+ *
+ * Le décalage négatif place le cœur de la première tache dans l'ouverture de la page,
+ * là où le pôle se nomme. */
+.lavis-pole {
+  background-color: var(--lavis-fond);
+  background-image: radial-gradient(farthest-side at 50% 50%, var(--lavis-tache), transparent);
+  background-repeat: repeat-y;
+  background-size: 1600px 1100px;
+  background-position: 50% -320px;
+}
+
+/* Échelle BLOC — une plaque, un maillon : quelques centaines de pixels.
+ *
+ * La tache est ancrée en haut à gauche du bloc plutôt que centrée : elle entre par le
+ * coin où commence la lecture, et s'éteint vers le bas. Un centre au milieu de la carte
+ * dessinerait une auréole, ce qui se lit comme un état (survol, sélection) et non comme
+ * un fond. */
+.lavis-bloc {
+  background-color: var(--lavis-fond);
+  background-image: radial-gradient(farthest-side at 18% 0%, var(--lavis-tache), transparent);
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+}

--- a/src/app/lavis.css
+++ b/src/app/lavis.css
@@ -74,17 +74,36 @@
  * un fond en pourcentage ne rasterise rien de notable et suit exactement la carte.
  */
 
+/* Deux répartitions pour un seul plafond.
+ *
+ * Le plafond est le même partout — c'est lui qui est mesuré, et il ne bouge pas. Ce qui
+ * change, c'est la part qui revient au fond plat plutôt qu'à la tache, et c'est une
+ * conséquence de la SURFACE :
+ *
+ *   à l'échelle d'une PAGE, la tache a mille pixels pour s'installer ; elle porte donc la
+ *   moitié du plafond et fait le dégradé de la demande ;
+ *   à l'échelle d'un BLOC — une porte de l'accueil fait 160 px de haut — une tache qui
+ *   décroît sur cette hauteur laisse le bas de la carte au fond plat seul. Mesuré à
+ *   l'écran : les quatre portes se lisaient alors quasiment beiges. La part constante
+ *   monte donc, et la tache se réduit à une modulation.
+ *
+ * Les deux répartitions composent au même endroit : `1-(1-4%)(1-4%) = 7.84 %` et
+ * `1-(1-6%)(1-2%) = 7.88 %` en clair, `6.88 %` et `6.90 %` en sombre. Un seul jeu de
+ * ratios à tenir, donc, et c'est le point. */
 :root {
-  /* Les deux parts, et non la densité composée : c'est ce que le CSS applique. La
-     densité composée qui en découle est le nombre mesuré (voir plus haut). */
+  /* Les parts, et non la densité composée : c'est ce que le CSS applique. */
   --lavis-fond-part: 4%;
   --lavis-tache-part: 4%;
+  --lavis-bloc-fond-part: 6%;
+  --lavis-bloc-tache-part: 2%;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --lavis-fond-part: 3.5%;
     --lavis-tache-part: 3.5%;
+    --lavis-bloc-fond-part: 5%;
+    --lavis-bloc-tache-part: 2%;
   }
 }
 
@@ -95,6 +114,8 @@
 [data-pole] {
   --lavis-fond: color-mix(in srgb, var(--accent) var(--lavis-fond-part), transparent);
   --lavis-tache: color-mix(in srgb, var(--accent) var(--lavis-tache-part), transparent);
+  --lavis-bloc-fond: color-mix(in srgb, var(--accent) var(--lavis-bloc-fond-part), transparent);
+  --lavis-bloc-tache: color-mix(in srgb, var(--accent) var(--lavis-bloc-tache-part), transparent);
 }
 
 /* Échelle PAGE — un gabarit de pôle, haut de plusieurs milliers de pixels.
@@ -121,8 +142,8 @@
  * dessinerait une auréole, ce qui se lit comme un état (survol, sélection) et non comme
  * un fond. */
 .lavis-bloc {
-  background-color: var(--lavis-fond);
-  background-image: radial-gradient(farthest-side at 18% 0%, var(--lavis-tache), transparent);
+  background-color: var(--lavis-bloc-fond);
+  background-image: radial-gradient(farthest-side at 18% 0%, var(--lavis-bloc-tache), transparent);
   background-repeat: no-repeat;
   background-size: 100% 100%;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,11 +14,14 @@ import { SITE_IDENTITY, SITE_PROMESSE, SITE_THEME_COLORS, SITE_URL } from '@/@sh
 import { buildPersonSchema, buildProfessionalServiceSchema } from '@/@shared/seo/structured-data'
 import { FONT_VARIABLES } from '@/@shared/typography/fonts'
 import './globals.css'
-// Après `globals.css`, et pas avant : les deux fichiers s'appuient sur ses jetons
+// Après `globals.css`, et pas avant : les trois fichiers s'appuient sur ses jetons
 // (`--cuivre`, `--encre`, `--verre-lueur`). Ils n'en sont séparés que par la limite de
 // 300 lignes du projet.
 import './poles.css'
 import './verre.css'
+// Après `poles.css` : les jetons de lavis sont dérivés de `--accent`, que `poles.css`
+// mappe sur le pôle courant.
+import './lavis.css'
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),


### PR DESCRIPTION
Répond à l'issue #104 — « un lavis pastel par pôle sur le fond papier ».

## Le problème

Le fond portait une **maille** : quatre `radial-gradient`, un par pôle, posés une fois pour
tout le document dans `.fond-atelier`, à des **coordonnées fixes**. Deux défauts, et
aucun des deux n'était un réglage :

1. **Les coordonnées ne savaient pas ce qu'on lisait.** Sur `/services/ia/`, le haut de
   page recevait le lavis d'ingénierie — non parce qu'on y parlait d'ingénierie, mais
   parce que c'est le haut du document.
2. **Étalés sur plus de 9 000 px, les quatre lavis n'atteignaient nulle part leur propre
   densité.** À 5,5 % au centre d'ellipses de la taille d'un écran, le résultat à l'écran
   était un beige uniforme du haut en bas de la page.

## Le mécanisme retenu

**Le lavis suit le contenu.** Il n'a plus de coordonnées : il est peint par le bloc qui
parle du pôle, c'est-à-dire par celui qui porte déjà `data-pole`.

- Nouveau fichier `src/app/lavis.css` — jetons et recettes. Extrait comme `poles.css` et
  `verre.css` l'ont été, pour la limite de 300 lignes.
- Les jetons sont **dérivés de `--accent`** et **déclarés sur `[data-pole]` lui-même**,
  jamais seulement sur `:root` : une propriété personnalisée est substituée sur l'élément
  qui la déclare. À la racine, ils figeraient le cuivre et descendraient tels quels dans
  les quatre pages de pôle — c'est le piège déjà documenté pour `--verre-arete`.
- **Aucun composant ne nomme une teinte de pôle.** Deux classes globales, qui ne
  connaissent que les jetons :

| Classe | Échelle | Porteur |
|---|---|---|
| `.lavis-pole` | une page de pôle, plusieurs milliers de pixels | `PolePageView` |
| `.lavis-bloc` | une carte | `PoleEntries` — les quatre portes de l'accueil |

**Deux couches** — un fond plat translucide, plus une tache dégradée. Le fond plat
garantit que le bloc est teinté *partout* (c'est ce qui manquait à la maille), la tache
fait le dégradé et empêche l'aplat. Deux et pas trois, parce que les alphas se
composent : le pire cas est ainsi **fixe et calculable**, donc vérifiable.

| Échelle | Clair | Sombre |
|---|---|---|
| page | 4 % + 4 % → **7,84 %** | 3,5 % + 3,5 % → **6,88 %** |
| bloc | 6 % + 2 % → **7,88 %** | 5 % + 2 % → **6,90 %** |

La répartition change avec la surface, le plafond jamais : à 160 px de haut, une porte de
l'accueil laissait le bas de la carte au fond plat seul et se lisait beige — mesuré à
l'écran, puis corrigé.

`.fond-atelier` ne porte plus aucune couleur de pôle : grain, trame, dégradé, et **une
seule** tache en haut du document dans le cuivre — la couleur de la maison, une lueur de
seuil qui ne prétend rien dire d'un pôle.

## Le plafond n'est pas un réglage d'apparence

Il ne vient pas du texte (`--encre-douce` tient 5,95:1 à 7,88 %, seuil AA 4,5:1). Il vient
des jetons **`--accent-vif`**, qui portent les filets et doivent tenir 3:1 (WCAG 1.4.11).
Sur le fond réellement peint — `#EDE9E0`, le bas du dégradé d'atelier et non `--fond` —
`--pole-data-vif` n'est déjà qu'à **3,29:1** nu. Il reste 0,29 point, et le lavis en
consomme la quasi-totalité : **à 9 % il passe sous 3:1**. Le monter demanderait de rouvrir
d'abord la palette des `-vif`.

## Contrastes mesurés

Deux mesures indépendantes : le calcul analytique sur la couleur composée, puis la
**lecture au pixel du rendu servi** — grain, trame et lueur de seuil compris.

Calcul, pire cas (lavis à densité maximale, sur le fond le plus défavorable du dégradé) :

| Thème | Pôle | Fond composé | `--encre` | `--encre-douce` | `--accent` (texte) | `--accent-vif` (non-texte) |
|---|---|---|---|---|---|---|
| clair | ingénierie web | `#E6DCD1` | 13.30:1 | **5.95:1** | 5.10:1 | 3.27:1 |
| clair | data | `#DADFD8` | 13.30:1 | **5.96:1** | 4.70:1 | **3.02:1** |
| clair | IA | `#E2DDDA` | 13.34:1 | **5.98:1** | 5.11:1 | 3.30:1 |
| clair | SEA & UX | `#E0DFD1` | 13.39:1 | **6.00:1** | 4.72:1 | 3.03:1 |
| sombre | ingénierie web | `#222020` | 13.16:1 | **6.34:1** | 6.15:1 | 7.89:1 |
| sombre | data | `#13232A` | 13.12:1 | **6.32:1** | 6.65:1 | 8.44:1 |
| sombre | IA | `#1F202B` | 13.11:1 | **6.31:1** | 6.08:1 | 7.79:1 |
| sombre | SEA & UX | `#1C2321` | 13.04:1 | **6.28:1** | 6.59:1 | 8.33:1 |

Lecture au pixel, sur le rendu servi. Légèrement plus basse que le calcul — le grain et la
lueur de seuil s'y ajoutent, et c'est ce qu'un lecteur a sous les yeux :

| Thème | Surface | `--encre-douce` | `--encre` |
|---|---|---|---|
| clair | les quatre portes de l'accueil | **5.59 → 5.70:1** | 12.48 → 12.72:1 |
| clair | les quatre pages de pôle | **5.85 → 5.86:1** | 13.06 → 13.09:1 |
| sombre | les quatre portes de l'accueil | **6.49 → 6.71:1** | 13.48 → 13.92:1 |
| sombre | les quatre pages de pôle | **6.74 → 6.80:1** | 14.00 → 14.12:1 |

Seuils : 4.5:1 pour le texte, 3:1 pour le non-texte. Les deux tiennent.

**Le verre par-dessus.** `GlassSurface` floute ce lavis, un fond plus coloré change ce
qu'il rend. Contrôlé sur les quatre teintes, dans les deux thèmes : `--encre-douce` sur un
panneau posé sur le lavis le plus dense vaut **6.79 à 6.82:1** en clair et **5.23 à
5.28:1** en sombre. Le panneau améliore le contraste en clair (son voile blanc éclaircit
le fond) et le réduit en sombre sans jamais l'approcher du seuil.

## Ce qui a été vérifié

- **Rendu réel** : `next dev` sur les cinq gabarits — accueil et les quatre
  `/services/<pole>/` — dans les **deux thèmes**, par émulation `prefers-color-scheme`.
  Captures et sondes au pixel à l'appui.
- **Budgets** : `make budgets` — Lighthouse accueil **96**, page de pôle **96**, blog /
  article / réalisations **97** ; A11y, bonnes pratiques et SEO à **100** partout.
  axe-core : **0 violation** sur les six pages.
- **Coût** : deux propriétés de fond sur un élément déjà peint. Aucune couche de
  compositing, aucun `filter`, aucun `transform`, rien de repeint au défilement. La tache
  de `.lavis-pole` est dimensionnée en **pixels** et répétée en Y : rasterisée une fois
  sur 1600 × 1100 px, jamais à la hauteur d'un gabarit.
- **Aucune teinte de pôle nommée hors de `poles.css`** : `grep` des huit littéraux ne
  renvoie que les entrées de `poles.css` et les usages **antérieurs** du cuivre de marque
  (`globals.css`, `icon.svg`, `apple-icon.tsx`, `opengraph-image.tsx` — là où une variable
  CSS n'existe pas).
- **`make lint`** et **`make test`** verts. Aucun fichier au-dessus de 300 lignes.
- **WCAG 1.4.1** : le lavis est un décor, le nom du pôle reste écrit en toutes lettres.
- **`prefers-reduced-motion`** : le lavis est statique, il n'y a rien à couper.

## Deux points signalés, non traités ici

- **Le survol d'une porte ne monte plus le fond.** Le lavis est au plafond de contraste :
  un aplat de plus ferait passer `--accent-vif` sous 3:1 pour la donnée et le SEA & UX.
  L'état reste porté par deux choses visibles — l'arête qui se ferme et l'invite qui se
  souligne — dont aucune ne repose sur la seule couleur.
- **`ChainDiagram` n'est pas peint**, bien que l'issue le liste dans les impacts. Le
  maillon « data » **contient** les deux branches IA et SEA & UX : une nappe posée dessus
  se composerait avec la leur à ~15 %, sous le seuil de 3:1. Et ses plaques sont des
  surfaces de verre, pas du papier. À rouvrir séparément si Jérôme MARICHEZ le souhaite.
- **`--accent` dilué à 45 %** (chiffre de place de `PoleHero`, filet de preuve de
  `PoleEntries`) est à **1,9 à 2,5:1**, et l'était **déjà avant ce lot** — le lavis lui
  coûte 0,07 point, teinte et fond bougeant ensemble. Consigné dans
  `docs/accessibility.md` comme point ouvert.

## Documentation

- `docs/design.md` — la section « La maille de fond » devient « **Le lavis de pôle** » :
  mécanisme, les deux couches, le plafond et son origine, contraintes tenues, et les deux
  tableaux de contraste.
- `docs/accessibility.md` — nouvelle section « **Le lavis de pôle — contrastes relevés** »
  avec les valeurs mesurées, le verre par-dessus, et les points ouverts.

## Tests

Aucun fichier de test n'est posé par cette PR : la politique du projet réserve leur
écriture à Jérôme MARICHEZ. Les **intentions** proposées sont exposées dans le fil de la
tâche — elles portent sur le mécanisme (le porteur du lavis est bien celui qui porte
`data-pole`) et sur l'invariant de palette (aucune teinte nommée hors de `poles.css`),
tous deux vérifiables en unitaire sans navigateur.
