### PR TITLE
chore: le verrou de dépendances rattrape la version 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeromemarichez-fr",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "next": "^16.0.0",
         "react": "^19.0.0",


### PR DESCRIPTION
## Résumé

Le bump de version en `package.json` vers 0.9.0 (commit chore: version 0.9.0) n'a pas régénéré le verrou de dépendances. `package-lock.json` est resté à 0.8.0 aux deux emplacements critiques :
- racine du fichier (champ `version`)
- `packages[""].version`

## Contenu exact du diff

Le diff ne contient que `package-lock.json`, avec exactement deux changements :
- Ligne 3 : `"version": "0.8.0"` → `"version": "0.9.0"` (racine)
- Ligne 9 : `"version": "0.8.0"` → `"version": "0.9.0"` (packages[""])

Aucune dépendance n'a été mise à jour. Aucun épinglage de version parasite.

**Référence** : #118