### PR TITLE
fix: le README n'annonce plus un test de veracite absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,17 @@ au-delà.
 **Règle de rédaction de cette section** : elle énonce ce qui est fait, elle ne **nomme
 jamais** un outil ou un niveau de certification proscrit par la table de véracité, même
 sous forme de négation. « Deux régies publicitaires, pas douze » plutôt que la liste de
-celles qui ne sont pas couvertes. Le test d'intégration `veracite-contenu.spec.ts`
-échoue si un terme proscrit réapparaît où que ce soit dans le contenu publié.
+celles qui ne sont pas couvertes.
+
+**État du contrôle** : la table des interdits du [`CLAUDE.md`](./CLAUDE.md) fait
+autorité, mais **aucun contrôle automatisé ne la vérifie à ce jour**. Le test
+d'intégration qui doit échouer dès qu'un terme proscrit réapparaît dans le contenu
+publié — `tests/integration/veracite-contenu.integration.spec.ts`, au nommage imposé
+par la [stratégie de tests](./docs/testing.md) — **reste à écrire**. Son intention
+complète (motifs couverts, jeu de données, cas limites) est spécifiée dans l'issue
+[#117](https://github.com/Jerome-Marichez/jeromemarichez2026/issues/117) et il revient
+à Jérôme MARICHEZ de le poser. D'ici là, la table s'applique à la relecture, pas à
+la CI.
 
 ---
 


### PR DESCRIPTION
Refs #117 — l'issue ne doit **pas** être fermée par cette PR : elle porte une seconde
moitié qui appartient à Jérôme MARICHEZ.

## L'affirmation fausse

Le `README.md` affirmait au présent, ligne 280 :

> Le test d'intégration `veracite-contenu.spec.ts` échoue si un terme proscrit
> réapparaît où que ce soit dans le contenu publié.

Ce fichier n'existe pas : `tests/integration/` est vide. Le dépôt annonçait donc un
filet de sécurité qu'il n'a pas, dans le fichier qui sert de source de vérité du
contenu — exactement le filet qui aurait attrapé l'issue #107.

## Ce qui la remplace

La section « Les limites assumées » porte désormais un paragraphe **État du contrôle**
qui dit le réel : la table des interdits du `CLAUDE.md` fait autorité, mais aucun
contrôle automatisé ne la vérifie à ce jour. Rester muet aurait été dommage — la règle
existe bel et bien, c'est son automatisation qui manque.

Le nom annoncé est aligné sur la convention du niveau intégration :
`tests/integration/veracite-contenu.integration.spec.ts` (`docs/testing.md`), et non
`veracite-contenu.spec.ts`.

## Le test reste à poser par Jérôme MARICHEZ

Aucun fichier sous `tests/` n'a été créé — la politique du `CLAUDE.md` réserve
l'écriture des tests à Jérôme MARICHEZ, et un hook l'applique. L'intention complète
du test (motifs couverts, jeu de données — le vrai contenu du site, pas une fixture —
et cas limites : casse, accents, apostrophes typographiques, exclusion des
commentaires de code, message d'échec nommant le terme et l'endroit) est spécifiée
dans l'issue #117, et le `README` y renvoie explicitement.

## Vérifications

- `grep -rnoE '[a-zA-Z0-9._-]+\.(spec|test|cy)\.(ts|tsx|js|jsx)' README.md docs/` : plus
  aucune autre affirmation ne décrit un fichier de test inexistant. Le seul autre nom
  trouvé est le motif de convention `.integration.spec.ts` dans `docs/testing.md`, qui
  n'affirme pas d'existence.
- `docs/testing.md` ne portait pas la même affirmation — aucun alignement n'y était
  nécessaire.
- `make lint` vert (limite 300 lignes incluse), `make test` vert.
- Diff limité à `README.md`, 11 insertions / 2 suppressions.