### PR TITLE
feat: l'enchainement data vers IA et son test de determinisme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ plus une file de quatre étapes qu'il faudrait toutes acheter :
 | Place | Pôle | Ce qu'il fait |
 |-------|------|---------------|
 | socle | **Ingénierie web** | construire le site, le SaaS, l'application mobile — et les exploiter |
-| passage | **Data** | comprendre le métier, bâtir ou reprendre la stratégie data, gouverner |
+| passage | **Data** | comprendre le métier, gouverner, bâtir ou reprendre la stratégie data, puis explorer |
 | suite | **IA** | choisir la solution — règle métier intégrée à l'existant, modèle, ou LLM |
 | suite | **SEA & UX** | trancher les parcours et les budgets sur la donnée, puis implémenter |
 
@@ -69,7 +69,7 @@ sans en cacher une.
 | De → vers | Ce qui est transmis | Si le client l'a déjà |
 |-----------|---------------------|-----------------------|
 | Ingénierie web → Data | un produit en production, exploité et mesuré : c'est le run qui fabrique la donnée | on part du produit existant, il n'est pas réécrit pour avoir le droit d'être mesuré |
-| Data → IA | un métier formalisé et une donnée gouvernée | la stratégie data est reprise telle quelle, elle ne se rachète pas |
+| Data → IA | un métier formalisé, une donnée gouvernée, et la réponse au test de déterminisme : cette suite ne s'ouvre que si elle est non | la stratégie data est reprise telle quelle, elle ne se rachète pas |
 | Data → SEA & UX | la même donnée, tournée vers l'arbitrage | on arbitre dessus dès le premier jour, et rien n'oblige à prendre l'IA |
 
 Cette seconde colonne est ce qui distingue une dépendance de **matière** — vraie et
@@ -128,10 +128,34 @@ bout. Elle mobilise toutes les compétences du parcours.
 
 ### Le passage obligé — Data
 
