### PR TITLE
feat: deux articles, le plugin open source et la carte vivante

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,15 @@ d'image — et, quand il en a une, un lien vers sa **publication d'origine**. Le
 l'entité est décrit dans [`docs/data-model.md`](./docs/data-model.md), la grammaire des
 figures dans [`docs/design.md`](./docs/design.md).
 
+Un article peut reprendre un post publié ailleurs, jamais le recopier : les règles de
+véracité s'y appliquent mot pour mot, et un post plus large que ce qui est établi se
+**réécrit à la baisse** — c'est ce qui s'est passé pour « Un générateur de projets, public
+et personnel », dont le post d'origine annonçait une CI plus validée qu'elle ne l'est.
+Deux conséquences valables partout : aucun appel à l'action de réseau social (étoile,
+partage, contribution) n'entre dans le contenu publié, et un article dont l'**URL
+d'origine n'a pas été fournie se publie sans source** plutôt qu'avec une adresse
+approchée — même règle que les justificatifs de certification.
+
 ## ✅ Contraintes produit
 
 - **SEO** : **export statique intégral** (`output: 'export'`) — aucune page n'est rendue

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -112,11 +112,14 @@ construction du site, ou elles restent à la charge de l'auteur :
 - **`source.url` n'est jamais devinée.** C'est la règle des justificatifs de certification,
   à l'identique : tant que l'adresse n'a pas été fournie par Jérôme MARICHEZ, l'article se
   publie **sans source**. C'est la raison d'être du caractère optionnel du champ, et non une
-  commodité de saisie. Les trois articles publiés n'en portent aucune.
+  commodité de saisie. Le cas s'est présenté dès le quatrième article : « Un générateur de
+  projets, public et personnel » reprend un post LinkedIn dont l'URL n'a pas été fournie ; il
+  se publie **sans source** plutôt qu'avec une adresse approchée. Le cinquième, lui, porte
+  la sienne, fournie telle quelle.
 - **`figure` est obligatoire, délibérément.** La laisser facultative aurait produit une liste
   où certains articles ont une figure et d'autres pas, c'est-à-dire un rythme cassé sans
   qu'aucune information ne le justifie. Deux articles peuvent partager une figure — rien ne
-  l'interdit — mais les trois publiés en ont chacun une, sans quoi elle cesserait de
+  l'interdit — mais les articles publiés en ont chacun une, sans quoi elle cesserait de
   distinguer.
 
 ### Règles portées par le service
@@ -141,8 +144,8 @@ un composant :
   une URL qui rendrait 404 serait une affirmation fausse de plus. Le jour où une image est
   réellement servie, le champ s'ajoute ; pas avant. Voir `docs/design.md`, « Les figures
   d'article ».
-- **Pas de rattachement à un pôle, pas de tags, pas de catégories.** Avec trois articles,
-  une taxonomie serait un classement sans classe. Le jour où elle s'impose, le
+- **Pas de rattachement à un pôle, pas de tags, pas de catégories.** À cinq articles,
+  une taxonomie serait encore un classement sans classe. Le jour où elle s'impose, le
   rattachement dérivera de `PoleId` et de l'ordre porté par `POLES_NAV` — jamais d'une
   liste de pôles recopiée dans le blog. L'ordre est **la position dans `POLES_NAV`**, et
   nulle part ailleurs : une seconde liste d'ordre finirait par contredire la première.

--- a/docs/design.md
+++ b/docs/design.md
@@ -709,8 +709,8 @@ site que l'accueil.
 ### Construite, jamais matricielle
 
 Le site n'a **aucune image matricielle** : quatre SVG en tout, `next/image` écarté
-délibérément. Une illustration d'article n'allait pas en introduire la première. Les trois
-figures sont du **SVG rendu au serveur**, elles pèsent quelques centaines d'octets dans le
+délibérément. Une illustration d'article n'allait pas en introduire la première. Les figures
+sont du **SVG rendu au serveur**, elles pèsent quelques centaines d'octets dans le
 document, et le budget Lighthouse — qui ne tient qu'à un point — n'en sait rien.
 
 Elles n'ont **aucun fichier**, ce qui a une conséquence en dehors du design : le JSON-LD
@@ -750,6 +750,25 @@ au rendu, pas supposé.
 | Pourquoi ce site est un export statique | `borne` | Trois plaques écrites, un aboutissement, une ligne que rien ne franchit ; au-delà, tireté, le serveur applicatif qui n'existe plus |
 | Le test avant le code, même avec un agent | `anteriorite` | Deux temps sur un axe — le point posé d'abord, la boîte ouverte ensuite ; dessous, tiretée et fermée d'une croix, la voie inverse |
 | Mesurer avant d'arbitrer | `appui` | Un fléau à l'horizontale et deux plateaux identiques, la décision au sommet du mât, portés par une assise et sa trame de mesure |
