### PR TITLE
chore: version 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeromemarichez-fr",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "next": "^16.0.0",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jeromemarichez-fr",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "description": "Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel à Lille : ingénierie web, data & IA, SEO/SEA.",
   "scripts": {


### PR DESCRIPTION
Bump de version 0.9.0 vers 0.10.0 (mineur : fonctionnalités, aucune rupture d'API).

Adresse l'issue #138 : dev porte 54 commits d'avance sur main et package.json était resté à 0.9.0, alors que le tag v0.9.0 existait déjà. Sans cette PR, fusionner en l'état livrerait 54 commits sans aucune release.

## Contenu du diff

Deux fichiers, trois changements de version :
- `package.json` : champ `version` de 0.9.0 à 0.10.0
- `package-lock.json` : deux emplacements (racine et packages[""]) de 0.9.0 à 0.10.0

Aucune modification de dépendances, aucun épinglage de version ajouté.

## Condition de la mise en production

Cette PR est **obligatoire** avant toute fusion vers main. Sans elle, la CI auto-génère un tag vX.Y.Z à la création du commit, mais le tag v0.9.0 existant déjà, aucune nouvelle release ne serait publiée, et les 54 commits resteraient en production sans versioning.