### PR TITLE
feat: la chaine porte ses lavis, et les derniers porteurs sont tranches

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -118,6 +118,72 @@ Trois points relevés, à garder en tête :
   et l'information qu'ils accompagnent est écrite à côté, mais le point est **ouvert** et
   n'a pas été traité par ce lot.
 
+### La chaîne et les derniers porteurs — contrastes relevés (issue #114)
+
+Le lavis s'étend à `ChainDiagram`, dont les plaques sont **du verre** : le lavis passe sous
+le voile plutôt que devant, et ses parts compensent ce que le voile absorbe. Le mécanisme
+est dans [`design.md`](./design.md) ; ce qui suit est la **lecture au pixel du rendu
+servi** (`next dev`, viewport 1440, capture PNG décodée, deux thèmes).
+
+**La non-composition, prouvée sur le rendu et non déduite.** Deux témoins ont été rendus
+dans la page à côté de la vraie chaîne : *A*, une plaque IA hors de toute chaîne (un seul
+lavis) ; *B*, la même plaque IA dans un conteneur peint au lavis de la donnée — c'est-à-dire
+exactement ce qu'aurait produit un lavis posé sur le maillon.
+
+| Thème | Plaque IA réelle (dans le maillon « data ») | Témoin A — un lavis | Témoin B — deux lavis | Écart réel↔A | Écart réel↔B |
+|---|---|---|---|---|---|
+| clair | `#E4DFDC` | `#E4DFDC` | `#DEDCDA` | **0 niveau** | 6 niveaux |
+| sombre | `#191A22` | `#191A22` | `#181D25` | **0 niveau** | 3 niveaux |
+
+La plaque réelle est **au niveau près** identique au cas « un seul lavis », et distincte du
+cas « deux lavis ». Le `<li data-pole="data">` a par ailleurs
+`background-color: rgba(0,0,0,0)` et `background-image: none` en style calculé : il ne
+peint rien. Contrôle croisé sur le fond, à la même abscisse — la gouttière entre les deux
+branches, *dans* le maillon « data », vaut `#E5E1D8` ; le gap de la chaîne, *hors* de tout
+`<li>`, vaut `#E6E2D9`. L'écart d'un niveau est celui du dégradé d'atelier, pas un lavis.
+
+**Parité des deux branches.** IA et SEA & UX passent par le même composant, donc la même
+classe et les mêmes jetons : leur lavis ne peut différer que par la teinte. Écart de
+luminance mesuré entre les deux plaques : **0,39 %** en clair, **0,03 %** en sombre.
+
+Contrastes sur la couleur **composée réellement lue** au centre de chaque plaque :
+
+| Thème | Pôle | Fond composé | `--encre` | `--encre-douce` | place (`--accent`, **texte**) | arête + soulignement (`--accent-vif`, non-texte) |
+|---|---|---|---|---|---|---|
+| clair | ingénierie web | `#E8E0D7` | 13.77:1 | 6.17:1 | 5.29:1 | 3.38:1 |
+| clair | data | `#DEE2DC` | 13.72:1 | 6.15:1 | **4.84:1** | **3.11:1** |
+| clair | IA | `#E4DFDC` | 13.61:1 | 6.10:1 | 5.21:1 | 3.37:1 |
+| clair | SEA & UX | `#E2E1D5` | 13.68:1 | 6.13:1 | **4.82:1** | **3.09:1** |
+| sombre | ingénierie web | `#1D1B1A` | 13.93:1 | 6.71:1 | 6.51:1 | 8.35:1 |
+| sombre | data | `#101C21` | 14.09:1 | 6.79:1 | 7.14:1 | 9.07:1 |
+| sombre | IA | `#191A22` | 14.07:1 | 6.78:1 | 6.53:1 | 8.36:1 |
+| sombre | SEA & UX | `#171C1A` | 14.01:1 | 6.75:1 | 7.08:1 | 8.95:1 |
+
+Les deux cas les plus serrés sont le SEA & UX et la donnée, à 4,82:1 pour du texte
+(seuil 4.5:1) et 3,09:1 pour du non-texte (seuil 3:1) — tenus, dans les deux thèmes.
+
+**Un défaut antérieur, trouvé et corrigé.** `PoleTagList` portait un lavis écrit à la main
+à 8 %, au-dessus du plafond, et **sous du texte de sa propre teinte**. Mesuré en thème
+clair sur `/realisations/` :
+
+| Pôle | Texte avant → après | Filet avant → après |
+|---|---|---|
+| ingénierie web | 5.01 → **5.60:1** | 3.21 → **5.60:1** |
+| IA | 4.75 → **5.28:1** | 3.06 → **5.28:1** |
+| SEA & UX | 4.63 → **5.13:1** | **2.97** → **5.13:1** |
+| data | **4.30** → **4.78:1** | **2.76** → **4.78:1** |
+
+Deux valeurs étaient **sous le seuil** avant ce lot : le texte de la donnée à 4,30:1
+(WCAG 1.4.3) et son filet à 2,76:1 (WCAG 1.4.11), celui du SEA & UX à 2,97:1. L'aplat est
+retiré et le filet passe de `--accent-vif` à `--accent` — raisonnement et alternatives
+mesurées dans [`design.md`](./design.md). En thème sombre, aucune de ces valeurs n'était en
+défaut (6,05 à 6,60:1) et toutes montent (6,76 à 7,41:1).
+
+**Les pages de pôle et les portes de l'accueil sont inchangées** : `.lavis-pole` et
+`.lavis-bloc` n'ont pas bougé. Relevé de contrôle en thème clair — `--encre-douce` de 6,80
+à 6,83:1 et `--accent-vif` de 3,73 à 3,75:1 sur les quatre pages ; en sombre, 7,22 à 7,25:1
+et 8,98 à 9,02:1.
+
 ### Pages contrôlées
 
 Les mêmes que les budgets de performance — accueil, page de pôle, liste du blog, page
