### PR TITLE
docs: le modele de l'offre porte l'enchainement data vers IA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,51 @@ posées côte à côte au catalogue :
   contenu, aucun visuel, aucun libellé, aucun numéro d'ordre ne doit laisser croire que
   l'une vient après l'autre.
 
+**Le passage obligé a une méthode.** Les étapes qui précèdent le test, gouvernance et
+stratégie data comprises, servent **les deux branches** : elles valent autant pour
+SEA & UX que pour IA. Le test de déterminisme, lui, ne commande que l'entrée dans la
+branche IA. Le détail qu'on lui donne ici ne la hisse pas au-dessus de SEA & UX, il dit
+seulement à quelle condition on y entre, et à quelle condition on n'y entre pas. Aucun
+contenu ne réordonne ces étapes.
+
+```
+métier  →  gouvernance  →  stratégie data  →  problématique  →  exploration de données
+  →  [ le problème a-t-il une réponse déterministe ? ]
+        oui  →  on s'arrête. Pas d'IA.
+        non  →  alors seulement, on considère l'IA
+                (supervisé, non supervisé, LLM, agents)
+```
+
+*(Enchaînement décrit par Jérôme MARICHEZ le 2026-08-23.)*
+
+- **La gouvernance vient avant la stratégie data**, jamais l'inverse : on établit qui
+  détient la donnée, qui l'arbitre et sous quelles règles, avant de décider ce qu'on en
+  fait. C'est cet ordre qui fait foi *(arbitré par Jérôme MARICHEZ, issue #126)*.
+- **La problématique s'écrit, et l'exploration de données est une étape nommée.** La
+  première pose la question, la seconde y répond sur les données réelles. Ni l'une ni
+  l'autre n'est un préliminaire implicite qu'on saute.
+- **Le test de déterminisme est un test, pas une intuition.** Il pose une question
+  unique : le problème a-t-il une réponse déterministe ? Quand le cadrage a déjà donné
+  la réponse, elle est acquise avant l'exploration ; sinon, c'est l'exploration qui la
+  produit. Elle se constate, elle ne se suppose pas.
+- **Le cas déterministe est un bon résultat**, jamais un échec ni un moindre résultat.
+  Ce qui s'arrête est la trajectoire vers l'IA, pas la mission : le problème est traité,
+  il l'est sans modèle, et c'est un client à qui on évite une dépense inutile. Le lui
+  dire est un argument de lucidité, jamais une porte qui se ferme.
+- **Les familles de solutions IA se nomment sans hiérarchie** : supervisé, non
+  supervisé, LLM, agents. Aucun ordre, aucun numéro, aucune formule ne doit en désigner
+  une comme le choix par défaut ou comme le niveau supérieur. Quand le problème l'impose,
+  un LLM classique reste un choix légitime, open source ou propriétaire : « propriétaire »
+  désigne ici un modèle fermé, à ne pas confondre avec la propriété du client ci-dessous.
+- **L'axe économique donne au passage obligé sa raison chiffrable.** Deux notions
+  distinctes, à ne jamais confondre. La **propriété** : quand la stratégie data est
+  solide en amont, le client peut être propriétaire de sa solution IA au lieu de payer
+  indéfiniment l'usage d'un modèle tiers. Le **niveau cognitif** : un workflow agentique
+  de bas niveau cognitif, autrement dit un enchaînement automatisé qui ne demande au
+  modèle que ce que lui seul sait faire, coûte moins cher qu'un LLM sollicité pour tout,
+  parce que la donnée bien structurée a déjà fait le travail. Le chiffre se mesure sur
+  le projet, il ne s'annonce pas d'avance.
+
 Le **périmètre éditorial complet** (les quatre pôles en détail, les preuves chiffrées,
 les certifications, l'arborescence des pages, les contraintes SEO / perf / a11y / RGPD)
 est décrit dans le [`README.md`](./README.md) : c'est la **source de vérité du contenu**.


### PR DESCRIPTION
Porte dans le `CLAUDE.md` l'enchaînement Data vers IA décrit par Jérôme MARICHEZ le
2026-08-23. Référence : issue #127. (`Closes` volontairement absent : les PR visent `dev`,
la fermeture de l'issue reste manuelle.)

## Autorisation

La règle 10 du `CLAUDE.md` interdit à l'assistant de modifier ce fichier, sauf demande
explicite de Jérôme MARICHEZ. Cette demande a été faite le **2026-08-23** : Jérôme MARICHEZ
a décrit l'enchaînement Data vers IA en demandant qu'il serve pour le contenu du site et
pour clarifier les étapes. L'autorisation couvre **cet ajout précis**. Aucune autre partie
du fichier n'est retouchée, aucun autre fichier n'est modifié.

## Le problème

La section « Le modèle de l'offre » affirmait que Data est le passage obligé et le
justifiait par « sans mesure, l'IA devine ». C'est une justification par le résultat, pas
une méthode. Un agent qui écrit du contenu sur ces deux pôles ne savait donc ni par quelles
étapes on passe de la donnée à l'IA, ni à quel moment on décide qu'il n'en faut pas.

## Ce qui est ajouté

45 lignes dans `CLAUDE.md`, entre la troisième affirmation du modèle de l'offre et le
paragraphe « Le périmètre éditorial complet ». Texte exact :

> **Le passage obligé a une méthode.** Les étapes qui précèdent le test, gouvernance et
> stratégie data comprises, servent **les deux branches** : elles valent autant pour
> SEA & UX que pour IA. Le test de déterminisme, lui, ne commande que l'entrée dans la
> branche IA. Le détail qu'on lui donne ici ne la hisse pas au-dessus de SEA & UX, il dit
> seulement à quelle condition on y entre, et à quelle condition on n'y entre pas. Aucun
> contenu ne réordonne ces étapes.
>
> ```
> métier  →  gouvernance  →  stratégie data  →  problématique  →  exploration de données
>   →  [ le problème a-t-il une réponse déterministe ? ]
>         oui  →  on s'arrête. Pas d'IA.
>         non  →  alors seulement, on considère l'IA
>                 (supervisé, non supervisé, LLM, agents)
> ```
>
> *(Enchaînement décrit par Jérôme MARICHEZ le 2026-08-23.)*
>
> - **La gouvernance vient avant la stratégie data**, jamais l'inverse : on établit qui
>   détient la donnée, qui l'arbitre et sous quelles règles, avant de décider ce qu'on en
>   fait. C'est cet ordre qui fait foi *(arbitré par Jérôme MARICHEZ, issue #126)*.
> - **La problématique s'écrit, et l'exploration de données est une étape nommée.** La
>   première pose la question, la seconde y répond sur les données réelles. Ni l'une ni
>   l'autre n'est un préliminaire implicite qu'on saute.
> - **Le test de déterminisme est un test, pas une intuition.** Il pose une question
>   unique : le problème a-t-il une réponse déterministe ? Quand le cadrage a déjà donné
>   la réponse, elle est acquise avant l'exploration ; sinon, c'est l'exploration qui la
>   produit. Elle se constate, elle ne se suppose pas.
> - **Le cas déterministe est un bon résultat**, jamais un échec ni un moindre résultat.
>   Ce qui s'arrête est la trajectoire vers l'IA, pas la mission : le problème est traité,
>   il l'est sans modèle, et c'est un client à qui on évite une dépense inutile. Le lui
>   dire est un argument de lucidité, jamais une porte qui se ferme.
> - **Les familles de solutions IA se nomment sans hiérarchie** : supervisé, non
>   supervisé, LLM, agents. Aucun ordre, aucun numéro, aucune formule ne doit en désigner
>   une comme le choix par défaut ou comme le niveau supérieur. Quand le problème l'impose,
>   un LLM classique reste un choix légitime, open source ou propriétaire : « propriétaire »
>   désigne ici un modèle fermé, à ne pas confondre avec la propriété du client ci-dessous.
> - **L'axe économique donne au passage obligé sa raison chiffrable.** Deux notions
>   distinctes, à ne jamais confondre. La **propriété** : quand la stratégie data est
>   solide en amont, le client peut être propriétaire de sa solution IA au lieu de payer
>   indéfiniment l'usage d'un modèle tiers. Le **niveau cognitif** : un workflow agentique
>   de bas niveau cognitif, autrement dit un enchaînement automatisé qui ne demande au
>   modèle que ce que lui seul sait faire, coûte moins cher qu'un LLM sollicité pour tout,
>   parce que la donnée bien structurée a déjà fait le travail. Le chiffre se mesure sur
>   le projet, il ne s'annonce pas d'avance.

## Le choix de mise en forme, et l'équilibre des branches

Le bloc est posé **sans titre de section**. Un `####` aurait avalé le paragraphe
« Le périmètre éditorial complet », puis « Stack » et « Contraintes produit », qui vivent
tous sous le `###` du modèle de l'offre. Le paragraphe d'ouverture en gras joue le rôle de
titre, comme le font déjà « **Stack** : » et « **Contraintes produit non négociables** : ».

Le risque signalé par l'issue est traité **par le périmètre, pas par une dénégation** :
l'ouverture pose que gouvernance et stratégie data servent les deux branches, et que seul
le test de déterminisme commande l'entrée dans la branche IA. IA et SEA & UX restent donc
de rang égal par construction. Une première version fermait le bloc sur une phrase qui
commentait son propre nombre de lignes ; elle a été supprimée, elle attirait l'attention
sur le déséquilibre au lieu de le lever.

## Relecture par un second agent

Conformément à la règle entrée en vigueur avec la PR #125, le texte est passé par un
second agent sans contexte de rédaction (`opus-dev`), à qui seuls le texte final et les
points à vérifier ont été transmis. Il a rendu treize constats. Traitement :

**Retenus et intégrés**

| Constat | Ce qui a changé |
|---------|-----------------|
| La phrase d'ouverture définissait la méthode de Data par sa seule sortie IA, ce qui affaiblissait « l'embranchement est inclusif » | Ouverture réécrite : les étapes en amont du test servent les deux branches, le test ne commande que l'entrée dans la branche IA |
| Le paragraphe de clôture commentait le nombre de lignes du bloc | Supprimé, le périmètre posé en tête le rend inutile |
| « propriétaire » employé à quelques lignes d'écart dans deux sens (le client possède / le modèle est fermé) | Les deux sens sont désormais séparés en deux puces et explicitement distingués |
| « Le cas échéant, on passe par un LLM classique » était orpheline dans la puce économique | Déplacée dans la puce des familles de solutions, avec sa condition explicite |
| Le schéma plaçait le test après l'exploration, la puce disait que la réponse peut venir du cadrage | Levé : « quand le cadrage a déjà donné la réponse, elle est acquise avant l'exploration ; sinon, c'est l'exploration qui la produit » |
| « on s'arrête » ne disait pas si c'est la mission ou la branche IA qui s'arrête | Précisé : « ce qui s'arrête est la trajectoire vers l'IA, pas la mission » |
| « problématique » figurait au schéma sans qu'aucune puce ne l'explique | Puce ajoutée, la problématique pose la question, l'exploration y répond |
| « raison chiffrable » annonçait un chiffre jamais fourni | Garde-fou ajouté : « le chiffre se mesure sur le projet, il ne s'annonce pas d'avance » |
| « louer indéfiniment l'intelligence d'un tiers », formule d'agence | Remplacé par le fait brut : « payer indéfiniment l'usage d'un modèle tiers » |
| L'état passé du site (« le contenu enchaînait l'ordre inverse ») vieillira mal dans une règle permanente | Remplacé par l'attribution seule : *(arbitré par Jérôme MARICHEZ, issue #126)* |
| Flèches `->` alors que le schéma voisin utilise `→` | Aligné sur `→` |