-**L'ordre est le contenu.** Ce pôle ne part pas de la technique, il y arrive. On
-comprend d'abord le métier, on traite ensuite la stratégie data, puis la gouvernance et
-le droit. Toute réécriture qui remettrait la technique en tête viderait l'offre de son
-sens.
+**L'ordre est le contenu.** Ce pôle ne part pas de la technique, il y arrive. On comprend
+d'abord le métier, on gouverne ensuite, on bâtit alors la stratégie data, et on finit sur
+une question posée puis explorée. Toute réécriture qui remettrait la technique en tête
+viderait l'offre de son sens.
+
+**La gouvernance précède la stratégie data** (arbitré par Jérôme MARICHEZ le 2026-08-23,
+issue #126). Ce n'est pas un détail de plan : ce qui a le droit d'être collecté borne ce
+qu'on décide de mesurer, jamais l'inverse. Un plan de collecte arbitré avant la question
+du droit se refait.
+
+L'enchaînement complet, celui qui doit rester lisible sur le site :
+
+```
+métier  →  gouvernance  →  stratégie data  →  problématique  →  exploration de données
+   →  [ le problème a-t-il une réponse déterministe ? ]
+         oui  →  on s'arrête. Pas d'IA.
+         non  →  alors seulement, on considère l'IA
+                 (supervisé, non supervisé, LLM, agents)
+```
+
+Le **test de déterminisme** est un test, pas une intuition : il se pose à un endroit
+précis, et sa réponse tombe soit **en amont** (le métier la porte déjà, elle est définie
+dès le cadrage), soit **pendant l'exploration de données**. Dans les deux cas on s'arrête
+là. Le cas « déterministe » s'écrit toujours comme un **bon résultat** : c'est un client à
+qui on évite une dépense inutile, jamais un projet raté.
+
+Le test ne gouverne que la suite IA. **Le SEA & UX ne l'attend pas** : les deux suites
+restent parallèles et de rang égal.
 
 C'est aussi le pôle par lequel tout passe — et celui qui **se livre pour lui-même**. Un
 client peut s'arrêter au document produit ici, sans jamais acheter d'IA ni de SEA. Cette
@@ -155,18 +179,7 @@ péage.
 - **Livrable propre** : ce que la donnée dit de l'activité, les règles formalisées, les
   profils identifiés, les questions sans réponse. Le client peut s'arrêter là.
 
-**2. La stratégie data — la déployer, ou s'appuyer sur celle qui existe.**
-
-- **Quand rien n'est en place** — définition des indicateurs à partir des questions du
-  métier, plan de collecte, pipelines d'ingestion, modélisation : PostgreSQL
-  (relationnel, séries temporelles, vectoriel), MySQL, Firebase.
-- **Quand la donnée existe** — reprise de l'existant, agrégation et réconciliation
-  multi-sources, dédoublonnage des identités, contrôles d'intégrité et de véracité dès
-  l'ingestion, détection d'anomalies. La qualité est un **prérequis**, pas un correctif.
-  *Preuve : système d'analyse multi-sources conforme RGPD mesurant la rentabilité client
-  à long terme, branché sur Google Ads et Bing Ads.*
-
-**3. Gouvernance et législation — avant la technique, jamais après.**
+**2. Gouvernance et législation — avant la technique, jamais après.**
 
 - **Qui possède quoi** — cartographie des sources et de leur propriété, ce qui peut
   sortir de chez le client et ce qui doit y rester.
@@ -179,6 +192,35 @@ péage.
   d'office un service tiers et ramène l'arbitrage entre modèle open-weight hébergé et
   règle explicite.
 
+**3. La stratégie data — la déployer, ou s'appuyer sur celle qui existe.**
+
+- **Quand rien n'est en place** — définition des indicateurs à partir des questions du
+  métier, plan de collecte, pipelines d'ingestion, modélisation : PostgreSQL
+  (relationnel, séries temporelles, vectoriel), MySQL, Firebase.
+- **Quand la donnée existe** — reprise de l'existant, agrégation et réconciliation
+  multi-sources, dédoublonnage des identités, contrôles d'intégrité et de véracité dès
+  l'ingestion, détection d'anomalies. La qualité est un **prérequis**, pas un correctif.
+  *Preuve : système d'analyse multi-sources conforme RGPD mesurant la rentabilité client
+  à long terme, branché sur Google Ads et Bing Ads.*
+
+**4. La problématique et l'exploration de données : l'étape qui produit le test.**
+
+- **Poser la problématique** : une question à laquelle une donnée peut répondre, et dont
+  la réponse change une décision. Un objectif large ne se traite pas, il se découpe en
+  questions.
+- **Explorer les données** : la question est posée, l'exploration ne cherche plus à
+  comprendre l'activité (c'est l'étape 1) mais à savoir si la réponse tient déjà dans un
+  seuil, une règle ou une requête.
+- **Le test de déterminisme** : « ce problème a-t-il une réponse déterministe ? ». Oui,
+  la réponse s'écrit, se vérifie et s'explique, et on s'arrête là, sans IA. Non, elle
+  dépend de régularités qu'aucune règle ne tient, et l'IA devient une option à examiner.
+  Le test est posé **ici, et une seule fois** : la page IA n'en rejoue pas la question,
+  elle part de son résultat. Et il ne préjuge de rien pour le SEA & UX, qui s'ouvre sur
+  la même exploration sans avoir à attendre cette réponse.
+- **S'arrêter est un résultat** : le cas déterministe n'est pas un projet raté, c'est un
+  projet répondu. Le client repart avec la règle qui tranche et sans le budget d'un
+  modèle à entraîner puis à maintenir.
+
 ### Une des deux suites — IA
 
 **La solution répond au problème posé au départ, pas à l'état de l'art**, et **elle
@@ -187,9 +229,14 @@ donnée gouvernée, un modèle apprend l'erreur de cadrage au lieu de la corrige
 ne se prend pas forcément : le SEA & UX s'ouvre en parallèle, et rien n'oblige à acheter
 de l'IA pour tirer parti de sa donnée.
 
-- **Une règle métier suffit souvent** — moins chère à faire tourner, plus facile à
-  expliquer à un régulateur, plus simple à corriger qu'un modèle. Intégrée aux systèmes
-  existants, c'est un **livrable complet**. *Preuve : règles anti-fraude définies puis
+Ce pôle ne s'ouvre que sur une réponse : celle du **test de déterminisme**, posé à
+l'étape 4 du pôle Data. Le site ne repose pas le test ici, il en reçoit le résultat et
+raconte ses deux issues. **Les quatre familles se nomment sans hiérarchie** : supervisé,
+non supervisé, LLM, agents. Aucune n'est un niveau au-dessus d'une autre.
+
+- **Réponse déterministe : une règle métier suffit** — moins chère à faire tourner, plus
+  facile à expliquer à un régulateur, plus simple à corriger qu'un modèle. Intégrée aux
+  systèmes existants, c'est un **livrable complet**. *Preuve : règles anti-fraude définies puis
   implémentées dans le produit — fraude en baisse, conversion des inscriptions en
   hausse, latence réduite ; flux commande, stock et facturation modélisés en BPMN puis
   intégrés entre un ERP et un site marchand — survente évitée sur des pièces uniques.*
@@ -199,6 +246,18 @@ de l'IA pour tirer parti de sa donnée.
   caractéristiques du signal audio selon une méthode publiée sur **arXiv**, implémentée
   par Jérôme lui-même, adaptée aux données réelles puis industrialisée. *Preuve : routes
   vocales coûteuses évitées.*
+- **Coût et propriété** : ce que la stratégie data rembourse. C'est l'argument le plus
+  différenciant du pôle. Si la stratégie data est assez solide en amont, on passe sur une
+  solution IA **dont le client est propriétaire**, à **coûts réduits**, via
+  l'implémentation d'un **workflow agentique de bas niveau cognitif** ; le cas échéant, on
+  passe par un **LLM classique, open source ou propriétaire**. Deux notions distinctes,
+  à ne jamais fondre en une :
+  - **La propriété** : le client possède la solution au lieu de louer indéfiniment
+    l'intelligence d'un tiers. Ce qui se lit sur ce qui reste s'il coupe, pas sur le prix
+    du mois.
+  - **Le niveau cognitif** : un workflow agentique de bas niveau cognitif coûte moins
+    cher qu'un LLM sollicité pour tout, parce que la donnée bien structurée a déjà fait
+    une fois le travail que le modèle aurait facturé à chaque appel.
 - **LLM, quand le problème est du langage** — Claude (Vertex AI, API Anthropic), OpenAI,
   Gemini, Llama. Context engineering, comparaison continue et arbitrage
   **coût / latence / qualité / confidentialité** par cas d'usage. Fine-tuning de

--- a/src/@vitrine/contenu/data-sections.ts
+++ b/src/@vitrine/contenu/data-sections.ts
@@ -1,14 +1,27 @@
 // data-sections.ts — jeromemarichez-fr
-// Les chapitres de la page Data : métier, stratégie data, gouvernance et droit.
+// Les chapitres de la page Data : métier, gouvernance et droit, stratégie data, puis la
+// problématique et son exploration.
 //
 // Le critère de rattachement est le CONTENU, jamais le titre. Vient ici ce qui parle de
 // collecte, de plan de taggage, de gouvernance, de qualité ou de réconciliation
 // d'identités ; ce qui parle de modèles, d'inférence, de fine-tuning, de RAG ou d'agents
 // est dans `ia-sections.ts`, qui sert désormais un pôle distinct.
 //
-// L'ORDRE EST LE CONTENU : métier → stratégie data → gouvernance et droit. On part de
-// l'activité, pas d'un catalogue de technologies — la solution technique répond au
+// L'ORDRE EST LE CONTENU, et c'est celui de Jérôme MARICHEZ (2026-08-23) :
+// métier → gouvernance → stratégie data → problématique → exploration de données. On part
+// de l'activité, pas d'un catalogue de technologies : la solution technique répond au
 // problème posé au départ, elle n'en est jamais le point de départ.
+//
+// **Gouvernance avant stratégie data (issue #126).** Les deux sections étaient dans
+// l'ordre inverse. Ce n'est pas un détail de mise en page : ce qui a le droit d'être
+// collecté borne ce qu'on décide de mesurer, jamais l'inverse. Un plan de collecte
+// arbitré avant la question du droit se refait.
+//
+// **Le test de déterminisme (issue #126).** La section `exploration` porte la question
+// « ce problème a-t-il une réponse déterministe ? ». Elle vit ici, et non sur la page IA,
+// parce que c'est la donnée qui y répond : la page IA ne fait qu'en recevoir la réponse.
+// Le cas « oui » s'écrit comme un résultat, jamais comme un échec. Et le test ne gouverne
+// que la suite IA : le SEA & UX ne l'attend pas, les deux suites restent parallèles.
 //
 // Faits sourcés dans cv-ai-engineer.md, cv-tracking-specialist.md et
 // cv-ingenieur-fullstack.md. Règles de véracité du CLAUDE.md appliquées : méthode arXiv
@@ -65,14 +78,46 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     ],
   },
   {
+    id: 'gouvernance',
+    kind: 'chapitre',
+    pole: 'data',
+    kicker: 'Gouvernance et droit',
+    titre: 'Qui possède quoi, et ce qui a le droit d’être traité',
+    chapo:
+      'La question du droit se pose avant la moindre ligne de code, et avant le premier ' +
+      'indicateur : sa réponse écarte des solutions entières.',
+    blocs: [
+      {
+        titre: 'Qui possède la donnée',
+        decision: 'Quelle donnée reste chez vous, et ce que vous acceptez d’envoyer à un tiers.',
+      },
+      {
+        titre: 'Ce qui a le droit d’être collecté et traité',
+        preuve:
+          'Conformité RGPD et DORA tenue en appels d’offres grands comptes — distribution, ' +
+          'assurance, banque. Cadrage RGPD des données clients chez un e-commerçant de ' +
+          'joaillerie.',
+        decision:
+          'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
+      },
+      {
+        titre: 'La contrainte oriente la solution',
+        texte:
+          'Donnée qui ne peut pas sortir de chez vous : le service tiers est écarté, reste un ' +
+          'modèle open-weight hébergé — Llama 3 — ou une règle explicite.',
+      },
+    ],
+  },
+  {
     id: 'strategie-data',
     kind: 'chapitre',
     pole: 'data',
     kicker: 'La stratégie data',
     titre: 'Construire la stratégie data, ou s’appuyer sur celle qui existe',
     chapo:
-      'Soit il faut décider quoi mesurer, soit la donnée existe et il faut en tirer quelque ' +
-      'chose sans tout refaire.',
+      'Le périmètre légal est arbitré, on sait ce qui peut être collecté. Soit il faut ' +
+      'décider quoi mesurer, soit la donnée existe et il faut en tirer quelque chose sans ' +
+      'tout refaire.',
     blocs: [
       {
         titre: 'Quand rien n’est en place',
@@ -95,32 +140,52 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     ],
   },
   {
-    id: 'gouvernance',
+    id: 'exploration',
     kind: 'chapitre',
     pole: 'data',
-    kicker: 'Gouvernance et droit',
-    titre: 'Qui possède quoi, et ce qui a le droit d’être traité',
+    kicker: 'La problématique',
+    titre: 'Une question posée, des données explorées, et un test',
     chapo:
-      'Elle se pose avant la moindre ligne de code : sa réponse écarte des solutions entières.',
+      'La stratégie data sert une question, pas l’inverse. J’explore vos données pour savoir ' +
+      'si cette question a déjà sa réponse. Selon ce qui en sort, la suite est une règle, un ' +
+      'modèle, ou un arbitrage d’acquisition.',
     blocs: [
       {
-        titre: 'Qui possède la donnée',
-        decision: 'Quelle donnée reste chez vous, et ce que vous acceptez d’envoyer à un tiers.',
-      },
-      {
-        titre: 'Ce qui a le droit d’être collecté et traité',
-        preuve:
-          'Conformité RGPD et DORA tenue en appels d’offres grands comptes — distribution, ' +
-          'assurance, banque. Cadrage RGPD des données clients chez un e-commerçant de ' +
-          'joaillerie.',
-        decision:
-          'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
-      },
-      {
-        titre: 'La contrainte oriente la solution',
+        titre: 'Poser la problématique',
         texte:
-          'Donnée qui ne peut pas sortir de chez vous : le service tiers est écarté, reste un ' +
-          'modèle open-weight hébergé — Llama 3 — ou une règle explicite.',
+          'Une question à laquelle une donnée peut répondre, et dont la réponse change une ' +
+          'décision. Un objectif large ne se traite pas : il se découpe en questions.',
+        decision:
+          'La question que vous voulez voir tranchée en premier, et ce que sa réponse ' +
+          'changerait chez vous.',
+      },
+      {
+        titre: 'Explorer les données',
+        texte:
+          'Cette fois la question est posée, et l’exploration ne cherche plus à comprendre ' +
+          'votre activité : elle cherche si la réponse tient déjà dans un seuil, une règle ou ' +
+          'une requête.',
+        decision:
+          'Les questions que vous poursuivez avec ce que vous avez déjà, et celles qui ' +
+          'justifient d’aller collecter plus.',
+      },
+      {
+        titre: 'Le test : ce problème a-t-il une réponse déterministe ?',
+        texte:
+          'Je pose ce test sur vos données, et je vous rends la réponse avant qu’un euro parte ' +
+          'dans un modèle. Oui : la réponse s’écrit, se vérifie et s’explique, et je m’arrête ' +
+          'là, sans IA. Non : elle dépend de régularités qu’aucune règle ne tient, et l’IA ' +
+          'devient une option à examiner. Cette réponse tombe parfois dès le cadrage, quand ' +
+          'votre métier la porte déjà ; sinon elle sort de l’exploration.',
+        decision: 'Si ce problème appelle un modèle, ou s’il est déjà tranché.',
+      },
+      {
+        titre: 'S’arrêter est un résultat',
+        texte:
+          'Le cas déterministe n’est pas un projet raté, c’est un projet répondu. Vous ' +
+          'repartez avec la règle qui tranche, et sans le budget d’un modèle à entraîner puis ' +
+          'à maintenir.',
+        decision: 'Ce que vous n’avez pas besoin d’acheter, et sur quelle base.',
       },
     ],
   },
@@ -149,8 +214,9 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'Ce que l’IA en reçoit',
         texte:
-          'des règles explicites et un périmètre de données arbitré : de quoi décider si une ' +
-          'règle suffit, ou s’il faut vraiment un modèle.',
+          'des règles explicites, un périmètre de données arbitré, et la réponse à une ' +
+          'question : une règle suffit-elle, ou faut-il un modèle ? Cette suite ne s’ouvre que ' +
+          'dans le second cas.',
       },
       {
         titre: 'Ce que le SEA & UX en reçoit',

--- a/src/@vitrine/contenu/data.ts
+++ b/src/@vitrine/contenu/data.ts
@@ -1,8 +1,12 @@
 // data.ts — jeromemarichez-fr
 // Le pôle Data — le passage obligé. Métadonnées et chapitres.
 //
-// Le pôle part du métier et finit sur la gouvernance : le titre et la description le
-// disent dès la SERP, sinon la page est ouverte avec la mauvaise attente.
+// Le pôle part du métier et finit sur le test de déterminisme : le titre et la description
+// le disent dès la SERP, sinon la page est ouverte avec la mauvaise attente.
+//
+// L'ordre des chapitres est celui de Jérôme MARICHEZ (issue #126) : métier, gouvernance,
+// stratégie data, puis problématique et exploration. La description suit ce même ordre,
+// c'est lui qui se lit en SERP.
 //
 // Cette page ne porte plus que `data-sections.ts`. Les chapitres de modèles ont rejoint
 // `ia.ts`, qui est désormais un pôle à part entière : la donnée se livre pour elle-même,
@@ -16,8 +20,8 @@ export const PAGE_DATA: IEditorialPage = {
   meta: {
     title: 'Data : le métier d’abord — Lille',
     description:
-      'Insights métier, profils clients et règles existantes formalisés, stratégie data, ' +
-      'gouvernance et RGPD. La donnée se livre pour elle-même.',
+      'Métier, gouvernance et RGPD, stratégie data, exploration : le test qui dit si votre ' +
+      'problème demande un modèle. Rien n’oblige à prendre l’IA.',
   },
   sections: SECTIONS_DATA,
 }

--- a/src/@vitrine/contenu/ia-sections.ts
+++ b/src/@vitrine/contenu/ia-sections.ts
@@ -1,6 +1,6 @@
 // ia-sections.ts — jeromemarichez-fr
-// Les chapitres de la page IA : la réponse technique, le langage, la mise en production,
-// puis le retour au produit.
+// Les chapitres de la page IA : la réponse technique, le coût et la propriété, le langage,
+// la mise en production, puis le retour au produit.
 //
 // Le critère de rattachement est le CONTENU, jamais le titre. Vient ici ce qui parle de
 // modèles, d'inférence, de fine-tuning, de RAG ou d'agents ; ce qui parle de collecte, de
@@ -20,6 +20,24 @@
 // la main à aucun autre pôle — elle est un bout de chaîne, comme le SEA & UX — mais ce
 // qu'elle produit retourne dans le produit, et ça, c'est vrai des deux.
 //
+// **Le test de déterminisme et le prix de la donnée (issue #126).** Cette page disait
+// « souvent, une règle métier suffit » : un jugement, sans méthode ni moment. Le test
+// (« ce problème a-t-il une réponse déterministe ? ») est POSÉ sur la page Data, section
+// `exploration`, parce que c'est la donnée qui y répond. Ici, il n'est pas reposé : le
+// chapitre `solution` en reçoit la réponse et raconte les deux issues, chacune avec ses
+// preuves déjà en place. Ne pas dupliquer le test des deux côtés.
+//
+// Le chapitre `propriete` porte l'argument économique dicté par Jérôme MARICHEZ le
+// 2026-08-23, et il est nouveau : une stratégie data solide en amont permet une solution
+// dont le CLIENT est propriétaire, à coûts réduits, via un workflow agentique de BAS
+// niveau cognitif ; le LLM classique reste l'option quand ce n'est pas possible. Deux
+// notions distinctes, à ne jamais fondre en une : la propriété (posséder au lieu de
+// louer) et le niveau cognitif (la donnée structurée a déjà fait le travail que le modèle
+// aurait facturé à chaque appel).
+//
+// Ce chapitre porte la page à quatre chapitres et une charnière : exactement la forme du
+// pôle SEA & UX. Les deux suites restent de rang égal, c'est le modèle de l'offre.
+//
 // Faits sourcés dans cv-ai-engineer.md et cv-ingenieur-fullstack.md. Règles de véracité
 // du CLAUDE.md appliquées : RAG **maison** (aucun framework tiers), méthode arXiv
 // implémentée par Jérôme et non « en collaboration avec » l'Universitat de Barcelona,
@@ -36,11 +54,11 @@ export const SECTIONS_IA: IEditorialSection[] = [
     kicker: 'La réponse technique',
     titre: 'La solution répond au problème — et ce n’est pas toujours de l’IA',
     chapo:
-      'La technique n’arrive qu’ici, arbitrée contre le problème métier et ce que le droit ' +
-      'autorise. Pas contre l’état de l’art.',
+      'La technique n’arrive qu’ici, une fois établi sur vos données qu’aucune règle simple ne ' +
+      'répond. Les deux issues de ce test ont leur livrable, une seule demande un modèle.',
     blocs: [
       {
-        titre: 'Souvent, une règle métier suffit',
+        titre: 'Réponse déterministe : une règle métier suffit',
         texte:
           'Moins chère à faire tourner, plus facile à expliquer à un régulateur, plus simple ' +
           'à corriger qu’un modèle. Intégrée aux systèmes existants, c’est un livrable complet.',
@@ -49,18 +67,66 @@ export const SECTIONS_IA: IEditorialSection[] = [
           'personne : fraude en baisse, conversion des inscriptions en hausse, latence ' +
           'réduite. Flux commande, stock et facturation modélisés en BPMN puis intégrés ' +
           'entre un ERP et un site marchand : survente évitée sur des pièces uniques.',
-        decision:
-          'Ce qui se règle par une règle intégrée à l’existant, et ce qui mérite vraiment ' +
-          'un modèle.',
+        decision: 'Ce qui part en production sans modèle, et ce qui reste vraiment à apprendre.',
       },
       {
-        titre: 'Un modèle, quand la règle ne tient plus',
+        titre: 'Réponse non déterministe : le modèle apprend ce qu’aucune règle ne tient',
         texte:
           'Supervisé — classification, réseaux de neurones — ou non supervisé, selon ce que la ' +
           'donnée permet. La méthode d’extraction des caractéristiques du signal audio est ' +
           'publiée sur arXiv ; je l’ai implémentée moi-même, adaptée aux données réelles, puis ' +
           'industrialisée. TensorFlow, inférence en cloud functions.',
         preuve: 'Routes vocales coûteuses évitées.',
+        decision:
+          'Ce que vous acceptez de confier à une probabilité, et ce qui doit rester certain.',
+      },
+      {
+        titre: 'Quatre familles, et rien qui les classe',
+        texte:
+          'Aucune de ces familles n’est un niveau au-dessus des autres : supervisé, non ' +
+          'supervisé, LLM, agents. Le choix se fait sur la nature du problème et sur ce que la ' +
+          'donnée permet, pas sur un ordre de sophistication.',
+        decision: 'La famille que votre problème appelle, et ce qu’elle coûte à faire tourner.',
+      },
+    ],
+  },
+  {
+    id: 'propriete',
+    kind: 'chapitre',
+    pole: 'ia',
+    kicker: 'Coût et propriété',
+    titre: 'Une donnée solide en amont, une IA moins chère et qui vous appartient',
+    chapo:
+      'C’est ici que le travail sur la donnée se rembourse. Plus la stratégie data est solide ' +
+      'avant, moins la solution a besoin d’intelligence louée pour tenir.',
+    blocs: [
+      {
+        titre: 'Ce que la donnée fait à la place du modèle',
+        texte:
+          'Un LLM sollicité pour tout paie, à chaque appel, le travail que la donnée aurait pu ' +
+          'faire une fois : retrouver, recouper, mettre en forme, choisir le chemin. Quand ce ' +
+          'travail est déjà fait en amont, il reste un workflow agentique de bas niveau ' +
+          'cognitif, autrement dit un enchaînement d’étapes courtes où le modèle n’a qu’une ' +
+          'petite tâche à faire à chaque fois. Or un LLM se paie au volume de texte qu’il ' +
+          'traite : moins il en traite, moins la requête coûte, et cela vaut pour toutes les ' +
+          'requêtes suivantes.',
+        decision: 'Ce que vous préférez payer une fois en structurant, plutôt qu’à chaque requête.',
+      },
+      {
+        titre: 'Une solution dont vous êtes propriétaire',
+        texte:
+          'La différence ne se lit pas sur le prix du mois, elle se lit sur ce qui reste si vous ' +
+          'coupez. Le code, le paramétrage et la donnée restent chez vous : le workflow continue ' +
+          'de tourner et se transmet. Une intelligence louée, elle, s’arrête avec l’abonnement.',
+        decision: 'Ce que vous voulez posséder, et ce que vous acceptez de louer.',
+      },
+      {
+        titre: 'Quand ce n’est pas possible, le LLM classique',
+        texte:
+          'Certains problèmes demandent vraiment la capacité d’un grand modèle. On y va alors ' +
+          'sans détour, open source ou propriétaire : c’est un choix assumé, pas un défaut de ' +
+          'conception.',
+        decision: 'Le budget mensuel que vous acceptez pour cette part-là.',
       },
     ],
   },

--- a/src/@vitrine/contenu/ia.ts
+++ b/src/@vitrine/contenu/ia.ts
@@ -5,6 +5,10 @@
 // problème posé au départ, et ce n'est pas toujours un modèle. Un visiteur qui ouvre
 // cette page en croyant acheter de l'IA à tout prix doit être détrompé avant le clic.
 //
+// La description porte désormais le test de déterminisme et la propriété de la solution
+// (issue #126) : ce sont les deux choses qui distinguent cette offre en SERP, davantage
+// que la liste des techniques.
+//
 // Règles de véracité (CLAUDE.md) : RAG **maison**, aucun framework tiers ; Llama 3
 // nommable, corpus et chiffres du projet hors ligne.
 
@@ -16,9 +20,8 @@ export const PAGE_IA: IEditorialPage = {
   meta: {
     title: 'IA : règle métier, modèle ou LLM — Lille',
     description:
-      'La solution répond au problème posé, pas à l’état de l’art : règle métier ' +
-      'intégrée à l’existant, modèle supervisé, ou LLM arbitré sur le coût et la ' +
-      'confidentialité.',
+      'Un modèle seulement si aucune règle ne répond : supervisé, non supervisé, LLM ou ' +
+      'agents. Et une solution qui vous reste si vous coupez.',
   },
   sections: SECTIONS_IA,
 }


### PR DESCRIPTION
Porte l'enchainement Data vers IA decrit par Jerome MARICHEZ le 2026-08-23, et le test de determinisme qui le commande.

Reference : #126. (`Closes` ne ferme rien ici : la PR vise `dev`, la branche par defaut est `main`. L'issue reste a fermer a la main.)

## L'enchainement, tel qu'il apparait maintenant sur le site

```
metier -> gouvernance -> strategie data -> problematique -> exploration de donnees
  -> [ le probleme a-t-il une reponse deterministe ? ]
        oui -> on s'arrete. Pas d'IA.
        non -> alors seulement, on considere l'IA (supervise, non supervise, LLM, agents)
```

Le test est **pose une seule fois**, dans le nouveau chapitre `exploration` de la page Data, parce que c'est la donnee qui y repond. La charniere en **remet la reponse**. La page IA **part de ce resultat** sans rejouer la question.

## Ce qui a ete rearticule, et non ajoute a cote

| Existant | Ce qu'il devient |
|---|---|
| Charniere `charniere-suites` : « de quoi decider si une regle suffit, ou s'il faut vraiment un modele » | remet la reponse au test : « une regle suffit-elle, ou faut-il un modele ? Cette suite ne s'ouvre que dans le second cas. » La charniere devient operante au lieu d'annoncer une decision sans dire qui la prend. |
| IA, bloc « Souvent, une regle metier suffit » | devient « Reponse deterministe : une regle metier suffit ». Le jugement devient l'issue d'un test. **Preuves conservees mot pour mot** : fraude en baisse, conversion en hausse, latence reduite, survente evitee. |
| IA, bloc « Un modele, quand la regle ne tient plus » | devient « Reponse non deterministe : le modele apprend ce qu'aucune regle ne tient ». **Preuves conservees** : arXiv, TensorFlow, cloud functions, routes vocales evitees. |
| Chapo du chapitre `gouvernance` | ajoute « et avant le premier indicateur », ce qui justifie sa nouvelle position. |
| Chapo du chapitre `strategie-data` | s'ouvre sur « Le perimetre legal est arbitre », qui enchaine sur la section qui le precede desormais. |

**Reellement nouveau** : le chapitre `exploration` (page Data) et le chapitre `propriete` (page IA). Rien d'autre.

## L'inversion gouvernance / strategie data

`data-sections.ts` enchainait `metier`, `strategie-data`, `gouvernance`. C'est l'ordre de Jerome MARICHEZ qui fait foi : **la gouvernance precede la strategie data**.

Ce n'est pas un detail de mise en page. Ce qui a le droit d'etre collecte borne ce qu'on decide de mesurer, jamais l'inverse : un plan de collecte arbitre avant la question du droit se refait. Le chapo de `gouvernance` disait deja « elle se pose avant la moindre ligne de code », et le README disait deja « avant la technique, jamais apres » : la page contredisait ses propres textes.

**Verification des dependances a l'ancien ordre** (recherche exhaustive) :

- Aucune ancre `#id`, aucun lien interne, aucun `scrollIntoView`, aucun `getElementById` ne vise ces sections. Les seules ancres du site sont `#contenu` et `#chaine`.
- Sitemap et JSON-LD ne portent aucun fragment de section.
- Aucun test, aucun snapshot, aucune fixture ne reference `SECTIONS_DATA`, `SECTIONS_IA`, `PAGE_DATA` ni `PAGE_IA`.
- Le rendu (`PolePageView`) mappe le tableau et cle sur `section.id`, jamais sur l'index. Aucun traitement particulier de la derniere section.
- `poles-places.ts` porte des libelles de place, pas d'ordre de sections.
- **Un seul consommateur lit l'ordre** : `selectGlassSectionIds` (`glass-policy.ts`) fait `slice(0, 3)` sur les chapitres. Voir la note ci-dessous, c'est la seule consequence visuelle.

## Consequence assumee : le plafond de verre

`MAX_GLASS_PAGE_POLE = 3`. Les deux pages passent de 3 a 4 chapitres, donc le 4e ne recoit pas le verre. C'est **le comportement deja en place** sur `sea-ux` (4 chapitres) et `ingenierie-web` (5) : aucune regression, seulement l'extension d'une regle existante a deux pages qui n'y touchaient pas encore. Aucun fichier de verre n'a ete modifie (ils appartiennent a #115).

## Le rang egal des deux suites

Le point le plus sensible de l'issue, traite explicitement :

- La page IA passe a **4 chapitres + 1 charniere**, soit la forme exacte du pole SEA & UX. Avant cette PR l'IA en avait 3 contre 4 : le volume penchait **en defaveur** de l'IA, il est maintenant a egalite.
- Le chapo du chapitre `exploration` nomme les trois issues possibles : « la suite est une regle, un modele, ou un arbitrage d'acquisition ». Le SEA & UX est une issue legitime de l'exploration, pas un a-cote.
- Le test est explicitement dit **ne gouverner que la branche IA** (README, et commentaire d'en-tete de `data-sections.ts`). Le SEA & UX ne l'attend pas.
- Le mot « suite » est le vocabulaire etabli du site (`LIBELLE_PLACE.suite`, « Une des deux suites ») et s'applique aux deux branches a egalite.

## Relecture par un second agent

Regle #123 appliquee : un agent **sans le contexte de redaction** a recu les textes finaux et les criteres de controle, rien d'autre. Il a rendu 7 bloquants et 8 remarques de confort.

**Retenu et corrige (7)** :

1. **« Une solution dont vous etes proprietaire » n'etait pas etayee** : promesse a consonance juridique posee sans fondement. Le bloc dit maintenant sur quoi elle repose : « Le code, le parametrage et la donnee restent chez vous ».
2. **« une facture qui suit »** : affirmation de cout opaque et sans preuve. Remplacee par le mecanisme reel : « un LLM se paie au volume de texte qu'il traite : moins il en traite, moins la requete coute ».
3. **« workflow agentique de bas niveau cognitif » incomprehensible pour un dirigeant** : le terme de Jerome MARICHEZ est conserve tel quel, et desormais glose en langage courant juste apres (« un enchainement d'etapes courtes ou le modele n'a qu'une petite tache a faire a chaque fois »).
4. **La premiere personne avait disparu du chapitre de methode** : le bloc du test dit maintenant qui pose le test et qui repond. « Je pose ce test sur vos donnees, et je vous rends la reponse avant qu'un euro parte dans un modele. » Cela repare aussi l'incoherence avec la promesse d'interlocuteur unique.
5. **« Elle se pose avant la moindre ligne de code » : pronom sans antecedent** (texte herite, aggrave par le changement de position). Devient « La question du droit se pose... ».
6. **Le test etait enonce trois fois** : c'est exactement le piege signale par l'issue. Le chapo de la page IA rejouait la question en entier. Il part maintenant du resultat : « une fois etabli sur vos donnees qu'aucune regle simple ne repond ».
7. **La description SERP de la page IA** annoncait « regle, supervise, LLM ou agents » en oubliant « non supervise », et employait « deterministe » sans appui devant un lecteur qui n'a aucun contexte. Reecrite.

**Retenu, confort (3)** : la « decision » du bloc « Explorer les donnees » n'en etait pas une (c'etait un constat livre) ; le bloc « Quatre familles » ouvrait sur une liste d'outils au lieu du principe ; « La donnee se livre seule » se lisait d'abord au sens de livraison.

**Ecarte, avec motif (3)** :

1. « Remplacer *suite* par *branche*, le mot installe l'IA au-dessus. » **Non** : « suite » est le vocabulaire etabli du site pour **les deux** branches (`LIBELLE_PLACE`, « Une des deux suites de la donnee, sans ordre avec l'autre »). Le relecteur n'avait pas ce contexte, c'est le fonctionnement voulu de la relecture a l'aveugle. Changer ce mot sur une seule des deux branches creerait l'asymetrie qu'il craint.
2. « L'IA gagne du volume, le SEA & UX rien : la masse editoriale hierarchise. » **Non**, le constat s'inverse une fois les quatre pages comptees : l'IA avait 3 chapitres contre 4 au SEA & UX, elle en a maintenant 4. Cette PR **retablit** l'egalite au lieu de la rompre.
3. « Le titre *S'arrete est un resultat* ouvre sur un verbe d'echec. » Ecarte : le titre pose la tension que le bloc resout immediatement, et le relecteur juge par ailleurs ce bloc « le meilleur passage du corpus ». Le reformuler en affirmation lisse lui enleverait son effet.

Deux remarques de confort portaient sur du **texte herite** que je n'ai pas ecrit (« en tirer quelque chose », « ecarte des solutions entieres ») : hors perimetre de cette PR.

## Perimetre non touche, deliberement

- **`jointures.ts`** : l'arete Data vers IA aurait pu porter le test, ce qui l'aurait enonce une **quatrieme** fois. Laissee telle quelle.
- **`poles-nav.ts`** : son accroche Data (« le metier, puis la gouvernance et le droit ») decrit litteralement le **nouvel** ordre, elle n'est donc pas contredite. Ses consommateurs (`SiteHeader`, `HomeHero`) sont edites par #115 : je n'y touche pas. L'accroche IA y dit encore « souvent une regle metier suffit », formulation que cette PR corrige ailleurs : **cela merite une issue de suivi**.
- Aucun fichier de #115, #121 ou #123. `CLAUDE.md` lu, jamais ecrit.

## Verifications

- `make lint` vert (limite 300 lignes tenue : `data-sections.ts` 236, `ia-sections.ts` 218). Le seul avertissement restant (`<img>` dans `certifications`) est anterieur.
- `make type-check` vert, `make test` vert, `npm run build` vert.
- `make budgets` vert : **Lighthouse >= 95 sur les 4 categories** sur les 7 pages mesurees (accueil 95/100/100/100, gabarit de pole 96/100/100/100), axe-core 0 violation.
- Rendu reel controle sur `npx next dev` : ordre des sections verifie dans le HTML servi de `/services/data/` (metier, gouvernance, strategie-data, exploration, charniere-suites) et `/services/ia/` (solution, propriete, langage, production, boucle), accueil a 200 et chaine coherente.
- Descriptions SERP ramenees sous le plafond de 155 caracteres : Data 150, IA 140. **L'ancienne description IA en faisait 164** : depassement anterieur corrige au passage.
- `grep` des tirets cadratins sur les lignes ajoutees : **zero dans les phrases redigees ici**. Les 7 occurrences que le diff signale sont des lignes preexistantes **deplacees ou renumerotees** (le bloc `gouvernance` remonte, les titres `2.`/`3.` du README echangent leur chiffre). Les retirer releve de #124, pas de cette PR.
- Aucun emoji. `next-env.d.ts` et `package-lock.json` non commites.

## Tests : intentions proposees a Jerome MARICHEZ

Aucun fichier de test n'a ete cree (regle du projet : le test est ecrit par Jerome MARICHEZ). Aucun test ne couvre aujourd'hui le contenu editorial. Trois intentions, par ordre de valeur :

1. **Unitaire — l'ordre des chapitres du pole Data** (`tests/unitaire/data-sections.spec.ts`). *Intention* : garantir que la methode ne se fait pas inverser par un futur remaniement. Assertion : les `id` de `SECTIONS_DATA` filtres sur `kind === 'chapitre'` valent exactement `['metier', 'gouvernance', 'strategie-data', 'exploration']`, dans cet ordre. Cas limite : la charniere reste en derniere position. Aucun jeu de donnees externe.

2. **Integration — la veracite du contenu publie** (`tests/integration/veracite-contenu.integration.spec.ts`, deja specifie par #117). *Intention* : echouer des qu'un terme proscrit reapparait. Cette PR lui ajoute deux motifs utiles : aucun framework RAG (LangChain, LlamaIndex) dans les textes des deux poles, et **aucun tiret cadratin dans le contenu nouvellement ajoute** une fois #124 passee. Jeu de donnees : les tableaux `SECTIONS_*` reels, pas de doublure.

3. **Unitaire — le test de determinisme n'est enonce qu'une fois** (`tests/unitaire/determinisme-unicite.spec.ts`). *Intention* : c'est le piege explicite de #126, et rien ne le protege. Assertion : la question « a-t-il une reponse deterministe » n'apparait que dans `SECTIONS_DATA`, et jamais dans `SECTIONS_IA`. Cas limite : la charniere peut y **referer** sans la reposer.

Une quatrieme piste, plus structurante : `/services/data/` et `/services/ia/` **ne sont pas mesures** par `scripts/budgets/pages.mjs` (seul `ingenierie-web` represente le gabarit de pole). Les deux pages viennent de gagner un chapitre chacune sans qu'aucun budget ne les regarde. Cela merite son issue.