+| Un générateur de projets, public et personnel | `gabarit` | Une forme à trois compartiments, ouverte du côté de la sortie, et ce qui en sort : un cadre fermé, complet, jusqu'à son aboutissement |
+| Le premier risque n'est pas le code, c'est l'endroit | `liaison` | Des ensembles séparés, un lieu commun plus grand qu'eux, deux liens qui portent — et un troisième, tireté, qui n'aboutit à rien |
+
+Deux ajouts de l'issue #109 étendent la grammaire sans la contredire, et il vaut mieux
+l'écrire ici que le redécouvrir :
+
+- **Le trait tireté couvre une nuance de plus.** Sur `liaison`, « écarté » devient
+  « annoncé, jamais emprunté » — la dépendance déclarée que rien n'importe. C'est le même
+  sens au fond, un chemin qui n'a pas lieu ; le signe n'a donc pas eu à être dédoublé.
+- **La longueur d'un tracé tireté est une contrainte, pas un hasard.** C'est le constat déjà
+  fait sur la croix de `anteriorite` : à 2,6 unités de tiret, un segment court ne rend que
+  son amorce. Là où la croix a été traitée en **retirant** le tiretage, le lien de `liaison`
+  l'est en **allongeant** le tracé — quinze unités, soit trois tirets pleins.
+
+Ce que ces deux figures se sont **interdit** relève de la même règle que le fléau horizontal
+de `appui` : ne rien dessiner qui se compte. Pas de pile de formes produites sur `gabarit`,
+qui afficherait un nombre de projets générés que personne n'a mesuré ; pas un carré par dépôt
+sur `liaison`, qui afficherait la taille d'un système que l'article ne nomme pas et n'a pas à
+nommer.
 
 ### Deux registres, un seul jeton
 
@@ -783,9 +802,11 @@ n'appartient à aucun pôle. Les deux thèmes suivent sans qu'une ligne y soit c
 
 Un article peut reprendre un texte d'abord paru sur un réseau
 ([`ArticleSource`](../src/@vitrine/components/ArticleSource/index.tsx)). Le champ est
-**optionnel** et le restera : les trois articles publiés ont été écrits pour ce site et
-n'ont pas de post d'origine. **Une URL absente ne se devine pas** — c'est déjà la règle des
-justificatifs de certification. Sans source, rien n'est rendu : ni ligne vide, ni filet
+**optionnel** et le restera. Un seul article publié porte une source à ce jour ; les autres
+ont été écrits pour ce site, **ou bien reprennent un post dont l'adresse n'a pas été
+fournie** — c'est le cas de « Un générateur de projets, public et personnel », et il se
+publie donc sans source. **Une URL absente ne se devine pas** : c'est déjà la règle des
+justificatifs de certification. Sans source, rien n'est rendu — ni ligne vide, ni filet
 orphelin.
 
 Le lien sort du site, et **son caractère externe ne repose pas sur la couleur** (WCAG 1.4.1).

--- a/scripts/budgets/pages.mjs
+++ b/scripts/budgets/pages.mjs
@@ -73,6 +73,15 @@ export const PAGES = [
     pourquoi: "gabarit d'article : corps long, typographie, fil d'Ariane, JSON-LD",
   },
   {
+    id: 'article-avec-source',
+    chemin: '/blog/le-premier-risque-n-est-pas-le-code-c-est-l-endroit/',
+    pourquoi:
+      "variante du gabarit d'article : la note de publication d'origine et son lien sortant " +
+      'en target=_blank. Ajoutée avec le premier article qui en porte une (issue #109) — le ' +
+      "composant existait depuis l'issue #108, mais aucune page mesurée ne le rendait, donc " +
+      "son contraste et l'intitulé de son lien n'étaient contrôlés nulle part",
+  },
+  {
     id: 'realisations',
     chemin: '/realisations/',
     pourquoi:

--- a/src/@vitrine/components/ArticleFigure/index.tsx
+++ b/src/@vitrine/components/ArticleFigure/index.tsx
@@ -20,8 +20,12 @@
 // Elle est reprise trait pour trait, et c'est ce qui fait que le blog appartient au même
 // site que l'accueil : trait plein pour ce qui est retenu, **trait tireté pour ce qui est
 // écarté**, croix pour une voie fermée, point plein pour un aboutissement, trait plus
-// épais pour une assise. Un lecteur qui a vu les quatre marques lit ces trois figures sans
-// qu'on lui explique rien.
+// épais pour une assise. Un lecteur qui a vu les quatre marques lit ces figures sans qu'on
+// lui explique rien.
+//
+// Le trait tireté couvre une nuance de plus depuis la figure `liaison` : « écarté » y devient
+// « annoncé, jamais emprunté » — une dépendance déclarée que rien n'importe. C'est le même
+// sens au fond, un chemin qui n'a pas lieu, et le signe n'a donc pas eu à être dédoublé.
 //
 // Le registre, lui, diffère : une marque de pôle est carrée (32 × 32), une figure d'article
 // est **couchée** (48 × 32). Une page de pôle vend, un article raconte — et une figure large
@@ -100,10 +104,67 @@ function Appui() {
   )
 }
 