**Refusés, et pourquoi**

- **Remplacer la « propriété » par la « dépendance ».** Le relecteur y voyait une promesse
  d'absolu du même ordre que « aucune sous-traitance ». Refusé : « propriété » est le mot
  de Jérôme MARICHEZ (« une solution IA dont vous seriez le propriétaire ») et l'issue #127
  exige explicitement la distinction propriété / niveau cognitif. La règle de fidélité à la
  source prime. La promesse est en revanche ramenée au conditionnel de la source (« peut
  être propriétaire », et non « est propriétaire »), et elle reste conditionnée à une
  stratégie data solide en amont.
- **Supprimer « workflow agentique de bas niveau cognitif », jugé illisible pour un
  prospect.** Refusé : c'est le terme de Jérôme MARICHEZ, et ce fichier est une règle
  interne, pas du contenu publié. La lisibilité est traitée par une glose ajoutée sur
  place, qui donne aux rédacteurs de quoi le traduire pour le site.
- **Remplacer « le test de déterminisme est un test, pas une intuition » par « le
  déterminisme se vérifie, il ne se pressent pas ».** Refusé : la tautologie est
  volontaire, c'est la formulation que l'issue demande de graver.
- **Titrer le bloc en `#### Entrée de la branche IA`.** Refusé pour la raison de structure
  exposée plus haut : le titre aurait capturé trois paragraphes qui ne lui appartiennent
  pas. Le périmètre est posé en toutes lettres dans le paragraphe d'ouverture.

**Point laissé à l'arbitrage de Jérôme MARICHEZ**

Le relecteur estime que « le client peut être propriétaire de sa solution IA » engage ce
qu'on promet au client et mérite une validation humaine. Le texte reprend la formulation de
l'issue et la conditionne, mais la décision reste ouverte.

## Vérifications

- Tirets cadratins du fichier : **37**, inchangé. Dans les lignes ajoutées : **0**. Aucun
  tiret demi-cadratin, aucun emoji, aucune apostrophe typographique introduite.
- Largeur maximale des lignes ajoutées : 90 caractères, conforme au reste du fichier.
- Aucune règle existante contredite, aucune numérotation cassée, aucun autre fichier touché
  (`git status` ne montre que `CLAUDE.md`). Ni `next-env.d.ts` ni `package-lock.json` ne
  sont commités.
- `make lint` : vert. `make test` : vert.

## Impacts

Documentation seule. Aucun impact code, sécurité, RGPD ni migration. Le `README.md` n'est
pas touché, il relève de l'issue #126 traitée en parallèle.