@@ -128,5 +194,8 @@ non protégé. La liste vit dans `scripts/budgets/pages.mjs`.
 |----------|-------|------|
 | Accueil, pôle, blog, article, réalisations | axe-core (`ci-dev-a11y`) | **0 violation** — dernière exécution 2026-08-23, avec le lavis de pôle |
 | Contrastes sur le lavis de pôle | mesure au pixel, deux thèmes | **tenu** — 2026-08-23, voir le tableau ci-dessus |
+| Contrastes sur le lavis de feuille (`ChainDiagram`) | mesure au pixel, deux thèmes | **tenu** — 2026-08-23, pire cas 4,82:1 (texte) et 3,09:1 (non-texte) |
+| Non-composition des lavis dans `ChainDiagram` | témoins rendus + mesure au pixel | **prouvée** — 2026-08-23, écart nul avec le cas « un seul lavis » |
+| Étiquettes de pôle (`PoleTagList`) | mesure au pixel, deux thèmes | **corrigé** — 2026-08-23, deux valeurs étaient sous le seuil |
 | Clavier + lecteur d'écran | manuel | _à réaliser_ |
 | WCAG 2.2.2 — pause des animations | manuel | _à réaliser_ |

--- a/docs/design.md
+++ b/docs/design.md
@@ -841,13 +841,14 @@ substituée au *computed-value time*, sur l'élément qui la déclare. Déclaré
 ils figeraient le cuivre et descendraient tels quels dans les quatre pages de pôle. C'est
 le piège déjà documenté pour `--verre-arete`, et c'est le même remède.
 
-**Aucun composant ne nomme une teinte de pôle.** Deux classes globales suffisent, et elles
+**Aucun composant ne nomme une teinte de pôle.** Trois classes globales suffisent, et elles
 ne connaissent que les jetons :
 
 | Classe | Échelle | Porteur | Recette |
 |---|---|---|---|
 | `.lavis-pole` | une page de pôle, plusieurs milliers de pixels | `PolePageView` | tuile de 1600 × 1100 px répétée en Y, `farthest-side` centré |
 | `.lavis-bloc` | une carte, quelques centaines de pixels | `PoleEntries` | tache ancrée en haut à gauche, dimensionnée sur le bloc |
+| `.lavis-feuille` | une plaque de **verre** qui n'en contient aucune autre | `ChainDiagram` | même dessin que `.lavis-bloc`, mais **sous** le voile de verre, parts pré-compensées |
 
 ### Deux couches, et pourquoi pas trois
 
@@ -964,6 +965,123 @@ voile blanc éclaircit le fond) et le réduit en sombre sans jamais l'approcher 
 > fond, et l'était déjà avant ce lot (le lavis lui coûte 0,07 point, teinte et fond
 > bougeant ensemble). Les deux sont décoratifs et l'information qu'ils accompagnent est
 > écrite à côté, mais le point est ouvert et n'est pas traité ici.