+/**
+ * Le gabarit — « Un générateur de projets, public et personnel ».
+ *
+ * À gauche, la forme : un cadre à trois compartiments, **ouvert du côté de la sortie**, parce
+ * qu'un gabarit n'est pas ce qu'il produit. À droite, ce qui en sort, fermé et complet jusqu'à
+ * son aboutissement — le projet qui se construit dès la génération.
+ *
+ * Ce qui n'est PAS dessiné : un compte. Une pile de formes produites, ou plusieurs
+ * aboutissements alignés, afficherait un nombre de projets générés que personne n'a mesuré.
+ * Une seule sortie, donc — la figure dit qu'il en sort quelque chose de complet, jamais
+ * combien de fois.
+ */
+function Gabarit() {
+  return (
+    <>
+      <path d="M16 6H4v20h12" />
+      <path d="M4 12.5h9M4 19.5h9" />
+      <path d="M16 16h8" />
+      <path d="M24 6h12v20H24z" />
+      <path d="M24 12.5h12M24 19.5h12" />
+      <path d="M36 16h2.6" />
+      <circle cx="41" cy="16" fill="currentColor" r="2.4" stroke="none" />
+    </>
+  )
+}
+
+/**
+ * La liaison — « Le premier risque n'est pas le code, c'est l'endroit ».
+ *
+ * Des ensembles séparés — des dépôts — et, plus grand qu'eux, le lieu commun où le
+ * comportement partagé doit atterrir. Deux liens pleins le relient vraiment ; le troisième
+ * est **tireté et n'aboutit à rien**, c'est la dépendance déclarée que rien n'importe, celle
+ * que la carte de l'article a fait apparaître.
+ *
+ * Le lien tireté est le plus long des trois, et c'est mesuré, pas décoratif : à 2,6 unités de
+ * tiret, un segment court ne rend que son amorce et se lit comme un trait plein — la même
+ * correction que la croix de `anteriorite`, prise ici en allongeant le tracé plutôt qu'en
+ * retirant le tiretage.
+ *
+ * Les blocs ne se comptent pas : ils sont là pour être reliés. Aligner un dépôt par carré
+ * afficherait la taille d'un système qui n'est pas nommé dans l'article, et n'a pas à l'être.
+ */
+function Liaison() {
+  return (
+    <>
+      <path d="M3 4h7v7H3z" />
+      <path d="M3 21h7v7H3z" />
+      <path d="M14 11.5h9v9h-9z" />
+      <path d="M38 12.5h7v7h-7z" />
+      <path d="M10 9l4 4M10 23l4-4" />
+      <path className={styles.ecarte} d="M23 16h15" />
+    </>
+  )
+}
+
 const TRACES: Record<ArticleFigureId, () => React.JSX.Element> = {
   borne: Borne,
   anteriorite: Anteriorite,
   appui: Appui,
+  gabarit: Gabarit,
+  liaison: Liaison,
 }
 
 /**

--- a/src/@vitrine/components/ArticleSource/index.tsx
+++ b/src/@vitrine/components/ArticleSource/index.tsx
@@ -5,10 +5,12 @@
 // à s'attribuer la primeur d'un texte republié, ce qui est exactement le genre d'affirmation
 // que les règles de véracité du CLAUDE.md interdisent.
 //
-// **Aucune URL n'est devinée.** Les trois articles publiés n'ont pas de post d'origine connu
-// et ne portent donc pas de source : ce composant n'est alors jamais rendu, et la fiche n'a
-// ni ligne vide ni filet orphelin. C'est la même règle que les justificatifs de certification
-// — tant que l'adresse n'a pas été fournie par Jérôme MARICHEZ, rien n'est publié.
+// **Aucune URL n'est devinée.** Un seul article publié porte une source à ce jour. Les autres
+// n'ont pas de post d'origine — ou en ont un dont l'adresse n'a pas été fournie, et c'est le
+// cas de l'article sur le générateur de projets : il se publie donc sans source. Dans les deux
+// cas ce composant n'est pas rendu, et la fiche n'a ni ligne vide ni filet orphelin. C'est la
+// même règle que les justificatifs de certification : tant que l'adresse n'a pas été fournie
+// par Jérôme MARICHEZ, rien n'est publié.
 
 import type { IArticleSource } from '@/interfaces/IArticleSource'
 import type { ArticleSourceReseau } from '@/interfaces/types'

--- a/src/@vitrine/contenu/blog/articles.ts
+++ b/src/@vitrine/contenu/blog/articles.ts
@@ -10,11 +10,15 @@
 
 import type { IArticle } from '@/interfaces/IArticle'
 import { ARTICLE_EXPORT_STATIQUE } from './export-statique'
+import { ARTICLE_GENERATEUR_DE_PROJETS } from './generateur-de-projets'
 import { ARTICLE_MESURER_AVANT_ARBITRER } from './mesurer-avant-arbitrer'
+import { ARTICLE_RISQUE_DE_L_ENDROIT } from './risque-de-l-endroit'
 import { ARTICLE_TEST_AVANT_CODE } from './test-avant-code'
 
 export const ARTICLES: IArticle[] = [
   ARTICLE_EXPORT_STATIQUE,
   ARTICLE_TEST_AVANT_CODE,
   ARTICLE_MESURER_AVANT_ARBITRER,
+  ARTICLE_GENERATEUR_DE_PROJETS,
+  ARTICLE_RISQUE_DE_L_ENDROIT,
 ]

--- a/src/@vitrine/contenu/blog/generateur-de-projets.ts
+++ b/src/@vitrine/contenu/blog/generateur-de-projets.ts
@@ -1,0 +1,107 @@
+// generateur-de-projets.ts — jeromemarichez-fr
+// Article — le générateur qui initialise mes projets, ouvert au public.
+//
+// Véracité (CLAUDE.md) : tout ce qui est affirmé ici vient du README du dépôt
+// `bootstrap-claudecode-typescript` (public, licence MIT), et non du post LinkedIn qui a
+// annoncé le plugin. Trois écarts au post sont délibérés :
+//
+// 1. La CI. Le post dit « GitHub Actions ou GitLab CI au choix » ; le README dit que les
+//    workflows GitHub Actions sont testés et fonctionnels et que le fichier GitLab généré
+//    n'est validé que par le test de fumée. L'article dit la version du README.
+// 2. Le plugin est assumé « avant tout personnel », comme le README l'écrit en tête, et
+//    non « pensé pour être réutilisé » comme le disait le post.
+// 3. Aucune revendication d'adoption, de popularité ou de traction : le dépôt est à zéro
+//    étoile au 2026-08-23. Aucun appel à mettre une étoile, à partager ou à contribuer
+//    non plus — ce site n'est pas un réseau social.
+//
+// Pas de champ `source` : l'URL du post d'origine n'a pas été fournie par Jérôme MARICHEZ,
+// et une URL ne s'invente ni ne s'approxime (voir `IArticleSource`).
+
+import type { IArticle } from '@/interfaces/IArticle'
+
+export const ARTICLE_GENERATEUR_DE_PROJETS: IArticle = {
+  slug: 'un-generateur-de-projets-public-et-personnel',
+  titre: 'Un générateur de projets, public et personnel',
+  chapo:
+    'J’ai ouvert le code du plugin qui initialise mes projets TypeScript : une commande, et ' +
+    'le projet existe — documentation, règles, tests, lint, CI. Il est public, et il encode ' +
+    'mes conventions à moi. Les deux tiennent ensemble, à condition de le dire.',
+  meta: {
+    title: 'Un générateur de projets, public et personnel',
+    description:
+      'Un plugin qui initialise un projet TypeScript complet en une commande : le critère ' +
+      'de réussite que je me suis donné, ce que la CI générée vaut réellement, et où ' +
+      'devraient vivre vos conventions.',
+  },
+  datePublication: '2026-08-23',
+  // La figure « gabarit » : une forme ouverte du côté de la sortie, et ce qui en sort déjà
+  // complet, jusqu'à son aboutissement. Elle dit qu'un point de départ se produit, jamais
+  // combien de projets en sont sortis — aucun compte n'est affiché nulle part.
+  figure: 'gabarit',
+  sections: [
+    {
+      id: 'le-cout-du-premier-jour',
+      titre: 'Ce que coûte le premier jour',
+      paragraphes: [
+        'Le premier jour d’un projet est celui où l’on décide le plus avec le moins : ' +
+          'l’emplacement des tests, le modèle de branches, la limite de taille d’un fichier, ' +
+          'ce que la CI refuse de laisser passer. Personne n’a le temps de trancher vraiment, ' +
+          'alors on recopie le dernier projet — la moitié du dernier projet, en réalité — et ' +
+          'on vit deux ans avec le résultat.',
+        'Quand une part du code est produite par un agent, ce jour-là pèse plus lourd encore : ' +
+          'les règles qu’un agent applique sont exactement les fichiers posés au démarrage. Une ' +
+          'convention absente le premier jour ne s’ajoute pas le quarantième — elle se discute ' +
+          'en revue de code, une fois que le code contraire existe déjà.',
+      ],
+    },
+    {
+      id: 'un-critere-de-reussite',
+      titre: 'Un critère de réussite, pas un squelette',
+      paragraphes: [
+        'D’où ce plugin, bootstrap-claudecode-typescript : le générateur pose ses questions — ' +
+          'type de projet, framework, CI, niveaux de tests — puis écrit l’ensemble. Le critère ' +
+          'que je me suis donné tient en une ligne de terminal : make install, make lint, make ' +
+          'test et make build passent dès la génération. Un squelette qui ne se construit pas ' +
+          'n’est pas un point de départ, c’est une liste de choses à faire — précisément ce ' +
+          'qu’on n’a pas le temps de faire le premier jour.',
+        'Ce critère décide de tout le reste. La CI générée exécute les vraies cibles du ' +
+          'Makefile au lieu d’étapes qui affichent un TODO ; la structure de tests contient un ' +
+          'test qui passe, pour que la chaîne d’outils soit prouvée et non supposée ; et les ' +
+          'règles qui comptent — la limite de trois cents lignes par fichier, le test écrit ' +
+          'avant le code, l’interdiction des doublures de modules — sont portées par des hooks ' +
+          'qui refusent, pas par un paragraphe de documentation lu une fois.',
+      ],
+    },
+    {
+      id: 'ce-qu-il-n-est-pas',
+      titre: 'Ce qu’il n’est pas',
+      paragraphes: [
+        'Le dépôt est public sous licence MIT, et le plugin reste avant tout personnel : il ' +
+          'encode mes conventions et mes habitudes de travail. Utilisable par d’autres, mais ' +
+          'les choix — la structure, les hooks, les règles — reflètent ma façon de faire. Je ' +
+          'préfère l’écrire en tête du dépôt plutôt que laisser quelqu’un le découvrir à la ' +
+          'troisième question du générateur.',
+        'L’état de la CI se dit de la même manière. Les workflows GitHub Actions sont testés ' +
+          'et fonctionnels ; le fichier GitLab CI produit est conçu pour tourner sur les deux ' +
+          'exécuteurs, mais il n’est validé que par le test de fumée du générateur. C’est ' +
+          'l’état de la validation, pas celui de l’intention — et c’est exactement ce que ' +
+          'j’attends qu’un prestataire me dise avant que je m’engage sur son travail.',
+      ],
+    },
+    {
+      id: 'ou-vivent-vos-conventions',
+      titre: 'Où vivent vos conventions',
+      paragraphes: [
+        'La question n’est pas de savoir quel générateur adopter — le mien encode mes règles, ' +
+          'pas les vôtres. Elle est de savoir où vivent vos conventions : dans un document lu ' +
+          'une fois à l’arrivée d’une nouvelle personne, ou dans un outillage rencontré à ' +
+          'chaque écriture de fichier. Le premier se périme en silence ; le second échoue ' +
+          'bruyamment, à la trois cent unième ligne.',
+        'Vient ensuite une décision qui coûte plus qu’elle n’en a l’air : ce que vaut le ' +
+          'premier jour de votre prochain projet, et qui le paie. Une équipe qui réimprovise ' +
+          'son point de départ à chaque fois le paie deux fois par an, dans la monnaie la plus ' +
+          'chère qui soit — les choix qu’elle garde ensuite.',
+      ],
+    },
+  ],
+}

--- a/src/@vitrine/contenu/blog/risque-de-l-endroit.ts
+++ b/src/@vitrine/contenu/blog/risque-de-l-endroit.ts
@@ -1,0 +1,112 @@
+// risque-de-l-endroit.ts — jeromemarichez-fr
+// Article — le contexte d'un agent sur un produit réparti, et la carte qui le rend visible.
+//
+// Confidentialité (CLAUDE.md) : ni le produit, ni les dépôts, ni le client ne sont nommés.
+// Le post d'origine n'en nomme aucun non plus — il dit « app web, app mobile, vitrine,
+// package partagé, backend », et l'article s'en tient là. Obsidian est nommé : c'est un
+// outil du commerce, pas une information couverte.
+//
+// Véracité (CLAUDE.md) : la seule preuve avancée est celle que la carte a réellement
+// produite — une dépendance déclarée que rien n'importait. Aucun gain de temps, aucun
+// nombre d'incidents évités, aucun pourcentage n'est revendiqué : rien de tout cela n'a
+// été mesuré, et l'article ne le laisse pas entendre.
+//
+// La `source` porte l'URL exacte fournie par Jérôme MARICHEZ. Le post est paru le
+// 2026-08-10 ; `datePublication` est la date de publication **sur ce site**, et la note de
+// republication dit au lecteur que le texte a d'abord paru ailleurs.
+
+import type { IArticle } from '@/interfaces/IArticle'
+
+export const ARTICLE_RISQUE_DE_L_ENDROIT: IArticle = {
+  slug: 'le-premier-risque-n-est-pas-le-code-c-est-l-endroit',
+  titre: 'Le premier risque n’est pas le code, c’est l’endroit',
+  chapo:
+    'Un produit découpé en plusieurs dépôts indépendants ne casse pas quand un comportement ' +
+    'partagé est écrit au mauvais endroit : il diverge, en silence, et on l’apprend des mois ' +
+    'plus tard. Les tests et la CI n’y voient rien — ils vérifient le code, pas son adresse.',
+  meta: {
+    title: 'Le premier risque n’est pas le code, c’est l’endroit',
+    description:
+      'Donner le bon contexte à un agent sur un produit réparti en plusieurs dépôts : des ' +
+      'règles nées d’incidents, ce qu’elles ne protègent pas, et une carte de l’architecture ' +
+      'faite des fichiers du code eux-mêmes.',
+  },
+  datePublication: '2026-08-23',
+  source: {
+    reseau: 'linkedin',
+    url: 'https://www.linkedin.com/feed/update/urn:li:ugcPost:7492203940789391360/',
+  },
+  // La figure « liaison » : des ensembles séparés, un lieu commun plus grand qu'eux, les
+  // liens qui portent vraiment, et un lien tireté qui n'aboutit à rien — la dépendance
+  // déclarée que rien n'importe. Aucune quantité n'y est dessinée, pas même un compte de
+  // dépôts : les blocs sont là pour être reliés, pas pour être comptés.
+  figure: 'liaison',
+  sections: [
+    {
+      id: 'plusieurs-depots-un-seul-bon-endroit',
+      titre: 'Plusieurs dépôts, un seul bon endroit',
+      paragraphes: [
+        'Le produit dont je parle n’est pas un monorepo : application web, application mobile, ' +
+          'vitrine, package partagé et backend vivent chacun dans leur dépôt, avec leur cycle ' +
+          'de vie, leur intégration continue et leurs versions. C’est un choix, il se défend, ' +
+          'et il tient.',
+        'Mais il déplace le risque. Un comportement partagé n’a qu’une seule bonne adresse — le ' +
+          'package commun. Écrit dans une application, rien ne casse : les deux plateformes ' +
+          'commencent simplement à diverger sans que personne le voie. C’est arrivé, et ce ' +
+          'n’était pas un problème de qualité de code : le code était juste, il était au ' +
+          'mauvais endroit.',
+      ],
+    },
+    {
+      id: 'des-regles-nees-d-incidents',
+      titre: 'Des règles nées d’incidents',
+      paragraphes: [
+        'La réponse a été un fichier de règles à la racine, écrit comme une table ' +
+          'd’aiguillage : cette demande, ce dépôt, ce piège. Un fichier par dépôt en dessous, et ' +
+          'des hooks qui rappellent la règle au moment où elle s’applique et tiennent la ' +
+          'documentation à jour au fil du travail. Chaque règle vient d’un incident réel, jamais ' +
+          'd’une intention de bien faire : un guide de style écrit à l’avance décrit un projet ' +
+          'imaginaire, une règle écrite après une erreur décrit celui qu’on a.',
+        'Reste ce qu’aucun de ces fichiers ne couvre. Les tests, la CI et la procédure ' +
+          'protègent la correction du code ; aucun des trois ne dit qui a touché quoi, ni si le ' +
+          'contexte qu’un agent a lu était le bon fichier plutôt qu’un fichier voisin qui ne dit ' +
+          'plus la vérité. Ce manque-là ne se voit pas dans une pipeline rouge — il se voit des ' +
+          'mois plus tard, sous la forme d’un comportement écrit deux fois.',
+      ],
+    },
+    {
+      id: 'une-carte-faite-des-fichiers',
+      titre: 'Une carte faite des fichiers eux-mêmes',
+      paragraphes: [
+        'J’ai donc ouvert ces mêmes fichiers Markdown — documentation, fichiers de règles, ' +
+          'skills, agents — dans Obsidian, et je l’ai laissé tracer le graphe. La carte est ' +
+          'synchronisée par construction, puisqu’elle est faite du dépôt lui-même : ce n’est pas ' +
+          'un schéma dessiné à côté, déconnecté dès le lendemain. Chaque dépôt a sa couleur, les ' +
+          'dossiers de documentation portent un pastel de la couleur de leur dépôt — ce qui ' +
+          'montre d’un coup d’œil où la documentation est dense et où elle est maigre — et les ' +
+          'liens ne sont posés qu’aux endroits d’usage réel, vérifiés avant d’être écrits.',
+        'Le gain est visuel, et ce n’est pas un gain d’esthétique : un nœud isolé sans aucune ' +
+          'arête, une couleur qui n’a rien à faire là. Une anomalie de structure se regarde, ' +
+          'elle ne se lit pas — aucune lecture séquentielle ne la fait ressortir aussi vite. ' +
+          'C’est ainsi que la carte a fait apparaître une dépendance déclarée que rien ' +
+          'n’importait : une ligne juste dans un fichier de configuration, et pas une ligne de ' +
+          'code derrière.',
+      ],
+    },
+    {
+      id: 'ce-que-vous-tranchez',
+      titre: 'Ce que vous pouvez trancher',
+      paragraphes: [
+        'La question n’est pas « monorepo ou pas » : les deux se défendent, et le découpage ' +
+          'décrit ici tient. Elle est de savoir ce qui, chez vous, signale qu’un comportement ' +
+          'partagé a été écrit au mauvais endroit, et combien de temps il faut pour l’apprendre. ' +
+          'Si la réponse est « une revue de code, à condition que le relecteur connaisse tout le ' +
+          'produit », alors le dispositif repose sur la mémoire d’une personne.',
+        'Le principe, lui, n’a pas changé : ne pas se répéter est une règle aussi vieille que ' +
+          'le métier. Ce qui a changé, c’est la vitesse à laquelle on peut la violer sans s’en ' +
+          'apercevoir. Et c’est cette vitesse-là, pas le principe, qui décide de l’outillage ' +
+          'dont vous avez besoin.',
+      ],
+    },
+  ],
+}

--- a/src/@vitrine/views/ArticleView/index.tsx
+++ b/src/@vitrine/views/ArticleView/index.tsx
@@ -66,8 +66,8 @@ export function ArticleView({ article, index, autres }: ArticleViewProps) {
           ))}
         </div>
 
-        {/* Rien n'est rendu quand la source est absente : c'est le cas des trois articles
-            publiés, et une note « publié nulle part ailleurs » n'aurait aucun sens. */}
+        {/* Rien n'est rendu quand la source est absente : c'est le cas de la plupart des
+            articles, et une note « publié nulle part ailleurs » n'aurait aucun sens. */}
         {article.source ? <ArticleSource source={article.source} /> : null}
       </article>
 

