### PR TITLE
fix: l'accroche du pole IA dit le test, plus une frequence

### DIFF
--- a/src/@vitrine/contenu/poles-nav.ts
+++ b/src/@vitrine/contenu/poles-nav.ts
@@ -44,8 +44,8 @@ export const POLES_NAV: IPole[] = [
     route: ROUTES.ia,
     promesse: 'La réponse n’est pas toujours un modèle, et je le dis avant d’en construire un.',
     accroche:
-      'Souvent une règle métier intégrée à l’existant suffit ; sinon un modèle, ou un LLM ' +
-      'arbitré sur le coût et la confidentialité.',
+      'Je teste si votre problème a une réponse déterministe : si oui, une règle suffit ; ' +
+      'sinon un modèle, ou un LLM arbitré sur le coût et la confidentialité.',
   },
   {
     id: 'sea-ux',


### PR DESCRIPTION
Référence : issue #133 (la référence est écrite sans `Closes`, qui ne ferme rien ici : la PR vise `dev`, la branche par défaut est `main`).

## L'accroche du pôle IA

**Avant**

> Souvent une règle métier intégrée à l'existant suffit ; sinon un modèle, ou un LLM arbitré sur le coût et la confidentialité.

**Après**

> Je teste si votre problème a une réponse déterministe : si oui, une règle suffit ; sinon un modèle, ou un LLM arbitré sur le coût et la confidentialité.

Ce qui change : « souvent » disparaît. La décision n'est plus une fréquence observée, c'est un test posé, avec son critère nommé (la réponse déterministe) et ses deux issues. C'est exactement le test que porte la section `exploration` de `data-sections.ts` et dont le chapitre `solution` de `ia-sections.ts` reçoit la réponse. Le test n'est pas rejoué ici, il est annoncé.

L'accroche prolonge la promesse du pôle sans la répéter : la promesse dit que je le dis avant d'en construire un, l'accroche dit sur quoi je m'appuie pour le dire. La promesse n'est pas touchée.

Les deux issues gardent leurs livrables et leurs critères d'origine (le coût et la confidentialité), donc aucun contenu n'est perdu. Aucun framework RAG nommé, aucune techno hors stack, aucun tiret cadratin, aucun emoji.

## Les trois autres accroches

Relues, **laissées strictement intactes**. Aucune ne décrit une décision par une fréquence :

- Ingénierie web : énumération de périmètres, puis un critère (« outillée et certifiée plutôt que promise »).
- Data : un livrable et une sortie possible (« vous pouvez vous arrêter là »).
- SEA & UX : quatre critères d'arbitrage, aucun adverbe de fréquence.

Le tiret cadratin de l'accroche SEA & UX n'est pas retiré : il relève de l'issue #124.

## Rang égal entre IA et SEA & UX, vérifié au rendu

`npx next dev -p 3120`, mesure sur le rendu réel plutôt qu'estimée. L'accroche est consommée par `PoleHero`, en tête de `/services/<pole>/` (voir la note ci-dessous).

| Largeur | Accroche IA | Accroche SEA & UX |
|---|---|---|
| 1440 px | 969 px de large, 2 lignes | 969 px de large, 2 lignes |
| 500 px | 452 px de large, 4 lignes | 452 px de large, 4 lignes |

Empreinte identique aux deux largeurs, y compris sous 500 px où la colonne se resserre. Aucune carte déformée, aucun débordement. Les deux suites restent de rang égal en mise en page comme dans le texte.

## Une précision sur le lieu du défaut

L'issue situe l'accroche dans la section « Par où vous entrez » de l'accueil. Sur `dev` à jour, `PoleEntries` ne rend pas `accroche` : chaque porte affiche `promesse` et `PREUVE_POLE`. L'accroche est rendue par `PoleHero`, en haut de la page du pôle. Le défaut est donc bien réel et le correctif inchangé, mais il se lisait sur `/services/ia/`, en tête de page, juste au-dessus du chapitre qui portait déjà le nouveau cadrage. Deux formulations du même arbitrage sur la même page, à quelques centimètres d'écart. Vérifié au rendu, pas déduit. `PoleEntries` n'a pas été touché, conformément à la réserve posée pour la branche #115.

## Relecture par un second agent

Un second agent a relu les quatre accroches finales, sans le raisonnement de rédaction. Ses retours :

- **Registre de la fréquence** : aucune occurrence dans les quatre accroches. Point tenu.
- **Tiret cadratin** : présent uniquement dans l'accroche SEA & UX. Relevé, laissé en place (issue #124).
- **Emoji** : aucun.
- **Clarté** : il a signalé qu'une première version disait « Un test sur vos données » sans dire ce qui était testé, et que « déterministe » demandait un effort au lecteur qui découvre. **Retour intégré** : l'accroche nomme désormais l'objet du test (« si votre problème a une réponse déterministe »), et les deux issues qui suivent immédiatement glosent le mot par l'exemple, une règle d'un côté, un modèle de l'autre. Le terme lui-même est conservé : c'est le vocabulaire que portent désormais le `CLAUDE.md`, la page Data et la page IA, et le remplacer ici aurait rouvert l'écart que cette PR ferme.
- **Longueur** : il jugeait l'écart avec l'accroche SEA & UX perceptible. **Retour intégré en partie** : la formulation a été resserrée (« une règle suffit » au lieu de « une règle métier suffit »), ce qui ramène l'écart à une dizaine de caractères. Le reste de l'objection est levé par la mesure au rendu ci-dessus : à 1440 px comme à 500 px, les deux accroches occupent exactement le même nombre de lignes et la même largeur. L'écart en caractères ne se voit pas en page.

## Vérifications

- `make lint` : vert (les avertissements Biome sur `<img>` et la limite de 300 lignes sont préexistants et inchangés).
- `make test` : vert, sortie 0.
- Rendu réel contrôlé à 1440 px et à 500 px, sur `/services/ia/` et `/services/sea-ux/`.

## Note sur la politique de test

La modification est une chaîne éditoriale, sans logique : le dépôt ne porte aujourd'hui aucun test couvrant le contenu de `poles-nav.ts` (`tests/unitaire/` ne contient que `exemple.spec.ts`), et les PR #131 et #132, de même nature, ont été livrées ainsi. Aucun fichier de test n'a été posé par l'assistant. Si un garde-fou éditorial est souhaité (par exemple : aucune accroche ne contient d'adverbe de fréquence, aucune ne contient de tiret cadratin), c'est à Jérôme MARICHEZ de le poser, et l'intention peut être détaillée à la demande.