+
+### La feuille : peindre le verre sans jamais composer
+
+La chaîne de l'accueil avait été laissée de côté par le lot précédent, sur un constat
+exact et une conclusion fausse.
+
+Le constat : dans `ChainDiagram`, le maillon « data » **contient** les deux branches.
+
+```
+<li.maillon data-pole="data">        <- contient les branches
+  <article.plaque>                   <- feuille
+  <ul.branches>
+    <li.branche data-pole="ia">      <- imbriqué dans le maillon data
+      <article.plaque>               <- feuille
+    <li.branche data-pole="sea-ux">
+      <article.plaque>               <- feuille
+```
+
+Peindre `.maillon` et `.branche` empilerait donc deux lavis sous les plaques de l'IA et du
+SEA & UX, à `1-(1-7,88 %)(1-7,88 %) = 15,14 %` — le double du plafond.
+
+La conclusion « donc on ne peint pas » ne suit pas, parce qu'il existe dans cet arbre un
+niveau où la composition est **impossible par construction** : la `.plaque`. Aucune plaque
+n'en contient une autre — c'est une **feuille**. Peindre la feuille plutôt que le nœud
+supprime le problème au lieu de le surveiller : il n'y a plus de pire cas géométrique à
+tenir, puisqu'il n'y a plus de recouvrement possible. Les `<li>` gardent `data-pole` — ils
+portent la teinte pour toute leur descendance — mais ne peignent plus rien du tout.
+
+C'est une règle générale, pas une astuce locale : **la teinte descend par la cascade, la
+peinture reste sur les feuilles.** Tout porteur de `data-pole` susceptible d'en contenir un
+autre se traite ainsi.
+
+#### Le verre est conservé, et c'est là qu'est la difficulté
+
+Une plaque de la chaîne est **du verre, pas du papier** : elle porte déjà
+`color-mix(in srgb, var(--fond) var(--verre-voile), transparent)`. Poser le lavis
+*par-dessus* ce voile le peindrait sur la face avant du verre ; retirer le voile pour faire
+de la place au lavis supprimerait le matériau. Ni l'un ni l'autre.
+
+Le lavis passe donc **sous** le voile, en couches de `background` empilées sur la plaque
+elle-même. L'ordre se lit de l'avant vers l'arrière : voile de verre, puis tache, puis fond
+plat. Le voile n'est ni retiré ni affaibli — il est déplacé d'une propriété du module vers
+la première couche de `.lavis-feuille`, à la valeur identique.
+
+La troisième couche ne rouvre pas la règle « deux couches et pas plus » : ce qu'elle
+interdisait, c'est une troisième **tache**, dont le recouvrement dépendrait de la
+géométrie. Le voile est un aplat plein cadre — il ne se recouvre avec rien, il recouvre
+tout, également. Le pire cas reste `1-(1-fond)(1-tache)`, atténué d'un facteur constant.
+
+#### La compensation est dérivée, jamais réglée
+
+Un voile à 55 % ne laisse passer que **45 %** de ce qui est dessous. Un lavis de bloc posé
+tel quel sous le verre ne peindrait donc que `0,45 × 7,88 % = 3,5 %` : la plaque se lirait
+beige, exactement le symptôme que `.lavis-bloc` avait été créé pour corriger.
+
+Les parts de la feuille sont donc celles du bloc **divisées par la transmission**. Ce n'est
+pas un réglage d'apparence : c'est la seule valeur qui fait qu'une feuille de verre et une
+porte de l'accueil peignent la **même densité à l'écran**. Elle se recalcule seule si les
+parts de bloc bougent, et elle suit le thème sans être réécrite.
+
+| Échelle | Clair | Sombre |
+|---|---|---|
+| feuille (`.lavis-feuille`), sous le voile | 13,33 % + 4,44 % → composé 17,19 % → **peint 7,73 %** | 11,11 % + 4,44 % → composé 15,06 % → **peint 6,78 %** |
+
+La composition n'étant pas linéaire, le résultat tombe très légèrement **sous** la densité
+de bloc, ce qui va dans le bon sens : 7,73 % contre un plafond de 7,84 % en clair, 6,78 %
+contre 6,88 % en sombre. Aucune marge à surveiller à la main.
+
+`--lavis-feuille-transmis` (45) est le complément de `--verre-voile` (55 %). Les deux
+disent la même opacité, l'une du côté du verre, l'autre du côté de ce qu'il laisse voir :
+**elles bougent ensemble**. Remonter le voile sans descendre cette valeur ferait pâlir
+toutes les feuilles d'un coup, sans qu'aucune règle ne le signale.
+
+### Les autres porteurs de `data-pole` — peints ou écartés
+
+Aucun n'est laissé sans décision.
+
+| Porteur | Décision | Raison |
+|---|---|---|
+| `ChainDiagram` | **peint** | `.lavis-feuille` sur `.plaque`, la feuille de l'arbre. Non-composition mesurée au pixel. |
+| `PoleTagList` | **écarté, et corrigé** | Il portait déjà un lavis, écrit à la main à 8 % — voir ci-dessous. |
+| `RealisationCard` | **écarté** | `IRealisation.poles` est un tableau : les fiches portent 1, 2 ou 3 pôles. Aucun lavis unique n'est possible sans affirmer une hiérarchie que le modèle nie, et un dégradé des pôles rattachés se lirait comme une succession — sur `['data','ia','sea-ux']`, il dirait que l'IA vient avant le SEA & UX. Les pôles sont déjà rendus **tous**, à facture identique, par `PoleTagList`. |
+| `PoleStickyBar` | **écarté** | C'est une **bande**, pas un panneau. `verre.css` documente pourquoi les deux ne partagent pas leurs réglages : une bande collante passe sur du texte et compense par un voile plus opaque (`--verre-voile-barre`, 82 %), qui ne laisserait passer que 18 % d'un lavis. La barre porte déjà son pôle par `--accent` — le chiffre de temps et le filet du bas. |
+| `SiteHeader` | **écarté** | Bande également, et surtout : ses quatre entrées portent **quatre** `data-pole` différents dans une seule barre de navigation. Quatre lavis côte à côte sur 40 px de haut ne se liraient pas comme quatre pôles mais comme un dégradé sale. Le chiffre de temps porte déjà la teinte. |
+| `SlabScene` | **écarté** | La scène du seuil a déjà ses dégradés par pôle, **en SVG**, un par dalle. Un lavis HTML par-dessus dupliquerait la même information dans un second système de couleur. |
+
+### `PoleTagList` — le dernier littéral de densité, et il était hors norme
+
+L'étiquette était le seul endroit du site où une surface était teintée à la teinte de son
+pôle par un **littéral écrit à la main** — `--accent` à 8 %, puis 16 % au survol —
+antérieur au plafond. Lui ajouter `.lavis-bloc` aurait empilé un second lavis sur le
+premier : exactement la composition que ce lot supprime ailleurs.
+
+Mesuré au pixel sur `/realisations/` en thème clair, cet aplat mettait l'étiquette de la
+**donnée** à **4,30:1** pour son texte (seuil 4.5:1, WCAG 1.4.3) et son filet à **2,76:1**
+(seuil 3:1, WCAG 1.4.11) ; le SEA & UX suivait à 2,97:1. La cause est propre à ce
+composant : ailleurs le lavis porte de l'**encre**, ici il portait **sa propre teinte**.
+Les seize ratios des tableaux de jetons sont mesurés sur `--fond`, jamais sur un lavis de
+la couleur qu'ils servent — un `--accent` posé sur son propre lavis perd des deux côtés à
+la fois, la teinte et le fond se rapprochant ensemble.
+
+Baisser l'aplat au jeton gouverné (`--lavis-bloc-fond`, 6 %) a été essayé et **mesuré** :
+la donnée remonte à 4,41:1, toujours sous le seuil, et la marge restante dépend de
+l'endroit de la page où la carte tombe — le dégradé d'atelier n'a pas la même clarté en
+haut et en bas de la liste. Un seuil qui se tient à 0,09 point près selon la position d'une
+carte n'est pas tenu.
+
+**L'aplat est donc retiré, pas rebaissé** — et c'est ce que disait déjà la première ligne
+du module : *un filet à gauche plutôt qu'une pastille pleine*. L'aplat contredisait
+l'intention qu'il était censé servir. Le filet passe de `--accent-vif` à `--accent` :
+`--accent-vif` est documenté « non-texte » et tient 3:1 sur `--fond`, pas sur un lavis de
+lui-même. Sur le papier nu, `--accent` donne au filet le ratio du texte qu'il accompagne.
+
+Résultat mesuré, thème clair : **4,78 à 5,60:1** pour le texte comme pour le filet, contre
+4,30 à 5,01 (texte) et 2,76 à 3,21 (filet) avant. Les deux seuils sont franchis pour les
+quatre pôles, et il ne reste plus aucune densité de pôle écrite à la main hors de
+`lavis.css`.
 
 ## Le verre de la bande
 