--- a/src/interfaces/IArticle.ts
+++ b/src/interfaces/IArticle.ts
@@ -47,17 +47,18 @@ export interface IArticle {
    *
    * Ce n'est **pas** un chemin de fichier : le site ne sert aucune image matricielle, et
    * cette valeur désigne un tracé SVG rendu au serveur (voir `ArticleFigureId`). Deux
-   * articles peuvent partager une figure — rien ne l'interdit ici — mais les trois
-   * articles publiés en ont chacun une, sans quoi la figure cesserait de distinguer.
+   * articles peuvent partager une figure — rien ne l'interdit ici — mais les articles
+   * publiés en ont chacun une, sans quoi la figure cesserait de distinguer.
    */
   figure: ArticleFigureId
   /**
    * Publication d'origine de l'article, quand il en a une.
    *
-   * Optionnelle, et elle le restera : les trois premiers articles ont été écrits pour ce
-   * site et n'ont pas de post d'origine. **Une URL absente ne se devine pas** — un
-   * article sans source fournie se publie sans source, et la fiche n'affiche alors
-   * simplement rien. Voir `IArticleSource`.
+   * Optionnelle, et elle le restera : la plupart des articles sont écrits pour ce site et
+   * n'ont pas de post d'origine. **Une URL absente ne se devine pas** — un article
+   * repris d'ailleurs mais dont l'adresse n'a pas été fournie se publie **sans source**,
+   * jamais avec un lien deviné, et la fiche n'affiche alors simplement rien. Le cas s'est
+   * présenté dès le quatrième article. Voir `IArticleSource`.
    */
   source?: IArticleSource
   /** Corps de l'article, découpé en sections titrées. */

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -49,13 +49,15 @@ export type SectionKind = 'pole' | 'chapitre' | 'charniere' | 'fil' | 'preuves'
  * serveur par `@vitrine/components/ArticleFigure`. L'union est close, donc un article ne
  * peut pas réclamer une figure qui n'existe pas — le compilateur le dit avant le build.
  *
- * Les trois noms disent la STRUCTURE dessinée, pas le sujet de l'article : c'est la même
- * règle que les marques de pôle, dont aucune ne simule une donnée chiffrée.
+ * Les noms disent la STRUCTURE dessinée, pas le sujet de l'article : c'est la même règle
+ * que les marques de pôle, dont aucune ne simule une donnée chiffrée.
  * `borne`        : ce qui est produit s'arrête à une ligne, et au-delà rien ne tourne.
  * `anteriorite`  : deux temps sur un axe, et le sens inverse écarté.
  * `appui`        : une décision en équilibre, portée par une assise mesurée.
+ * `gabarit`      : une forme ouverte du côté de la sortie, et ce qui en sort déjà complet.
+ * `liaison`      : des ensembles séparés, et un lien annoncé qui ne relie rien.
  */
-export type ArticleFigureId = 'borne' | 'anteriorite' | 'appui'
+export type ArticleFigureId = 'borne' | 'anteriorite' | 'appui' | 'gabarit' | 'liaison'
 
 /**
  * Le réseau où un article a d'abord paru.


### PR DESCRIPTION
Referme le travail demande par l'issue #109 (la reference est ecrite ici, mais elle ne ferme rien automatiquement : la PR vise `dev`, la branche par defaut est `main`).

## Les deux articles

| Slug | Titre | Angle |
|------|-------|-------|
| `un-generateur-de-projets-public-et-personnel` | Un generateur de projets, public et personnel | Le premier jour d'un projet decide des deux annees suivantes. Le plugin en fait une commande — et le critere retenu n'est pas « un squelette », c'est « ca se construit ». Se termine sur : ou vivent vos conventions, dans un document ou dans un outillage ? |
| `le-premier-risque-n-est-pas-le-code-c-est-l-endroit` | Le premier risque n'est pas le code, c'est l'endroit | Plusieurs depots independants : le risque n'est pas la qualite du code, c'est son adresse. Des regles nees d'incidents, ce qu'elles ne protegent pas, et une carte faite des fichiers eux-memes. Se termine sur : qu'est-ce qui, chez vous, signale qu'un comportement partage a ete ecrit au mauvais endroit, et en combien de temps ? |

Les deux sont dates du 2026-08-23, la date de publication **sur ce site**. Quatre sections de deux paragraphes chacune, comme « Le test avant le code » — meme longueur, meme decoupage, meme facon de finir.

## Les ecarts au post LinkedIn, et pourquoi

Un post n'est pas un contenu de ce site : les regles de veracite du `CLAUDE.md` priment sur la formulation d'origine. Cinq ecarts, tous delibers.

**Article sur le plugin**

1. **La CI.** Le post annonce « GitHub Actions ou GitLab CI au choix ». Le README du depot est plus prudent, et c'est lui qui fait foi : les workflows GitHub Actions sont **testes et fonctionnels**, le `.gitlab-ci.yml` genere **n'est valide que par le test de fumee**. L'article ecrit la version du README, et en fait un argument : « c'est l'etat de la validation, pas celui de l'intention — et c'est exactement ce que j'attends qu'un prestataire me dise ».
2. **« Pense pour etre reutilise ».** Le README assume un plugin **avant tout personnel**. L'article le reprend tel quel, dans une section qui s'appelle « Ce qu'il n'est pas ».
3. **Aucune revendication d'adoption, de popularite ou de traction.** Le depot est a **0 etoile** au 2026-08-23 (verifie par `gh repo view`). Rien dans l'article ne parle de diffusion, de communaute ou de reutilisation par des tiers.
4. **Aucun appel a l'action de reseau social.** Le post en contient un ; le site n'est pas un reseau social. Ni etoile, ni partage, ni contribution.
5. **Pas de champ `source`.** L'URL du post n'a pas ete fournie, et une URL ne s'invente ni ne s'approxime — meme regle que les justificatifs de certification. L'article se publie donc sans reference plutot qu'avec une adresse approchee.

**Article sur la carte**

- `source` renseignee avec l'URL exacte fournie, reseau `linkedin`. La fiche affiche « Ce texte a d'abord paru sur LinkedIn ».
- **Ni le produit, ni les depots, ni le client ne sont nommes** — le post d'origine n'en nomme aucun non plus : il dit « app web, app mobile, vitrine, package partage, backend », et l'article s'en tient a cette liste. Obsidian est nomme, c'est un outil du commerce.
- **Une seule preuve, celle qui est verifiable** : la carte a fait apparaitre une dependance declaree que rien n'importait. Aucun gain de temps, aucun nombre d'incidents evites, aucun pourcentage — rien de cela n'a ete mesure.

## Les deux figures

`ArticleFigureId` passait de trois a cinq valeurs, et le composant dessine deux traces de plus, dans la grammaire de `PoleGlyph` : `currentColor`, aucune couleur en dur, `aria-hidden`, les deux themes par les jetons.

- **`gabarit`** — une forme a trois compartiments **ouverte du cote de la sortie**, et ce qui en sort : un cadre ferme, complet, jusqu'a son aboutissement.
- **`liaison`** — des ensembles separes, un lieu commun plus grand qu'eux, deux liens qui portent, et un troisieme **tirete qui n'aboutit a rien** : la dependance declaree que rien n'importe.

**Ni l'une ni l'autre ne dessine une quantite**, c'est la meme regle que le fleau strictement horizontal de `appui` : pas de pile de formes produites sur `gabarit` (elle afficherait un nombre de projets generes que personne n'a mesure), pas un carre par depot sur `liaison` (il afficherait la taille d'un systeme que l'article ne nomme pas).

Deux extensions de la grammaire sont ecrites dans `docs/design.md` plutot que laissees a redecouvrir : le trait tirete couvre desormais « annonce, jamais emprunte », et la **longueur** d'un trace tirete devient une contrainte — a 2,6 unites de tiret, un segment court ne rend que son amorce. C'etait deja le constat sur la croix de `anteriorite` ; il est traite ici en allongeant le trace au lieu de retirer le tiretage.

`ArticleFigure/index.tsx` fait 202 lignes, sous la limite : aucune extraction n'a ete necessaire.

## Corrections rendues necessaires par l'article a source

Le modele, le composant et la vue affirmaient tous les trois qu'**aucun article publie ne portait de source**. C'etait vrai, ca ne l'est plus. `IArticle`, `ArticleSource`, `ArticleView`, `docs/data-model.md` et `docs/design.md` disent maintenant la regle complete, dont l'autre moitie n'avait jamais ete ecrite : un article **repris d'ailleurs mais dont l'URL n'a pas ete fournie** se publie sans source.

## Couverture ajoutee (jamais affaiblie)

`scripts/budgets/pages.mjs` mesure une page de plus : `article-avec-source`. Le composant `ArticleSource` existait depuis l'issue #108, mais aucune page mesuree ne le rendait — son contraste et l'intitule de son lien sortant n'etaient controles nulle part. C'est un ajout de couverture, dans l'esprit de l'issue #112 qui avait ajoute `/blog/`.

## Ce qui a ete verifie

- `make lint` vert (limite 300 lignes comprise), `make type-check` vert, `make test` vert, `npm run build` vert — 34 pages statiques, les deux nouvelles fiches generees par `generateStaticParams`.
- `make budgets` vert sur **7 pages**, y compris la nouvelle : Lighthouse **96-97 / 100 / 100 / 100** partout, seuil de 95 tenu sur les 4 categories ; axe-core **0 violation** bloquante, mineure et moderee sur les 7.
- **Sitemap** : les deux URL y sont, avec `lastmod` 2026-08-23, et `/blog/` a bien repris la date de son article le plus recent.
- **Rendu reel controle sur l'export statique**, `/blog/` et les deux fiches, en **theme clair et sombre** (emulation `prefers-color-scheme`) : les cinq figures se distinguent a l'oeil dans la liste, les deux nouvelles restent lisibles a 48 px comme a 144 px, et la note de republication ne s'affiche que sur l'article qui porte une source.
- **Relecture contre la table des interdits du `CLAUDE.md`** : aucun terme proscrit, aucun emoji, aucun hashtag, aucun appel a l'action de reseau social dans le contenu publie.

## Tests

Aucun fichier de test n'a ete ecrit : la politique du depot reserve leur redaction a Jerome MARICHEZ. Les intentions proposees sont exposees dans le compte rendu de la tache, pretes a etre posees.

## Hors perimetre, signale

`package-lock.json` est reste a `0.8.0` alors que `package.json` est passe a `0.9.0`. Un `npm install` resynchronise le fichier ; la modification a ete **volontairement ecartee de cette PR** pour ne pas melanger un correctif de version a un travail editorial.
