### PR TITLE
docs: deux regles editoriales, tiret cadratin et relecture par un second agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,30 @@ considération marketing.
   baisse). Une affirmation sans preuve disponible se reformule ou se supprime.
 - **Ton** : sobre, direct, à la première personne. Pas de superlatif, pas de jargon
   d'agence, pas d'emoji dans le contenu publié.
+- **Jamais de tiret cadratin dans un texte destiné à être lu.** Ce caractère signe une
+  écriture de machine, et ce site vend un interlocuteur humain. La règle couvre le
+  contenu publié (`src/@vitrine/contenu/`), la documentation (`docs/`, `README.md`) et ce
+  fichier. Les **commentaires de code en sont exclus** : ils sont denses et raisonnés,
+  personne ne les lit de l'extérieur, les reformuler abîmerait leur propos sans bénéfice.
+  Ce n'est **pas une substitution de caractère** : le tiret y sert de ponctuation, donc la
+  phrase se **reformule** (virgule, deux-points, parenthèses, ou deux phrases). Un `sed`
+  global est proscrit, il produirait des phrases fausses.
+  *(Règle ajoutée à la demande explicite de Jérôme MARICHEZ, 2026-08-23.)*
+- **Tout texte destiné à être lu passe par un second agent avant la PR** : contenu du
+  site, articles, `README.md`, `docs/`. Le code et les commentaires n'y passent pas. Ce
+  second agent **n'a pas le contexte de rédaction**, et c'est précisément ce qui fait la
+  seconde vue : un agent qui a écrit un texte a déjà accepté ses propres choix, il ne peut
+  plus les voir. Il vérifie quatre points, dans cet ordre :
+  1. **La fidélité à la source**, quand le texte adapte un écrit existant de Jérôme
+     MARICHEZ. On le **porte**, on ne le réécrit pas : son titre, son plan et ses
+     formulations restent les siens. Corriger l'orthographe et la syntaxe est un devoir,
+     changer l'angle est une faute (issue #121).
+  2. **La table des interdits** des règles de véracité ci-dessus.
+  3. **La ligne éditoriale** : ton, preuve à chaque affirmation, absence d'emoji.
+  4. **L'absence de tiret cadratin.**
+
+  Il propose une réécriture ; le premier agent l'intègre ou motive son refus dans la PR.
+  *(Règle ajoutée à la demande explicite de Jérôme MARICHEZ, 2026-08-23.)*
 - **Le développement en IA augmentée** (Claude Code / Gemini — agents, hooks, skills,
   loop, serveurs MCP) **piloté par les tests (TDD)** est un différenciateur assumé : il
   apparaît partout où le site parle de programmation, jamais comme un détail


### PR DESCRIPTION
Referme le besoin decrit dans l'issue #123 (la PR vise `dev`, la fermeture de l'issue reste manuelle).

## Autorisation

La regle 10 du `CLAUDE.md` reserve toute evolution des regles a une demande explicite de Jerome MARICHEZ. Cette demande a ete faite le **2026-08-23** : ne plus utiliser de tiret cadratin, et faire relire les textes par un second agent. L'ajout se limite strictement a ces deux regles, aucune autre partie du fichier n'est touchee.

## Les deux regles ajoutees

Section **Ligne editoriale**, entre la puce sur le ton et celle sur le developpement en IA augmentee.

1. **Jamais de tiret cadratin dans un texte destine a etre lu.** Portee : contenu publie (`src/@vitrine/contenu/`), documentation (`docs/`, `README.md`) et le `CLAUDE.md` lui-meme. Les commentaires de code en sont exclus. La regle dit explicitement que ce n'est pas une substitution de caractere : le tiret sert de ponctuation, la phrase se reformule, et un `sed` global est proscrit parce qu'il produirait des phrases fausses.

2. **Tout texte destine a etre lu passe par un second agent avant la PR.** Portee : contenu du site, articles, `README.md`, `docs/`. Le code et les commentaires n'y passent pas. Le second agent n'a pas le contexte de redaction, et c'est ce qui fait la seconde vue. Il verifie, dans l'ordre : la fidelite a la source quand le texte adapte un ecrit existant de Jerome MARICHEZ (on le porte, on ne le reecrit pas, cf. issue #121), la table des interdits de veracite, la ligne editoriale, puis l'absence de tiret cadratin.

Chaque regle porte sa mention d'arbitrage datee et attribuee, selon la convention deja en vigueur dans le fichier.

## Verifications

- Le texte ajoute ne contient lui-meme **aucun tiret cadratin** : `git diff` sur les lignes ajoutees renvoie zero occurrence.
- Le compte global du `CLAUDE.md` reste a **37 occurrences**, inchange. La reprise des 656 occurrences existantes relevant du contenu, des docs et de ce fichier fait l'objet de l'**issue #124**, separee, et n'entre pas ici.
- Aucune regle existante contredite, aucune numerotation cassee : les regles 8, 9 et 10 de la methode de travail sont inchangees, les deux ajouts sont des puces de la ligne editoriale et ne renumerotent rien.
- `docs/` n'est pas touche : les seuls fichiers de `docs/` qui porteraient un pendant naturel (`design.md`, `data-model.md`) sont en cours de modification sur les branches des issues #115 et #121. Le point de verite reste le `CLAUDE.md`.
- `make lint` et `make test` verts en local.
- En application de la regle 2 elle-meme, le passage a ete relu par un second agent sans contexte de redaction : verdict OK, aucune correction proposee.