--- a/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
+++ b/src/@vitrine/components/ChainDiagram/chain-diagram.module.css
@@ -36,8 +36,12 @@
   padding: var(--e-3) var(--e-4);
   border: var(--verre-epaisseur) solid var(--verre-arete);
   border-radius: var(--rayon-verre);
-  background: color-mix(in srgb, var(--fond) var(--verre-voile), transparent);
   box-shadow: var(--elevation-posee);
+  /* Le fond n'est PAS déclaré ici : la plaque porte la classe globale `lavis-feuille`
+     (issue #114), qui empile le lavis pastel de son pôle SOUS le voile de verre. Le voile
+     n'a pas disparu — il est la première couche de cette classe, à la valeur identique
+     (`--fond` à `--verre-voile`). Le déclarer aussi ici le poserait en concurrence de
+     spécificité avec la classe globale, et la couche du dessous ne se verrait jamais. */
 }
 
 .place {

--- a/src/@vitrine/components/ChainDiagram/index.tsx
+++ b/src/@vitrine/components/ChainDiagram/index.tsx
@@ -18,10 +18,25 @@ import styles from './chain-diagram.module.css'
  * c'est exactement le doublon que cette issue est venue supprimer — et un schéma n'a pas
  * besoin de prose pour dire une topologie. Ce qui reste ici est ce que les portes ne
  * disent pas : les **arêtes**.
+ *
+ * **C'est la plaque qui porte le lavis, et non le maillon** (issue #114). La plaque est
+ * une FEUILLE de l'arbre : aucune plaque n'en contient une autre, alors que le maillon
+ * « data », lui, contient les deux branches. Peindre le maillon empilerait deux lavis
+ * sous l'IA et sous le SEA & UX ; peindre la feuille rend ce recouvrement impossible par
+ * construction, sans plafond à surveiller. Les `<li>` gardent `data-pole` — ils portent
+ * la teinte pour leur descendance — mais ne peignent plus rien.
+ *
+ * `lavis-feuille` et non `lavis-bloc` parce que la plaque est du VERRE : la classe empile
+ * le lavis sous le voile au lieu de le poser devant, et compense ce que le voile absorbe.
+ * Le composant, lui, ne connaît toujours aucune couleur — voir `lavis.css`.
+ *
+ * Les deux suites passent par ce même composant, donc par cette même classe et ces mêmes
+ * jetons : leur lavis ne peut différer que par la teinte, jamais par la densité. Le
+ * parallélisme des deux branches est tenu par le code, pas par une relecture.
  */
 function Plaque({ pole }: { pole: IPole }) {
   return (
-    <article className={styles.plaque}>
+    <article className={`${styles.plaque} lavis-feuille`}>
       <p className={styles.place}>{LIBELLE_PLACE[pole.place]}</p>
       <h3 className={styles.nom}>
         <Link className={styles.lien} href={pole.route}>
@@ -75,6 +90,10 @@ export function ChainDiagram() {
           // `data-pole` porte la teinte du maillon : la plaque ET l'arête qui en part
           // en héritent. Les branches, imbriquées, posent la leur et l'emportent — la
           // cascade dit la structure sans qu'aucun module ne nomme une couleur.
+          //
+          // Ce maillon ne PEINT rien, et c'est délibéré : il contient les deux branches,
+          // donc un fond posé ici se retrouverait sous leurs plaques, à composer avec le
+          // leur. La teinte descend, la peinture reste sur les feuilles (issue #114).
           <li className={styles.maillon} data-pole={pole.id} key={pole.id}>
             <Plaque pole={pole} />
 

--- a/src/@vitrine/components/PoleTagList/pole-tag-list.module.css
+++ b/src/@vitrine/components/PoleTagList/pole-tag-list.module.css
@@ -1,7 +1,51 @@
 /* pole-tag-list.module.css — les pôles mobilisés par une réalisation.
  * Un filet à gauche plutôt qu'une pastille pleine : la teinte du pôle reste un repère,
  * elle ne devient pas un bouton. Aucune couleur n'est nommée ici — `--accent` est mappé
- * par `poles.css` à partir du `data-pole` posé sur chaque item. */
+ * par `poles.css` à partir du `data-pole` posé sur chaque item.
+ *
+ * ## Pourquoi l'étiquette ne reçoit PAS de lavis (issue #114)
+ *
+ * Elle en porte déjà un. L'étiquette est le seul endroit du site où une surface était
+ * teintée à la teinte de son pôle par un littéral écrit à la main — `--accent` à 8 %,
+ * puis 16 % au survol — antérieur au plafond de densité calculé par #113. Lui ajouter
+ * `.lavis-bloc` aurait empilé un second lavis sur le premier : exactement la composition
+ * que cette issue supprime ailleurs.
+ *
+ * ## Le littéral n'était pas seulement hors système, il était hors norme
+ *
+ * Mesuré au pixel sur `/realisations/` en thème clair, l'aplat à 8 % mettait l'étiquette
+ * de la donnée à **4,30:1** pour son texte (seuil 4.5:1, WCAG 1.4.3) et son filet à
+ * **2,76:1** (seuil 3:1, WCAG 1.4.11) ; le SEA & UX suivait à 2,97:1. La cause est propre
+ * à ce composant : ailleurs le lavis porte de l'encre, ici il porte **sa propre teinte**.
+ * Les seize ratios de `docs/design.md` sont mesurés sur `--fond`, pas sur un lavis de la
+ * couleur qu'ils servent — un `--accent` sur son propre lavis perd des deux côtés à la
+ * fois, la teinte et le fond se rapprochant ensemble.
+ *
+ * Baisser l'aplat au jeton gouverné (`--lavis-bloc-fond`, 6 %) a été mesuré et ne suffit
+ * pas : la donnée remonte à 4,41:1, toujours sous 4.5:1, et la marge restante dépend de
+ * l'endroit de la page où la carte tombe — le dégradé d'atelier n'a pas la même clarté en
+ * haut et en bas de la liste. Un seuil qui se tient à 0,09 point près selon la position
+ * d'une carte n'est pas tenu.
+ *
+ * **L'aplat est donc retiré, pas rebaissé** — et c'est ce que dit déjà la première ligne
+ * de ce fichier : *un filet à gauche plutôt qu'une pastille pleine*. L'aplat contredisait
+ * l'intention qu'il était censé servir. Ce qui reste porte le pôle sans surface teintée :
+ *
+ *   1. le filet passe de `--accent-vif` à `--accent`. `--accent-vif` est documenté
+ *      « non-texte » et tient 3:1 sur `--fond` ; posé sur un lavis de lui-même il n'avait
+ *      plus la marge. Sur le papier nu, `--accent` donne au filet le ratio du texte qu'il
+ *      accompagne — 4,7 à 5,2:1 en clair, au-dessus des deux seuils à la fois ;
+ *   2. le nom du pôle reste écrit en toutes lettres : la couleur ne porte aucune
+ *      information seule (WCAG 1.4.1).
+ *
+ * Aucun lavis n'est donc posé ici, et aucune densité de pôle n'y est plus écrite à la
+ * main : c'était le dernier littéral du genre hors de `lavis.css`.
+ *
+ * ## Le survol ne monte plus le fond
+ *
+ * Il n'y a plus de fond à monter. Même arbitrage que pour `PoleEntries` (voir
+ * `pole-entries.module.css`) : l'état est porté par le soulignement, qui ne repose pas
+ * sur la couleur (WCAG 1.4.1). */
 
 .zone {
   display: flex;
@@ -24,20 +68,16 @@
   display: inline-flex;
   align-items: baseline;
   padding: var(--e-0) var(--e-2);
-  border-left: 2px solid var(--accent-vif);
-  border-radius: 0 var(--rayon-petit) var(--rayon-petit) 0;
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-left: 2px solid var(--accent);
   color: var(--accent);
   font-family: var(--police-mono-pile);
   font-size: var(--t--1);
   letter-spacing: 0.04em;
   text-decoration: none;
-  transition: background-color var(--duree-micro) ease-out;
 }
 
 .etiquette:hover,
 .etiquette:focus-visible {
-  background: color-mix(in srgb, var(--accent) 16%, transparent);
   text-decoration: underline;
   text-underline-offset: 0.18em;
 }

--- a/src/@vitrine/components/RealisationCard/realisation-card.module.css
+++ b/src/@vitrine/components/RealisationCard/realisation-card.module.css
@@ -1,6 +1,30 @@
 /* realisation-card.module.css — une réalisation dans une liste.
  * Pas de panneau ni de vignette : un filet supérieur suffit à séparer. Le verre est
- * réservé aux offres (docs/design.md), et une réalisation n'en est pas une. */
+ * réservé aux offres (docs/design.md), et une réalisation n'en est pas une.
+ *
+ * ## Pas de lavis de pôle ici, et ce n'est pas un oubli (issue #114)
+ *
+ * Une carte ne PEUT pas porter un lavis, parce qu'une réalisation ne porte pas un pôle :
+ * `IRealisation.poles` est un `readonly PoleId[]`. Relevé sur l'index des réalisations,
+ * les treize fiches se répartissent en 1, 2 ou 3 pôles — la majorité en portent deux.
+ *
+ * Trois issues, et deux sont fausses :
+ *
+ *   - **un seul lavis, celui du « pôle principal »** : il n'existe pas de pôle principal.
+ *     En choisir un affirmerait une hiérarchie entre les pôles d'un même travail, ce que
+ *     le modèle de l'offre nie explicitement (voir CLAUDE.md) ;
+ *   - **un dégradé des pôles rattachés** : `listPoles` les ordonne par la chaîne, donc un
+ *     dégradé de gauche à droite se lirait comme une succession. Sur une carte
+ *     `['data', 'ia', 'sea-ux']`, il dirait que l'IA vient avant le SEA & UX. C'est
+ *     précisément l'affirmation que la palette de `poles.css` est construite pour rendre
+ *     impossible ;
+ *   - **aucun lavis** : les pôles sont déjà rendus, tous, côte à côte et à facture
+ *     strictement identique, par `PoleTagList`. Aucun n'est privilégié parce qu'aucun
+ *     n'est peint plus que les autres.
+ *
+ * C'est la troisième qui est retenue. Le lavis dit « ce bloc parle de CE pôle » ; une
+ * carte de réalisation parle de plusieurs, et la seule façon honnête de le dire est de
+ * les nommer tous, pas d'en teinter un. */
 
 .carte {
   display: flex;

--- a/src/app/lavis.css
+++ b/src/app/lavis.css
@@ -72,6 +72,53 @@
  * PIXELS et répétée en Y, jamais dimensionnée en pourcentage d'un bloc de 6 000 px.
  * `.lavis-bloc`, lui, ne sert que des blocs de la taille d'une carte : à cette échelle,
  * un fond en pourcentage ne rasterise rien de notable et suit exactement la carte.
+ *
+ * ## La feuille : peindre sans jamais composer (issue #114)
+ *
+ * `ChainDiagram` avait été écarté sur un constat exact et une conclusion fausse. Le
+ * constat : le maillon « data » **contient** les deux branches, donc peindre `.maillon`
+ * et `.branche` empilerait deux lavis sous les plaques de l'IA et du SEA & UX, à
+ * `1-(1-7.88%)(1-7.88%) = 15.14 %` — le double du plafond.
+ *
+ * La conclusion ne suit pas, parce qu'il existe dans cet arbre un niveau où la
+ * composition est **impossible par construction** : la `.plaque`. Aucune plaque n'en
+ * contient une autre — c'est une FEUILLE. Peindre la feuille plutôt que le nœud supprime
+ * le problème au lieu de le surveiller : il n'y a plus de pire cas géométrique à tenir,
+ * puisqu'il n'y a plus de recouvrement possible. Les `<li>` gardent `data-pole` — ils
+ * portent la teinte pour toute leur descendance — mais ne peignent plus rien.
+ *
+ * ## Le verre est conservé, et c'est là qu'est la difficulté
+ *
+ * Seconde objection, elle aussi exacte : une plaque de la chaîne est **du verre, pas du
+ * papier**. Elle porte `color-mix(in srgb, var(--fond) var(--verre-voile), transparent)`.
+ * Poser le lavis PAR-DESSUS ce voile le peindrait sur la face avant du verre ; retirer le
+ * voile pour faire de la place au lavis supprimerait le matériau. Ni l'un ni l'autre.
+ *
+ * Le lavis passe donc **sous** le voile, en couches de `background` empilées sur la
+ * plaque elle-même — dans l'ordre de peinture : voile de verre (dessus), tache, fond plat
+ * (dessous). C'est la lecture physique juste : la teinte est sur le papier, le verre est
+ * devant. Le voile n'est ni retiré ni affaibli : il est déplacé d'une propriété `background`
+ * du module vers la première couche de cette classe, à la valeur identique.
+ *
+ * ## La compensation, et pourquoi elle est dérivée et non réglée
+ *
+ * Un voile à 55 % ne laisse passer que **45 %** de ce qui est dessous. Un lavis de bloc
+ * posé tel quel sous le verre ne peindrait donc que `0.45 × 7.88 % = 3.5 %` : la plaque
+ * se lirait beige, exactement le symptôme que `.lavis-bloc` a été créé pour corriger.
+ *
+ * Les parts de la feuille sont donc celles du bloc **divisées par la transmission**. Ce
+ * n'est pas un réglage d'apparence : c'est la seule valeur qui fait qu'une feuille de
+ * verre et une porte de l'accueil peignent la MÊME densité à l'écran. Elle se recalcule
+ * seule si les parts de bloc bougent, et elle suit le thème sans être réécrite.
+ *
+ * La composition n'étant pas linéaire, le résultat n'est pas exactement la densité de
+ * bloc — il tombe très légèrement en dessous, ce qui va dans le bon sens :
+ *
+ *   clair  : 6%/0.45 = 13.33 %, 2%/0.45 = 4.44 %  →  composé 17.19 %  →  peint 7.73 %
+ *   sombre : 5%/0.45 = 11.11 %, 2%/0.45 = 4.44 %  →  composé 15.06 %  →  peint 6.78 %
+ *
+ * Sous le plafond dans les deux thèmes (7,84 % et 6,88 %), sans marge à surveiller à la
+ * main. Les valeurs relevées au pixel sont dans `docs/accessibility.md`.
  */
 
 /* Deux répartitions pour un seul plafond.
@@ -96,6 +143,16 @@
   --lavis-tache-part: 4%;
   --lavis-bloc-fond-part: 6%;
   --lavis-bloc-tache-part: 2%;
+
+  /* Part de ce qui est peint SOUS le voile de verre d'un panneau qui ressort devant lui,
+     en points de pourcentage et sans unité — `calc()` sait multiplier un pourcentage par
+     un nombre, il ne sait pas le diviser par un autre pourcentage.
+
+     C'est le complément de `--verre-voile` (55 %, dans `verre.css`) : les deux disent la
+     même opacité, l'une du côté du verre, l'autre du côté de ce qu'il laisse voir. Elles
+     bougent donc ENSEMBLE — remonter le voile sans descendre cette valeur ferait pâlir
+     toutes les feuilles d'un coup, sans qu'aucune règle ne le signale. */
+  --lavis-feuille-transmis: 45;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -116,6 +173,20 @@
   --lavis-tache: color-mix(in srgb, var(--accent) var(--lavis-tache-part), transparent);
   --lavis-bloc-fond: color-mix(in srgb, var(--accent) var(--lavis-bloc-fond-part), transparent);
   --lavis-bloc-tache: color-mix(in srgb, var(--accent) var(--lavis-bloc-tache-part), transparent);
+
+  /* Échelle FEUILLE : les parts du bloc, pré-compensées de ce que le voile absorbe. Le
+     calcul est ici et non dans la classe pour la même raison que tout le reste de ce
+     bloc — `--accent` doit être résolu sur l'élément qui porte `data-pole`. */
+  --lavis-feuille-fond: color-mix(
+    in srgb,
+    var(--accent) calc(var(--lavis-bloc-fond-part) * 100 / var(--lavis-feuille-transmis)),
+    transparent
+  );
+  --lavis-feuille-tache: color-mix(
+    in srgb,
+    var(--accent) calc(var(--lavis-bloc-tache-part) * 100 / var(--lavis-feuille-transmis)),
+    transparent
+  );
 }
 
 /* Échelle PAGE — un gabarit de pôle, haut de plusieurs milliers de pixels.
@@ -144,6 +215,36 @@
 .lavis-bloc {
   background-color: var(--lavis-bloc-fond);
   background-image: radial-gradient(farthest-side at 18% 0%, var(--lavis-bloc-tache), transparent);
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+}
+
+/* Échelle FEUILLE — une plaque de VERRE qui ne contient aucune autre plaque.
+ *
+ * Même dessin que `.lavis-bloc` — même ancrage de tache, même densité peinte — mais en
+ * trois couches au lieu de deux, parce qu'il y a du verre devant. L'ordre de `background`
+ * se lit de l'avant vers l'arrière :
+ *
+ *   1. le voile de verre, à la valeur exacte qu'il avait dans le module ;
+ *   2. la tache, sous le verre ;
+ *   3. le fond plat, tout au fond (`background-color`).
+ *
+ * La troisième couche ne coûte pas le pire cas géométrique que `lavis.css` s'interdit
+ * plus haut : le voile est un aplat plein cadre, pas une tache. Il ne se recouvre avec
+ * rien, il recouvre tout, également. Le pire cas reste `1-(1-fond)(1-tache)`, atténué
+ * d'un facteur constant.
+ *
+ * Cette classe est posée sur l'élément qui porte le verre, jamais sur son parent : c'est
+ * ce qui garantit qu'un porteur de `data-pole` imbriqué dans un autre ne compose pas deux
+ * lavis. Le parent porte la teinte, la feuille porte la peinture. */
+.lavis-feuille {
+  background-color: var(--lavis-feuille-fond);
+  background-image:
+    linear-gradient(
+      color-mix(in srgb, var(--fond) var(--verre-voile), transparent),
+      color-mix(in srgb, var(--fond) var(--verre-voile), transparent)
+    ),
+    radial-gradient(farthest-side at 18% 0%, var(--lavis-feuille-tache), transparent);
   background-repeat: no-repeat;
   background-size: 100% 100%;
 }


### PR DESCRIPTION
Traite l'issue #114. (`Closes` volontairement absent : les PR visent `dev`, la branche
par defaut est `main`, la fermeture se fait a la main.)

## Le point que la PR precedente avait mal conclu

#113 avait ecarte `ChainDiagram` sur un **constat exact** — le maillon « data »
*contient* les branches IA et SEA & UX, donc deux lavis s'y composeraient a ~15 %,
au-dessus du plafond de 7,84 % — et une **conclusion qui ne suit pas**.

Il existe dans cet arbre un niveau ou la composition est impossible **par
construction** : la `.plaque`. Aucune plaque n'en contient une autre, c'est une
**feuille**. Peindre la feuille plutot que le noeud supprime le probleme au lieu de le
surveiller. Les `<li>` gardent `data-pole` — la teinte descend par la cascade — mais
ne peignent plus rien.

Regle generale qui en sort, et qui est documentee comme telle : **la teinte descend,
la peinture reste sur les feuilles.**

## Le verre est conserve — c'est le vrai point technique

La plaque est **du verre, pas du papier**. Le lavis passe donc **sous** le voile, en
couches de `background` empilees sur la plaque : voile devant, tache, fond plat
derriere. Le voile n'est ni retire ni affaibli — il est **deplace** du module vers la
premiere couche de `.lavis-feuille`, a la valeur identique.

Un voile a 55 % ne laisse passer que **45 %**. Un lavis de bloc pose tel quel sous le
verre ne peindrait que `0,45 x 7,88 % = 3,5 %` : la plaque se lirait beige. Les parts
de la feuille sont donc celles du bloc **divisees par la transmission** —
`calc(var(--lavis-bloc-fond-part) * 100 / var(--lavis-feuille-transmis))`. Ce n'est
pas un reglage d'apparence : c'est la seule valeur qui fait qu'une feuille de verre et
une porte de l'accueil peignent la **meme densite a l'ecran**. Elle se recalcule seule
si les parts de bloc bougent et suit le theme sans etre reecrite.

| Echelle | Clair | Sombre |
|---|---|---|
| feuille, sous le voile | 13,33 % + 4,44 % -> compose 17,19 % -> **peint 7,73 %** | 11,11 % + 4,44 % -> compose 15,06 % -> **peint 6,78 %** |

Sous le plafond dans les deux themes (7,84 % / 6,88 %), **sans marge a tenir a la
main**. Le plafond de #113 n'a pas bouge.

## Preuve de non-composition — chiffree, sur le rendu

Deux **temoins rendus** ont ete injectes dans la page a cote de la vraie chaine :
*A*, une plaque IA hors de toute chaine (un seul lavis) ; *B*, la meme plaque IA dans
un conteneur peint au lavis de la donnee — exactement ce qu'aurait produit un lavis
pose sur le maillon. Capture PNG decodee, lecture au pixel.

| Theme | Plaque IA **reelle** (dans le maillon data) | Temoin A (un lavis) | Temoin B (deux lavis) | Ecart reel<->A | Ecart reel<->B |
|---|---|---|---|---|---|
| clair | `#E4DFDC` | `#E4DFDC` | `#DEDCDA` | **0 niveau** | 6 niveaux |
| sombre | `#191A22` | `#191A22` | `#181D25` | **0 niveau** | 3 niveaux |

La plaque reelle est **au niveau pres** identique au cas « un seul lavis », et
distincte du cas « deux lavis ». Confirmations croisees :

- le `<li data-pole="data">` a `background-color: rgba(0,0,0,0)` et
  `background-image: none` en style **calcule** : il ne peint rien ;
- la gouttiere entre les deux branches, *dans* le maillon data, vaut `#E5E1D8` ; le
  gap de la chaine, *hors* de tout `<li>` et a la meme abscisse, vaut `#E6E2D9`.
  L'ecart d'un niveau est celui du degrade d'atelier, pas un lavis.

**Parite des deux branches** : meme composant, meme classe, memes jetons — le lavis ne
peut differer que par la teinte. Ecart de luminance mesure : **0,39 %** en clair,
**0,03 %** en sombre. Rien dans le rendu n'ordonne l'IA et le SEA & UX.

## Contrastes mesures, deux themes, sur la couleur composee reellement lue

| Theme | Pole | Fond compose | `--encre` | `--encre-douce` | place (`--accent`, **texte**) | arete + soulignement (`--accent-vif`, non-texte) |
|---|---|---|---|---|---|---|
| clair | ingenierie web | `#E8E0D7` | 13.77:1 | 6.17:1 | 5.29:1 | 3.38:1 |
| clair | data | `#DEE2DC` | 13.72:1 | 6.15:1 | **4.84:1** | **3.11:1** |
| clair | IA | `#E4DFDC` | 13.61:1 | 6.10:1 | 5.21:1 | 3.37:1 |
| clair | SEA & UX | `#E2E1D5` | 13.68:1 | 6.13:1 | **4.82:1** | **3.09:1** |
| sombre | ingenierie web | `#1D1B1A` | 13.93:1 | 6.71:1 | 6.51:1 | 8.35:1 |
| sombre | data | `#101C21` | 14.09:1 | 6.79:1 | 7.14:1 | 9.07:1 |
| sombre | IA | `#191A22` | 14.07:1 | 6.78:1 | 6.53:1 | 8.36:1 |
| sombre | SEA & UX | `#171C1A` | 14.01:1 | 6.75:1 | 7.08:1 | 8.95:1 |

Pires cas : **4,82:1** pour du texte (seuil 4.5:1) et **3,09:1** pour du non-texte
(seuil 3:1). Tenus dans les deux themes.

Les pages de pole et les portes de l'accueil sont **inchangees** — controle :
`--encre-douce` 6,80 a 6,83:1 et `--accent-vif` 3,73 a 3,75:1 en clair ; 7,22 a 7,25:1
et 8,98 a 9,02:1 en sombre.

## Porteur par porteur — aucun laisse sans decision

| Porteur | Decision | Raison |
|---|---|---|
| `ChainDiagram` | **peint** | `.lavis-feuille` sur `.plaque`, la feuille de l'arbre. Non-composition mesuree ci-dessus. |
| `PoleTagList` | **ecarte, et corrige** | Il portait deja un lavis, ecrit a la main a 8 % — voir ci-dessous. Lui en ajouter un aurait empile deux lavis. |
| `RealisationCard` | **ecarte** | `IRealisation.poles` est un tableau : les treize fiches portent 1, 2 ou 3 poles (releve : 2,1,2,2,2,2,2,3,1,2,2,1,1). Un lavis unique affirmerait une hierarchie que le modele nie ; un degrade des poles rattaches se lirait comme une succession — sur `['data','ia','sea-ux']` il dirait que l'IA vient avant le SEA & UX. Les poles sont deja rendus **tous**, a facture identique, par `PoleTagList`. Raison ecrite dans le module. |
| `PoleStickyBar` | **ecarte** | C'est une **bande**, pas un panneau. `verre.css` documente pourquoi les deux ne partagent pas leurs reglages : `--verre-voile-barre` est a 82 %, il ne laisserait passer que 18 % d'un lavis. La barre porte deja son pole par `--accent`. **Aucun fichier touche** (perimetre #115). |
| `SiteHeader` | **ecarte** | Bande egalement, et ses quatre entrees portent **quatre** `data-pole` dans une seule barre : quatre lavis sur 40 px de haut ne se liraient pas comme quatre poles mais comme un degrade sale. **Aucun fichier touche** (perimetre #115). |
| `SlabScene` | **ecarte** | La scene du seuil a deja ses degrades par pole, en **SVG**, un par dalle. Un lavis HTML dupliquerait la meme information dans un second systeme de couleur. |

## Un defaut anterieur, trouve a la mesure et corrige

`PoleTagList` portait un aplat de sa propre teinte a 8 %, **au-dessus du plafond**, et
**sous du texte de cette meme teinte**. Les seize ratios de `design.md` sont mesures
sur `--fond`, jamais sur un lavis de la couleur qu'ils servent : un `--accent` sur son
propre lavis perd des deux cotes a la fois.

| Pole | Texte avant -> apres | Filet avant -> apres |
|---|---|---|
| ingenierie web | 5.01 -> **5.60:1** | 3.21 -> **5.60:1** |
| IA | 4.75 -> **5.28:1** | 3.06 -> **5.28:1** |
| SEA & UX | 4.63 -> **5.13:1** | **2.97** -> **5.13:1** |
| data | **4.30** -> **4.78:1** | **2.76** -> **4.78:1** |

Trois valeurs etaient **sous le seuil** avant ce lot : le texte de la donnee a 4,30:1
(WCAG 1.4.3), son filet a 2,76:1 et celui du SEA & UX a 2,97:1 (WCAG 1.4.11).

Baisser l'aplat au jeton gouverne (6 %) a ete **essaye et mesure** : la donnee remonte
a 4,41:1, toujours sous le seuil, et la marge restante depend de l'endroit de la page
ou la carte tombe. **L'aplat est donc retire, pas rebaisse** — et c'est ce que disait
deja la premiere ligne du module : *un filet a gauche plutot qu'une pastille pleine*.
Le filet passe de `--accent-vif` (documente « non-texte ») a `--accent`, le jeton de
qualite texte. C'est un **changement visible** : les etiquettes n'ont plus de pastille.

Plus aucune densite de pole n'est ecrite a la main hors de `lavis.css`.

## Controles

- `make lint` : vert (1 avertissement preexistant sur `CertificationList`, hors lot) ;
  `scripts/check-max-lines.sh` : aucun fichier > 300 lignes.
- `make type-check` : vert. `make test` : vert.
- `make budgets` : **Lighthouse 96-97 / 100 / 100 / 100** sur les six gabarits,
  **axe-core 0 violation** sur les six pages.
- Rendu controle sur `next dev`, accueil + les quatre pages de pole + index des
  realisations, dans les deux themes.

## Regles du projet

- Aucune teinte de pole nommee hors de `poles.css`.
- Aucune information portee par la seule couleur (WCAG 1.4.1) : le nom du pole, son
  libelle de place et son temps restent ecrits.
- Le modele de l'offre est intact : les deux branches gardent un traitement
  strictement identique, garanti par le code (meme composant, meme classe).
- Aucun fichier de test ecrit par l'assistant. Les **intentions de test** proposees a
  Jerome MARICHEZ sont dans le compte rendu de la tache.