### PR TITLE
feat: le pilotage SEA dit sur quels segments il arbitre

### DIFF
--- a/src/@vitrine/contenu/sea-ux-sections.ts
+++ b/src/@vitrine/contenu/sea-ux-sections.ts
@@ -9,6 +9,38 @@
 // Acetelecom / MailingVox (chez Verhoeven : Google Analytics, A/B testing, heatmaps) ;
 // mobile = Firebase Analytics et Crashlytics uniquement ; régies = Google Ads et
 // Bing Ads, jamais Meta ni LinkedIn.
+//
+// Le chapitre `pilotage` dit désormais SUR QUOI il arbitre (issue #128) : les segments
+// d'abord, la valeur client dans la durée ensuite. Deux points de véracité s'y attachent,
+// et ils ne se rouvrent pas sans preuve nouvelle.
+//
+//  1. La FIDÉLISATION n'a aucune preuve, ni dans le dépôt ni dans aucun des trois CV de
+//     référence (recherche du 2026-08-23 : segmentation, LTV, profilage, fidélisation,
+//     rétention, churn). Elle n'apparaît donc jamais comme une prestation dont le
+//     résultat serait tenu. Mesurer ce qu'un client rapporte sur deux ans, c'est par
+//     construction mesurer ce qu'il vaut une fois acquis : c'est à ce titre, et à ce
+//     titre seulement, qu'elle est nommée, comme un arbitrage que la mesure permet. Toute
+//     reformulation qui laisserait entendre une campagne de rétention menée, un
+//     programme de fidélité ou un churn réduit serait fausse.
+//  2. Le PROFILAGE par clustering (KNN) reste écrit une seule fois, sur la page Data,
+//     qui dit COMMENT il est produit. Ici on dit seulement ce qu'on en fait. Recopier la
+//     méthode ferait perdre au site la seule chose qui distingue les deux pages.
+//
+// L'enrichissement tient DANS le chapitre existant, sans en créer un nouveau : le SEA &
+// UX et l'IA sont deux branches parallèles de rang égal, et une page qui gagnerait deux
+// chapitres quand l'autre en compte quatre dirait le contraire en pure mise en page.
+//
+// Le « sur deux ans » du chapô n'est pas un chiffre de performance et ne s'invente pas
+// ici : il vient de la fiche `mesure-ltv-multi-sources`, il y désigne l'horizon qu'aucune
+// régie ne couvre, et l'issue #128 le reprend tel quel. Il est resté au chapô, et une
+// seule fois : le bloc dit « dans la durée », pour ne pas répéter la formule à cinq lignes
+// d'intervalle.
+//
+// Le bloc « Valeur client à long terme » porte texte, preuve et décision à la fois, là où
+// le commentaire d'`IEditorialBlock` invite d'ordinaire à omettre le texte. C'est
+// délibéré : sans lui, la preuve du système multi-sources dit ce qui a été construit sans
+// dire ce qu'on en tire, et ce bloc était le plus maigre de la page alors qu'il en porte
+// l'argument central.
 
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 
@@ -110,10 +142,31 @@ export const SECTIONS_SEA_UX: IEditorialSection[] = [
     kicker: 'Le pilotage',
     titre: 'Arbitrer sur la rentabilité réelle, pas sur les métriques des régies',
     chapo:
-      'Une régie mesure ce qu’elle a servi, pas ce que le client vous rapportera sur deux ans.',
+      'Une régie mesure ce qu’elle a servi, pas ce que le client vous rapportera sur deux ' +
+      'ans, et elle ne sait pas à quel profil de client elle vient de parler. J’arbitre sur ' +
+      'ce qui lui manque : les segments calculés sur votre historique client, ce qu’un client ' +
+      'coûte à gagner et ce qu’il rapporte ensuite.',
     blocs: [
       {
+        titre: 'Sur quels segments j’arbitre',
+        texte:
+          'Les segments viennent du profilage client mené sur le pôle Data, pas d’une cible ' +
+          'choisie au départ. Je les reprends tels quels pour répartir le budget entre les ' +
+          'campagnes, régler les enchères et décider quel message va à quel groupe.',
+        decision:
+          'Quels segments reçoivent le budget d’acquisition du trimestre, et lesquels n’en ' +
+          'reçoivent plus.',
+      },
+      {
         titre: 'Valeur client à long terme',
+        texte:
+          'J’agrège les régies, le produit et le CRM dans un même modèle, puis je réconcilie ' +
+          'les identités avant toute lecture de performance. Je lis alors ce que le client ' +
+          'rapporte dans la durée, pas ce qu’un clic a coûté. Le même chiffre dit ce qu’il ' +
+          'vaut une fois acquis : il éclaire donc l’acquisition comme la fidélisation.',
+        preuve:
+          'Un système d’analyse multi-sources conforme RGPD : Google Ads, Bing Ads, produit ' +
+          'et CRM agrégés sur le modèle métier, identités réconciliées et dédoublonnées.',
         decision: 'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre.',
       },
       {

--- a/src/@vitrine/contenu/sea-ux.ts
+++ b/src/@vitrine/contenu/sea-ux.ts
@@ -1,6 +1,11 @@
 // sea-ux.ts — jeromemarichez-fr
 // Le pôle SEA & UX — l'une des deux suites de la donnée. Métadonnées ; les sections
 // vivent dans le fichier voisin.
+//
+// La description suit ce que la page dit vraiment depuis l'issue #128 : le pilotage
+// nomme désormais ce SUR QUOI il arbitre, les segments et la valeur client dans la durée.
+// « GTM web et server-side » lui a cédé la place : c'est un outil, et la règle du projet
+// est de vendre une décision. Plafond tenu : 155 caractères (docs/data-model.md).
 
 import type { IEditorialPage } from '@/interfaces/IEditorialPage'
 import { SECTIONS_SEA_UX } from './sea-ux-sections'
@@ -10,8 +15,8 @@ export const PAGE_SEA_UX: IEditorialPage = {
   meta: {
     title: 'SEA & arbitrages UX sur la donnée — Lille',
     description:
-      'Mesure construite dans le code (GTM web et server-side), consentement conforme, ' +
-      'rentabilité à long terme, arbitrages de parcours décidés puis implémentés.',
+      'Mesure construite dans le code, consentement conforme, campagnes arbitrées sur vos ' +
+      'segments et sur la valeur client à long terme, parcours implémentés.',
   },
   sections: SECTIONS_SEA_UX,
 }


### PR DESCRIPTION
Référence : #128 (la référence est écrite telle quelle, `Closes` ne ferme rien ici : la PR
vise `dev` et la branche par défaut est `main`).

## Ce qui est enrichi

Un seul chapitre bouge, `pilotage` de `sea-ux-sections.ts`. Il disait sur quoi il refusait
d'arbitrer (les métriques des régies) sans jamais dire sur quoi il arbitre.

- **Chapô** : la régie ne connaît ni l'horizon ni le profil du client. Le pilotage annonce
  ce qui lui manque : les segments calculés sur l'historique client, ce qu'un client coûte
  à gagner et ce qu'il rapporte ensuite.
- **Nouveau bloc « Sur quels segments j'arbitre »** : les segments viennent du profilage
  client mené sur le pôle Data, pas d'une cible choisie au départ ; la page SEA & UX dit ce
  qu'elle en fait (répartition du budget, enchères, message par groupe). Décision :
  « Quels segments reçoivent le budget d'acquisition du trimestre, et lesquels n'en
  reçoivent plus. »
- **Bloc « Valeur client à long terme »**, le plus maigre de la page, ne l'est plus : il
  porte enfin un texte et la preuve qui existait déjà dans le dépôt et n'était pas
  mobilisée ici, celle de la réalisation `mesure-ltv-multi-sources` (agrégation régies,
  produit et CRM sur le modèle métier, identités réconciliées et dédoublonnées, conforme
  RGPD). Sa ligne de décision est inchangée : c'est celle de la fiche.
- **Méta-description de `sea-ux.ts`** : elle suit ce que la page dit maintenant. « GTM web
  et server-side » lui cède la place, c'est un outil et la règle du projet est de vendre
  une décision. 151 caractères, sous le plafond de 155 de `docs/data-model.md`.

## Ce qui n'est pas touché

- Le discours sur le **parcours client** (`cadrage-ux`), jugé déjà juste par Jérôme
  MARICHEZ, est inchangé à la lettre près.
- `mesure`, `conformite` et `boucle` sont inchangées : le plan de taggage et la conformité
  restent où ils sont, rien n'est dupliqué.
- Le **profilage par clustering (KNN)** reste écrit une seule fois, sur la page Data, qui
  dit comment il est produit. La page SEA & UX dit seulement ce qu'elle en fait.
- Le modèle de l'offre est intact : l'enrichissement tient **dans** le chapitre existant,
  sans en créer un nouveau. Une page qui gagnerait deux chapitres quand l'IA en compte
  quatre dirait en pure mise en page que le SEA & UX est la branche principale. Il reste
  cinq sections, comme avant.
- Pas de `README.md`, pas de `data-sections.ts` : l'issue #126 y travaille en parallèle.
  Aucune doc n'est impactée, le changement est éditorial et n'ajoute ni champ ni gabarit.

## La fidélisation, et comment elle est formulée

Recherche menée dans le dépôt **et dans les trois CV de référence** : la fidélisation n'a
**aucune preuve**, ni chiffrée ni directionnelle. La règle du `CLAUDE.md` s'applique telle
quelle : une affirmation sans preuve se reformule ou se supprime.

Elle n'est donc **jamais présentée comme une prestation dont le résultat serait tenu**, et
aucune campagne de rétention, aucun programme de fidélité, aucun churn en baisse n'est
suggéré. Elle apparaît une seule fois, en conséquence logique de la mesure :

> Le même chiffre dit ce qu'il vaut une fois acquis : il éclaire donc l'acquisition comme
> la fidélisation.

Mesurer ce qu'un client rapporte dans la durée, c'est par construction mesurer ce qu'il
vaut une fois acquis. La fidélisation est donc un **arbitrage que la mesure permet**, pas
un savoir-faire revendiqué. Aucune ligne de décision et aucun chiffre ne s'y rattachent :
la décision du bloc reste sur la coupe d'une source d'acquisition. La contrainte est
inscrite en tête de fichier pour qu'elle ne se rouvre pas par inadvertance ; elle tombera
le jour où une preuve chiffrée sera fournie.

## Relecture par un second agent

Un second agent a relu les textes finaux **sans le contexte de rédaction**, sur la table
des interdits, la ligne éditoriale, le tiret cadratin et la clarté pour un nouveau lecteur.
Verdict initial : à corriger, quatre points.

**Retenus et intégrés :**

1. **« en production » ne figure dans aucune source.** Retiré de la preuve. La fiche dit
   « le système existe et il tourne », ce qui ne justifie pas d'en ajouter la formule.
2. **« côté data » est du jargon d'équipe** pour qui arrive sur la page par une recherche
   et ignore qu'il existe un pôle Data. Devenu « mené sur le pôle Data ».
3. **« les segments sortis de votre donnée » ne dit pas assez qu'ils sont calculés** et
   peut se lire comme une intuition informée, ce qui perdrait l'argument. Le chapô dit
   maintenant « les segments calculés sur votre historique client ».
4. **Répétitions** relevées entre le chapô et le bloc (« une fois gagné » / « une fois
   acquis », « sur deux ans » deux fois) : les formules ont été variées.

**Refusés, motivés :**

- **Supprimer le mot « fidélisation ».** L'agent a d'abord constaté que le texte est
  « conforme au sens strict », aucune formulation ne revendiquant de résultat, puis a
  proposé de retirer le mot par prudence. C'est l'issue #128 elle-même qui demande que la
  fidélisation soit nommée, et qui prescrit exactement cette formulation. Sa réserve
  d'accompagnement est en revanche tenue à la lettre : le mot n'est suivi d'aucune ligne
  de décision et d'aucun chiffre.
- **Retirer « sur deux ans », faute de preuve.** L'horizon de deux ans n'est pas un
  chiffre de performance et n'est pas inventé ici : il vient de la fiche
  `mesure-ltv-multi-sources` (« aucune ne dit ce qu'un client rapporte sur deux ans »), il
  était déjà dans le chapô avant cette PR, et l'issue le reprend tel quel. Il désigne
  l'horizon qu'aucune régie ne couvre, pas un résultat obtenu. Il est conservé, mais une
  seule fois : le bloc dit désormais « dans la durée ».

## Vérifications

- `make lint` vert, limite de 300 lignes tenue (213 lignes pour `sea-ux-sections.ts`).
- `npx tsc --noEmit` vert, `make test` vert, `npm run build` vert.
- `make budgets` vert : Lighthouse 96 à 99 en performance, 100 en accessibilité, bonnes
  pratiques et SEO sur les sept gabarits, axe-core sans violation.
- Rendu contrôlé sur `npx next dev` : `/services/sea-ux/` et l'accueil.
- `git diff -U0 | grep "^+"` ne contient **aucun tiret cadratin** ni emoji, commentaires
  compris.

## Tests

Aucun fichier de test n'est créé : le test est écrit par Jérôme MARICHEZ. Les intentions
proposées sont exposées dans le rapport de la tâche.
