### PR TITLE
feat: un formulaire de contact qui compose le courriel

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ ce qu'il faut réunir pour les quatre logos manquants.
 
 | Route | Rôle |
 |-------|------|
-| `/` | **Vitrine, pas catalogue déplié.** Accroche et promesse d'interlocuteur unique, le schéma de la chaîne et de son embranchement, les **quatre portes** — nom du pôle, promesse, une preuve chiffrée, lien vers sa page —, les deux objections traitées (« et si je disparais ? » et « et si le projet me dépasse ? »), preuves chiffrées, limites assumées, certifications, appel à contact. Le **détail de chaque pôle** vit sur `/services/<pole>/`, qui le disait déjà en plus long ; le **fil IA transverse** est descendu sur `/services/ingenierie-web/`, la page où le site dit comment le code est produit |
+| `/` | **Vitrine, pas catalogue déplié.** Accroche et promesse d'interlocuteur unique, le schéma de la chaîne et de son embranchement, les **quatre portes** — nom du pôle, promesse, une preuve chiffrée, lien vers sa page —, les deux objections traitées (« et si je disparais ? » et « et si le projet me dépasse ? »), preuves chiffrées, limites assumées, certifications, et un **formulaire de contact** qui compose un `mailto:` avec l'adresse affichée en clair à côté. Le **détail de chaque pôle** vit sur `/services/<pole>/`, qui le disait déjà en plus long ; le **fil IA transverse** est descendu sur `/services/ingenierie-web/`, la page où le site dit comment le code est produit |
 | `/services/ingenierie-web` | Le socle en détail |
 | `/services/data` | Le passage obligé en détail |
 | `/services/ia` | Une des deux suites en détail |
@@ -395,7 +395,7 @@ ce qu'il faut réunir pour les quatre logos manquants.
 | `/blog` | Liste des articles, du plus récent au plus ancien |
 | `/blog/<slug>` | Un article. Une page statique par article, générée au build par `generateStaticParams` |
 | `/parcours` | *(pas encore construite)* Parcours d'ingénieur et de chef de projet, formation |
-| `/contact` | *(reportée)* L'export statique ferme les routes API : un formulaire exigerait un service tiers ou un back séparé. L'accueil et le pied de page portent un `mailto:` direct, cohérent avec la promesse d'interlocuteur unique |
+| `/contact` | *(reportée)* Le contact vit dans la section `contact` de l'accueil. L'export statique ferme les routes API : le formulaire y **compose une URL `mailto:`** validée côté client, sans appel réseau, sans sous-traitant et sans cookie, et l'adresse reste affichée en clair en `mailto:` à côté pour qui n'a pas de client mail. Le pied de page porte le même `mailto:` direct |
 
 Chaque page de service porte ses propres métadonnées SEO, ses données structurées
 (`schema.org/Service` et `ProfessionalService`) et un appel à contact contextualisé.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -224,6 +224,58 @@ Deux points à garder en tête :
   `make budget-a11y` vert ne dit **rien** sur ce point : seul le relevé au pixel ci-dessus
   le couvre, et il est à rejouer dès qu'un voile de bande bouge.
 
+### Le formulaire de contact, premier élément interactif complexe du site
+
+Le site n'avait jusqu'ici que des liens et deux bascules. Un formulaire ouvre une famille
+de problèmes qu'aucun d'eux ne posait : un état d'erreur, un focus à déplacer, et un texte
+qui apparaît après une action. Les choix sont écrits ici, parce qu'ils ne se relisent pas
+dans le CSS et qu'axe-core n'en juge presque aucun.
+
+- **Un `label` visible et associé par champ** (`htmlFor` / `id`), jamais un `placeholder`
+  en guise de libellé : un `placeholder` disparaît dès la première frappe, et c'est
+  exactement au moment où l'on écrit qu'on veut relire ce qui est demandé.
+- **Le caractère obligatoire est ÉCRIT** : « (obligatoire) » à côté de chaque libellé, pas
+  un astérisque, pas une couleur (WCAG 1.4.1). L'attribut natif `required` le porte aussi
+  aux technologies d'assistance. La mention est rendue en casse normale à l'intérieur d'un
+  libellé en majuscules : « (OBLIGATOIRE) » se lit comme un avertissement, et certaines
+  synthèses vocales l'épellent.
+- **Chaque champ est décrit par son aide, puis par son erreur** (`aria-describedby`), dans
+  cet ordre. Un lecteur d'écran restitue les descriptions dans l'ordre donné, et on veut
+  entendre ce que le champ attend avant d'entendre pourquoi ce qui y est ne convient pas.
+  Le champ de message y ajoute son compteur de caractères.
+- **`aria-invalid` marque le champ fautif**, et l'état se dit trois fois : le message écrit
+  dessous, l'attribut, et seulement en dernier l'arête en `--cuivre` (6.02:1 en clair,
+  7.18:1 en sombre). La couleur n'est jamais seule.
+- **La validation n'a lieu qu'à la soumission, jamais à la frappe.** Valider pendant qu'on
+  écrit fait passer le champ en erreur au deuxième caractère, et le lecteur d'écran
+  l'annonce. Les erreurs posées restent affichées jusqu'à la soumission suivante.
+- **Deux régions vivantes distinctes, présentes dès le premier rendu, vides.** Un
+  `role="alert"` inséré dans le document en même temps que son texte n'est pas annoncé de
+  façon fiable ; une région déjà là au chargement l'est. Elles sont effacées par `:empty`,
+  jamais par une condition de rendu. Le refus passe par `role="alert"`, qui interrompt ; la
+  réussite par `role="status"`, qui attend une pause. Un envoi qui marche n'a aucune raison
+  de couper la parole.
+- **Le focus part au résumé d'erreurs, pas au premier champ fautif.** Le résumé liste les
+  erreurs et renvoie vers chaque champ par un vrai lien : on entend tout, on choisit quoi
+  corriger, on y arrive d'une touche. Sauter d'office au premier champ ferait perdre les
+  autres. Le bloc est `tabIndex={-1}` : focusable sans entrer dans l'ordre de tabulation.
+  Deux refus de suite sur les mêmes champs produisent le même état d'erreur, d'où un
+  compteur de refus plutôt qu'un booléen : sans lui, le second refus passerait inaperçu.
+- **`noValidate` sur le formulaire.** Sans lui, le navigateur affiche ses propres bulles,
+  dans sa langue et avec ses formulations, et court-circuite les messages écrits.
+- **Le champ de message n'est pas borné par `maxLength`.** Un `maxLength` tronque un texte
+  collé sans le dire, ce qui est le piège même que ce formulaire doit éviter. Le visiteur
+  peut dépasser, le compteur le lui montre, et la validation le lui dit en toutes lettres.
+- **Le bouton d'envoi ne bouge pas.** Aucun effet de déplacement au survol (issue #137) :
+  il est atteint au clavier bien plus souvent qu'un lien de fin de page, et le survol se
+  dit par une élévation et un anneau intérieur, deux changements de forme, pas par la
+  teinte seule.
+- **Ordre de tabulation vérifié**, du premier champ à l'envoi : nom, sujet, message,
+  bouton. Aucun piège de focus, aucun arrêt parasite, contour de focus global visible.
+- **L'adresse reste affichée en clair, en `mailto:`, à côté du formulaire.** Ce n'est pas
+  une redondance : le formulaire a besoin d'un client mail installé sur le poste, et sans
+  cette sortie un visiteur qui n'en a pas repartirait avec un bouton qui ne fait rien.
+
 ### Pages contrôlées
 
 Les mêmes que les budgets de performance — accueil, page de pôle, liste du blog, page
@@ -238,5 +290,7 @@ non protégé. La liste vit dans `scripts/budgets/pages.mjs`.
 | Non-composition des lavis dans `ChainDiagram` | témoins rendus + mesure au pixel | **prouvée** — 2026-08-23, écart nul avec le cas « un seul lavis » |
 | Étiquettes de pôle (`PoleTagList`) | mesure au pixel, deux thèmes | **corrigé** — 2026-08-23, deux valeurs étaient sous le seuil |
 | Contrastes sur les bandes de verre | mesure au pixel, page balayée, deux thèmes | **tenu** — 2026-08-24, rejoué après intégration de `dev`, marges de 0,10 à 0,35 point |
-| Clavier + lecteur d'écran | manuel | _à réaliser_ |
+| Formulaire de contact : ordre de tabulation, envoi au clavier, deux thèmes | manuel | **tenu** le 2026-08-24, du premier champ à l'envoi, sur l'export statique |
+| Formulaire de contact : lecteur d'écran | manuel | _à réaliser_ |
+| Clavier + lecteur d'écran (reste du site) | manuel | _à réaliser_ |
 | WCAG 2.2.2 — pause des animations | manuel | _à réaliser_ |

--- a/docs/rgpd.md
+++ b/docs/rgpd.md
@@ -12,6 +12,38 @@
 
 Décrire comment sont assurés : accès, rectification, effacement, portabilité.
 
+## Le formulaire de contact : aucun traitement, aucun sous-traitant
+
+C'est une information utile même quand la réponse est « rien à déclarer », et c'est
+justement parce que la réponse est « rien à déclarer » qu'elle est écrite ici : un
+formulaire est l'endroit du site où l'on s'attend à trouver une collecte, et ne rien dire
+laisserait supposer qu'elle existe sans être documentée.
+
+**Ce que le formulaire fait.** Le visiteur saisit trois champs (nom, sujet, message). Le
+navigateur les valide sur place avec un schéma Zod, en compose une URL `mailto:`, et ouvre
+le client mail du poste avec l'objet et le corps déjà écrits. C'est le visiteur qui envoie
+le mail, depuis sa propre boîte.
+
+**Ce qu'il ne fait pas**, et qui est vérifiable dans le code :
+
+- **aucun appel réseau sortant** : pas de `fetch`, pas de route d'API, pas de formulaire
+  posté. Le site est un export statique (`output: 'export'`), il n'a pas de serveur qui
+  pourrait recevoir quoi que ce soit ;
+- **aucun sous-traitant** : pas de service tiers de formulaire, pas de passerelle mail,
+  pas de clé d'API. Rien à ajouter au registre des sous-traitants ;
+- **aucun stockage** : ni cookie, ni `localStorage`, ni `sessionStorage`. La saisie vit
+  dans l'état React de la page et disparaît au rechargement ;
+- **aucune donnée en plus de ce que le visiteur écrit** : pas d'horodatage, pas
+  d'identifiant de campagne, pas d'adresse IP relevée, pas d'en-tête ajouté au corps du
+  mail. Le champ « adresse de réponse » est volontairement absent : le mail part de la
+  boîte du visiteur, son adresse voyage déjà dans l'en-tête, et la redemander serait
+  collecter une donnée pour rien.
+
+**Le traitement qui existe** est celui qui existait déjà avant le formulaire : la réception
+et la conservation d'un mail dans la boîte de Jérôme MARICHEZ, au titre de la relation
+commerciale. Le formulaire ne le crée pas, il ne l'élargit pas, et il ne change ni sa
+finalité ni sa base légale.
+
 ## Mesures
 
 - Minimisation : ne collecter que le nécessaire.

--- a/src/@vitrine/components/ContactField/contact-field.module.css
+++ b/src/@vitrine/components/ContactField/contact-field.module.css
@@ -1,0 +1,91 @@
+/* contact-field.module.css — un champ du formulaire de contact.
+ *
+ * Le champ est un creux dans le papier, pas une carte posée dessus : le bloc de contact
+ * est déjà une surface de verre (issue #115), et empiler un second relief à l'intérieur
+ * ferait deux plans qui se disputent la même lumière. D'où `--fond-creux` en fond et une
+ * arête discrète, plutôt qu'une ombre. */
+
+.champ {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-0);
+}
+
+.label {
+  font-family: var(--police-mono-pile);
+  font-weight: 500;
+  font-size: var(--t--1);
+  text-transform: uppercase;
+  letter-spacing: var(--suivi-etiquette);
+  color: var(--encre);
+}
+
+/* La mention est ÉCRITE, jamais réduite à un astérisque ni à une couleur (WCAG 1.4.1).
+   Elle est en casse normale : reprise en majuscules par le label, « (OBLIGATOIRE) »
+   se lit comme un avertissement, et certaines synthèses vocales l'épellent. */
+.obligatoire {
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+  color: var(--encre-douce);
+}
+
+.aide {
+  margin: 0;
+  font-size: var(--t-note);
+  line-height: 1.5;
+  color: var(--encre-douce);
+}
+
+.saisie {
+  width: 100%;
+  margin-top: var(--e-0);
+  padding: var(--e-2) var(--e-3);
+  border: 1px solid color-mix(in srgb, var(--encre) 24%, transparent);
+  border-radius: var(--rayon-petit);
+  background: color-mix(in srgb, var(--fond-creux) 70%, transparent);
+  color: var(--encre);
+  font-family: inherit;
+  font-size: var(--t-0);
+  line-height: 1.5;
+  transition: border-color var(--duree-micro) ease-out;
+}
+
+.saisie:hover {
+  border-color: color-mix(in srgb, var(--encre) 40%, transparent);
+}
+
+/* Le contour de focus global (`globals.css`) suffit et reste le même partout ; la bordure
+   qui se ferme n'est qu'un renfort, elle ne porte rien à elle seule. */
+.saisie:focus-visible {
+  border-color: var(--accent);
+}
+
+textarea.saisie {
+  resize: vertical;
+  min-height: 9rem;
+}
+
+/* L'état d'erreur se dit trois fois : par le message écrit dessous, par `aria-invalid`,
+   et seulement en dernier par cette arête. La couleur n'est jamais seule. */
+.saisie[aria-invalid="true"] {
+  border-color: var(--cuivre);
+  border-width: 2px;
+}
+
+.complement {
+  margin: 0;
+  font-family: var(--police-mono-pile);
+  font-size: var(--t--1);
+  color: var(--encre-douce);
+}
+
+/* `--cuivre` est mesuré à 6.02:1 en thème clair et 7.18:1 en sombre sur `--fond`
+   (globals.css) : au-dessus du 4.5:1 exigé pour du texte courant. */
+.erreur {
+  margin: 0;
+  font-size: var(--t-note);
+  line-height: 1.5;
+  font-weight: 500;
+  color: var(--cuivre);
+}

--- a/src/@vitrine/components/ContactField/index.tsx
+++ b/src/@vitrine/components/ContactField/index.tsx
@@ -1,0 +1,108 @@
+// ContactField/index.tsx — jeromemarichez-fr
+// Un champ du formulaire de contact : son libellé, son aide, son erreur, son compteur.
+//
+// Composant pur : il ne porte aucun état et ne connaît pas la validation. Il reçoit une
+// valeur et un message d'erreur, il rend le balisage qui les relie. C'est justement ce
+// câblage (`htmlFor`, `aria-describedby`, `aria-invalid`) qu'on ne veut pas voir écrit
+// trois fois de suite dans le formulaire, où une des trois finit toujours par diverger.
+
+import type { ContactField as ContactFieldName } from '@/schemas/contact.schema'
+import styles from './contact-field.module.css'
+
+interface ContactFieldProps {
+  /** Nom du champ dans le schéma. Il fabrique tous les identifiants du bloc. */
+  champ: ContactFieldName
+  label: string
+  aide: string
+  /** Le libellé du caractère obligatoire, écrit en toutes lettres à côté du label. */
+  marqueObligatoire: string
+  valeur: string
+  /** Message d'erreur du dernier envoi refusé, s'il portait sur ce champ. */
+  erreur?: string
+  /** Rend un `textarea` plutôt qu'un `input`. */
+  multiligne?: boolean
+  /** Texte d'appoint sous le champ, par exemple le compteur de caractères. */
+  complement?: string
+  /** Valeur d'`autocomplete` quand le navigateur peut aider au remplissage. */
+  autoComplete?: string
+  onChange: (valeur: string) => void
+}
+
+/** Nombre de lignes du champ long. Assez pour écrire un paragraphe sans faire défiler. */
+const LIGNES_MESSAGE = 7
+
+/**
+ * Le champ est toujours décrit par son aide, et en plus par son erreur quand il y en a une.
+ *
+ * L'ordre compte : l'aide d'abord, l'erreur ensuite. Un lecteur d'écran restitue les
+ * descriptions dans l'ordre donné, et on veut entendre ce que le champ attend avant
+ * d'entendre pourquoi ce qui y est ne convient pas.
+ */
+function listDescribedBy(champ: string, aErreur: boolean, aComplement: boolean): string {
+  const identifiants = [`${champ}-aide`]
+
+  if (aComplement) identifiants.push(`${champ}-complement`)
+  if (aErreur) identifiants.push(`${champ}-erreur`)
+
+  return identifiants.join(' ')
+}
+
+export function ContactField({
+  champ,
+  label,
+  aide,
+  marqueObligatoire,
+  valeur,
+  erreur,
+  multiligne,
+  complement,
+  autoComplete,
+  onChange,
+}: ContactFieldProps) {
+  const identifiant = `contact-${champ}`
+  const decrit = listDescribedBy(identifiant, Boolean(erreur), Boolean(complement))
+
+  /* `required` plutôt qu'`aria-required` : l'attribut natif porte déjà l'information aux
+     technologies d'assistance, et le formulaire pose `noValidate` — la bulle du
+     navigateur ne prend donc jamais la main sur les messages écrits ici. */
+  const communs = {
+    'aria-describedby': decrit,
+    'aria-invalid': Boolean(erreur),
+    className: styles.saisie,
+    id: identifiant,
+    name: champ,
+    onChange: (evenement: { target: { value: string } }) => onChange(evenement.target.value),
+    required: true,
+    value: valeur,
+  }
+
+  return (
+    <div className={styles.champ}>
+      <label className={styles.label} htmlFor={identifiant}>
+        {label} <span className={styles.obligatoire}>{marqueObligatoire}</span>
+      </label>
+
+      <p className={styles.aide} id={`${identifiant}-aide`}>
+        {aide}
+      </p>
+
+      {multiligne ? (
+        <textarea {...communs} rows={LIGNES_MESSAGE} />
+      ) : (
+        <input {...communs} autoComplete={autoComplete} type="text" />
+      )}
+
+      {complement ? (
+        <p className={styles.complement} id={`${identifiant}-complement`}>
+          {complement}
+        </p>
+      ) : null}
+
+      {erreur ? (
+        <p className={styles.erreur} id={`${identifiant}-erreur`}>
+          {erreur}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/@vitrine/components/_notPure/ContactForm/contact-form.module.css
+++ b/src/@vitrine/components/_notPure/ContactForm/contact-form.module.css
@@ -1,0 +1,88 @@
+/* contact-form.module.css — le formulaire de contact.
+ *
+ * Une seule colonne, quelle que soit la largeur : les trois champs se remplissent dans
+ * l'ordre, et une grille à deux colonnes rendrait l'ordre de tabulation moins évident
+ * qu'il ne le paraît à l'œil. Le formulaire ne cherche pas à remplir la place, il cherche
+ * à se remplir vite. */
+
+.formulaire {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-3);
+  width: 100%;
+  max-width: var(--mesure-texte);
+}
+
+.consigne {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-note);
+  line-height: 1.55;
+  color: var(--encre-douce);
+}
+
+/* Les deux régions d'annonce sont dans le document dès le premier rendu, vides. C'est
+   `:empty` qui les efface, et non une condition de rendu : une région vivante insérée en
+   même temps que son texte n'est pas annoncée de façon fiable. */
+.annonce:empty {
+  display: none;
+}
+
+.annonce {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-1);
+}
+
+.resumeTitre {
+  margin: 0;
+  font-weight: 600;
+  color: var(--cuivre);
+}
+
+.resumeListe {
+  margin: 0;
+  padding-left: var(--e-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-0);
+  font-size: var(--t-note);
+  line-height: 1.5;
+}
+
+.resumeListe a {
+  color: var(--cuivre);
+}
+
+.succes {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-note);
+  line-height: 1.55;
+  color: var(--encre);
+}
+
+/* Un `button` ordinaire, sans aucun effet de déplacement : un bouton d'envoi qui bouge
+   sous le pointeur se rate, et celui-ci est atteint au clavier bien plus souvent qu'un
+   lien de fin de page.
+   Le survol se dit par une ÉLÉVATION et par un anneau intérieur qui apparaît : deux
+   changements de forme. La teinte du bouton, elle, ne bouge pas — un état de survol
+   porté par la seule couleur ne se voit pas sous vision dichromate. */
+.bouton {
+  align-self: flex-start;
+  padding: var(--e-2) var(--e-4);
+  border: 0;
+  border-radius: var(--rayon-petit);
+  background: var(--accent);
+  color: var(--fond);
+  font-family: var(--police-mono-pile);
+  font-size: var(--t-0);
+  cursor: pointer;
+  transition: box-shadow var(--duree-micro) ease-out;
+}
+
+.bouton:hover {
+  box-shadow:
+    var(--elevation-levee),
+    inset 0 0 0 2px var(--fond);
+}

--- a/src/@vitrine/components/_notPure/ContactForm/index.tsx
+++ b/src/@vitrine/components/_notPure/ContactForm/index.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+// ContactForm/index.tsx — jeromemarichez-fr
+// Le formulaire de contact. Il ne poste rien : il compose une URL `mailto:` et ouvre le
+// client mail du visiteur avec l'objet et le corps déjà écrits.
+//
+// Il est dans `_notPure/` parce qu'il porte de l'état de saisie et déclenche un effet de
+// bord (l'ouverture du client mail). Toute la règle est ailleurs : la validation et
+// l'encodage dans `services/contact-mailto.ts`, l'état d'écran dans `use-contact-form`.
+
+import { CHAMPS_CONTACT, LONGUEUR_MAX_MESSAGE } from '@/schemas/contact.schema'
+import { formatContactCounter } from '@/utils/format-contact-counter'
+import { CONTACT_FORMULAIRE } from '../../../contenu/contact'
+import { useContactForm } from '../../../hooks/use-contact-form'
+import { ContactField } from '../../ContactField'
+import styles from './contact-form.module.css'
+
+interface ContactFormProps {
+  /** L'adresse de destination. Elle vient de `SITE_IDENTITY.email`, source unique. */
+  destinataire: string
+  /** Identifiant du titre de la section, repris en nom accessible du formulaire. */
+  titreId: string
+}
+
+/**
+ * Trois points d'accessibilité portent tout le reste, et aucun n'est décoratif.
+ *
+ * - **La région d'annonce est présente dès le premier rendu**, vide. Un `role="alert"`
+ *   inséré dans le document en même temps que son texte est annoncé de façon inégale
+ *   selon les lecteurs d'écran ; une région déjà là au chargement l'est toujours. Elle
+ *   disparaît visuellement par `:empty`, jamais par une condition de rendu.
+ * - **Le résumé d'erreurs renvoie vers les champs par de vrais liens.** Au clavier, on
+ *   entend le nombre d'erreurs, on choisit laquelle corriger, et on y arrive d'une
+ *   touche. Sauter d'office au premier champ fautif ferait perdre les autres.
+ * - **`noValidate`.** Sans lui, le navigateur affiche ses propres bulles, dans sa langue,
+ *   avec ses propres formulations, et court-circuite les messages écrits ici.
+ */
+export function ContactForm({ destinataire, titreId }: ContactFormProps) {
+  const { valeurs, erreurs, champsEnErreur, mailto, modifier, soumettre, resumeRef } =
+    useContactForm(destinataire)
+
+  return (
+    <form aria-labelledby={titreId} className={styles.formulaire} noValidate onSubmit={soumettre}>
+      <p className={styles.consigne}>{CONTACT_FORMULAIRE.consigne}</p>
+
+      <div className={styles.annonce} ref={resumeRef} role="alert" tabIndex={-1}>
+        {champsEnErreur.length > 0 ? (
+          <>
+            <p className={styles.resumeTitre}>{CONTACT_FORMULAIRE.resumeErreurs}</p>
+            <ul className={styles.resumeListe}>
+              {champsEnErreur.map((champ) => (
+                <li key={champ}>
+                  <a href={`#contact-${champ}`}>
+                    {CONTACT_FORMULAIRE.champs[champ].label} : {erreurs[champ]}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null}
+      </div>
+
+      {CHAMPS_CONTACT.map((champ) => (
+        <ContactField
+          aide={CONTACT_FORMULAIRE.champs[champ].aide}
+          autoComplete={champ === 'nom' ? 'name' : undefined}
+          champ={champ}
+          complement={
+            champ === 'message'
+              ? formatContactCounter(valeurs.message.trim().length, LONGUEUR_MAX_MESSAGE)
+              : undefined
+          }
+          erreur={erreurs[champ]}
+          key={champ}
+          label={CONTACT_FORMULAIRE.champs[champ].label}
+          marqueObligatoire={CONTACT_FORMULAIRE.marqueObligatoire}
+          multiligne={champ === 'message'}
+          onChange={(valeur) => modifier(champ, valeur)}
+          valeur={valeurs[champ]}
+        />
+      ))}
+
+      <button className={styles.bouton} type="submit">
+        {CONTACT_FORMULAIRE.bouton}
+      </button>
+
+      {/* Région distincte de celle des erreurs : `status` est poli, il attend une pause
+          dans la lecture, là où `alert` interrompt. Un envoi qui réussit n'a aucune
+          raison de couper la parole. */}
+      <div className={styles.annonce} role="status">
+        {mailto ? (
+          <p className={styles.succes}>
+            {CONTACT_FORMULAIRE.statutSucces} <a href={`mailto:${destinataire}`}>{destinataire}</a>
+          </p>
+        ) : null}
+      </div>
+    </form>
+  )
+}

--- a/src/@vitrine/contenu/contact.ts
+++ b/src/@vitrine/contenu/contact.ts
@@ -1,0 +1,44 @@
+// contact.ts — jeromemarichez-fr
+// Les textes du formulaire de contact : libellés, aides, bouton, statuts.
+//
+// Ils vivent ici et non dans le composant pour la même raison que le reste du contenu :
+// c'est de l'éditorial, il passe par la relecture, et il ne doit pas se retrouver dilué
+// dans du JSX. Les messages d'erreur, eux, appartiennent au schéma Zod et au service :
+// ils sont la formulation d'une règle, pas un libellé d'écran.
+
+/** Les textes du formulaire, dans l'ordre où le visiteur les rencontre. */
+export const CONTACT_FORMULAIRE = {
+  consigne:
+    'Les trois champs sont obligatoires. Rien ne part depuis cette page : le bouton ouvre ' +
+    'votre client mail avec le message déjà écrit, et c’est vous qui l’envoyez.',
+  marqueObligatoire: '(obligatoire)',
+  resumeErreurs: 'À compléter avant d’ouvrir le mail :',
+  bouton: 'Ouvrir mon client mail',
+  statutSucces:
+    'Votre client mail s’ouvre avec ce message déjà rempli. Vous le relisez, vous l’envoyez. ' +
+    'Si rien ne s’ouvre, c’est en général qu’aucun client mail n’est configuré sur ce poste. ' +
+    'Voici l’adresse.',
+  champs: {
+    nom: {
+      label: 'Votre nom',
+      aide: 'Il signe le mail, rien de plus.',
+    },
+    sujet: {
+      label: 'Le sujet',
+      aide: 'Une ligne, qui devient l’objet du mail.',
+    },
+    message: {
+      label: 'Votre message',
+      aide: 'Votre situation, ce que vous cherchez à trancher, et sous quel délai.',
+    },
+  },
+} as const
+
+/** Le bloc voisin du formulaire : l'adresse en clair, pour qui n'a pas de client mail. */
+export const CONTACT_DIRECT = {
+  titre: 'Écrire sans le formulaire',
+  texte:
+    'Le formulaire a besoin d’un client mail installé sur ce poste. Beaucoup de postes n’en ' +
+    'ont pas, en entreprise notamment, ou quand le courrier passe par un webmail. Dans ce ' +
+    'cas, voici l’adresse.',
+} as const

--- a/src/@vitrine/hooks/use-contact-form.ts
+++ b/src/@vitrine/hooks/use-contact-form.ts
@@ -1,0 +1,87 @@
+'use client'
+
+// use-contact-form.ts — jeromemarichez-fr
+// L'état d'écran du formulaire de contact : ce qui est saisi, ce qui est en erreur, et
+// où va le focus après une validation.
+//
+// Aucune règle métier ici. La validation et la composition de l'URL vivent dans
+// `services/contact-mailto.ts` ; ce hook les appelle et range le résultat pour le rendu.
+
+import { type FormEvent, useCallback, useEffect, useRef, useState } from 'react'
+import type { IMailtoCompose } from '@/interfaces/IMailtoCompose'
+import type { ContactErrors } from '@/interfaces/types'
+import { CHAMPS_CONTACT, type ContactField } from '@/schemas/contact.schema'
+import { prepareContactMail } from '../services/contact-mailto'
+
+type Saisie = Record<ContactField, string>
+
+const SAISIE_VIDE: Saisie = { nom: '', sujet: '', message: '' }
+
+/**
+ * Le formulaire ne valide qu'à la soumission, jamais à la frappe.
+ *
+ * Valider pendant qu'on écrit revient à dire « c'est faux » à quelqu'un qui n'a pas fini
+ * sa phrase : le champ passe en erreur au deuxième caractère, et le lecteur d'écran
+ * l'annonce. Les erreurs posées à la soumission restent affichées tant que la soumission
+ * suivante n'a pas tranché, ce qui laisse au visiteur le temps de les lire et de les
+ * corriger dans l'ordre qui l'arrange.
+ */
+export function useContactForm(destinataire: string) {
+  const [valeurs, setValeurs] = useState<Saisie>(SAISIE_VIDE)
+  const [erreurs, setErreurs] = useState<ContactErrors>({})
+  const [mailto, setMailto] = useState<IMailtoCompose | null>(null)
+  /**
+   * Compteur de soumissions refusées, et non un simple booléen.
+   *
+   * Deux soumissions de suite qui échouent sur les mêmes champs produisent le même état
+   * d'erreur : sans un compteur qui change, l'effet de focus ne se rejouerait pas et le
+   * second refus passerait inaperçu.
+   */
+  const [refus, setRefus] = useState(0)
+  const resumeRef = useRef<HTMLDivElement>(null)
+
+  const champsEnErreur = CHAMPS_CONTACT.filter((champ) => erreurs[champ])
+
+  /**
+   * Le focus part au résumé d'erreurs, pas au premier champ fautif.
+   *
+   * Le résumé donne le nombre d'erreurs et leur liste avant de renvoyer vers un champ ;
+   * sauter directement au premier champ ferait perdre les autres à qui navigue au
+   * clavier ou à l'oreille. `role="alert"` annonce le contenu, `tabIndex={-1}` rend le
+   * bloc focusable sans l'insérer dans l'ordre de tabulation.
+   */
+  useEffect(() => {
+    if (refus > 0) resumeRef.current?.focus()
+  }, [refus])
+
+  const modifier = useCallback((champ: ContactField, valeur: string) => {
+    setValeurs((precedentes) => ({ ...precedentes, [champ]: valeur }))
+    // Le message de réussite ne survit pas à une reprise de la saisie : il porterait sur
+    // un mail qui n'est plus celui qui est à l'écran.
+    setMailto(null)
+  }, [])
+
+  const soumettre = useCallback(
+    (evenement: FormEvent<HTMLFormElement>) => {
+      evenement.preventDefault()
+
+      const preparation = prepareContactMail(destinataire, valeurs)
+
+      if (!preparation.ok) {
+        setMailto(null)
+        setErreurs(preparation.erreurs)
+        // Le compteur est incrémenté ICI, et pas seulement dans l'état d'erreur : c'est
+        // lui, et lui seul, qui déclenche le renvoi du focus vers le résumé.
+        setRefus((precedent) => precedent + 1)
+        return
+      }
+
+      setErreurs({})
+      setMailto(preparation.mailto)
+      window.location.assign(preparation.mailto.url)
+    },
+    [destinataire, valeurs],
+  )
+
+  return { valeurs, erreurs, champsEnErreur, mailto, modifier, soumettre, resumeRef }
+}

--- a/src/@vitrine/services/contact-mailto.ts
+++ b/src/@vitrine/services/contact-mailto.ts
@@ -1,0 +1,143 @@
+// contact-mailto.ts — jeromemarichez-fr
+// La règle métier du contact : valider une saisie, puis en composer une URL `mailto:`
+// qu'un client mail ouvre sans rien perdre en route.
+//
+// Elle vit dans un service et non dans le composant pour une raison simple : l'encodage
+// d'un `mailto:` est la seule partie du formulaire qui puisse être fausse sans que rien
+// ne se voie à l'écran. Isolée ici, elle se teste sans monter un arbre React.
+
+import type { IMailtoCompose } from '@/interfaces/IMailtoCompose'
+import type { ContactErrors, ContactPreparation } from '@/interfaces/types'
+import { type ContactInput, contactSchema } from '@/schemas/contact.schema'
+
+/**
+ * Longueur d'URL au-delà de laquelle on refuse d'ouvrir le client mail.
+ *
+ * La valeur n'est pas une norme : RFC 6068 ne borne rien. C'est le plus petit dénominateur
+ * observé côté systèmes — le passage de l'URL au gestionnaire de protocole se fait par une
+ * ligne de commande sur Windows, et les troncatures y commencent bien avant les 8 000
+ * caractères qu'un navigateur accepterait. 1 800 laisse une marge sous le seuil de 2 000
+ * couramment retenu, en-tête `mailto:` et adresse comprises.
+ *
+ * Le risque qu'on refuse de courir : une troncature est SILENCIEUSE. Le client mail
+ * s'ouvre, le message paraît complet, et la dernière phrase manque.
+ */
+export const LONGUEUR_MAX_URL_MAILTO = 1800
+
+/**
+ * Message rendu quand l'URL dépasse la limite alors que la saisie tient dans ses bornes.
+ *
+ * Il ne parle pas d'encodage : le visiteur n'a pas à savoir qu'une apostrophe courbe pèse
+ * neuf caractères une fois pourcent-encodée. Il dit le geste à faire et rappelle la porte
+ * de sortie.
+ */
+export const MESSAGE_URL_TROP_LONGUE =
+  'Ce message est trop long pour être transmis à votre client mail. Retirez quelques lignes, ' +
+  'ou écrivez-moi directement à l’adresse indiquée à côté du formulaire.'
+
+/**
+ * Les cinq caractères que `encodeURIComponent` laisse passer et qu'un `mailto:` regrette.
+ *
+ * `! ' ( ) *` sont des `sub-delims` au sens de la RFC 3986 : légaux dans une URL, donc
+ * épargnés par `encodeURIComponent`, mais recopiés tels quels dans la ligne de commande
+ * que certains systèmes construisent pour appeler le client mail. Une apostrophe droite
+ * ou une parenthèse y ferment une chaîne au mauvais endroit. Les encoder ne coûte rien et
+ * ferme le cas.
+ */
+const SOUS_DELIMITEURS = /[!'()*]/g
+
+/** Toute forme de fin de ligne. Normalisée en CRLF, la seule que RFC 5322 connaisse. */
+const FINS_DE_LIGNE = /\r\n|\r|\n/g
+
+/**
+ * Pourcent-encode une valeur destinée à un champ d'en-tête d'un `mailto:`.
+ *
+ * Ce que `encodeURIComponent` fait déjà, et qu'il ne faut surtout pas défaire : les
+ * accents et les apostrophes typographiques passent en UTF-8 pourcent-encodé
+ * (`é` → `%C3%A9`, `’` → `%E2%80%99`), l'esperluette devient `%26`, le dièse `%23`, le
+ * plus `%2B` — ce dernier compte, un `+` littéral est relu comme une espace par une part
+ * des clients. Ce qu'il ne fait pas, et qui est ajouté ici : les cinq `sub-delims`.
+ *
+ * Les fins de ligne sont normalisées AVANT l'encodage, sans quoi un `\n` seul sortirait
+ * en `%0A` là où le corps d'un mail attend `%0D%0A`.
+ */
+export function encodeMailtoValue(valeur: string): string {
+  const normalisee = valeur.replace(FINS_DE_LIGNE, '\r\n')
+
+  return encodeURIComponent(normalisee).replace(
+    SOUS_DELIMITEURS,
+    (caractere) => `%${caractere.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+}
+
+/**
+ * Le corps du mail : le message, puis la signature.
+ *
+ * Rien d'autre n'y est ajouté — ni horodatage, ni mention du site, ni identifiant de
+ * campagne. Ce mail est écrit par une personne à une autre, et tout ce qui y ressemblerait
+ * à un en-tête de robot le ferait lire comme un mail de robot.
+ */
+function writeMailBody({ message, nom }: ContactInput): string {
+  return `${message}\n\n${nom}`
+}
+
+/**
+ * Compose l'URL `mailto:` à partir d'une saisie déjà validée.
+ *
+ * Seules les VALEURS sont encodées. Le `?` qui ouvre les champs et le `&` qui les sépare
+ * sont la syntaxe de l'URL : les encoder produirait un objet nommé « subject=... » au lieu
+ * de deux champs. C'est l'erreur classique d'un encodage appliqué à l'URL entière.
+ */
+export function composeContactMailto(destinataire: string, saisie: ContactInput): IMailtoCompose {
+  const objet = encodeMailtoValue(saisie.sujet)
+  const corps = encodeMailtoValue(writeMailBody(saisie))
+  const url = `mailto:${destinataire}?subject=${objet}&body=${corps}`
+
+  return {
+    url,
+    longueur: url.length,
+    depasseLimite: url.length > LONGUEUR_MAX_URL_MAILTO,
+  }
+}
+
+/** Le premier message d'erreur par champ. Zod en empile plusieurs, l'écran n'en montre qu'un. */
+function readFirstErrorPerField(issues: readonly { path: PropertyKey[]; message: string }[]) {
+  const erreurs: ContactErrors = {}
+
+  for (const issue of issues) {
+    const champ = issue.path[0]
+    if (typeof champ !== 'string') continue
+    if (champ !== 'nom' && champ !== 'sujet' && champ !== 'message') continue
+    if (erreurs[champ]) continue
+    erreurs[champ] = issue.message
+  }
+
+  return erreurs
+}
+
+/**
+ * Valide une saisie brute et en tire, soit l'URL à ouvrir, soit les erreurs à afficher.
+ *
+ * C'est le seul point d'entrée du formulaire : le hook n'appelle ni le schéma ni le
+ * composeur, il appelle ceci. Les deux façons d'échouer — une saisie hors bornes, une URL
+ * trop longue — ressortent sous la même forme, parce qu'elles demandent au visiteur le
+ * même geste.
+ */
+export function prepareContactMail(
+  destinataire: string,
+  saisie: Record<string, string>,
+): ContactPreparation {
+  const resultat = contactSchema.safeParse(saisie)
+
+  if (!resultat.success) {
+    return { ok: false, erreurs: readFirstErrorPerField(resultat.error.issues) }
+  }
+
+  const mailto = composeContactMailto(destinataire, resultat.data)
+
+  if (mailto.depasseLimite) {
+    return { ok: false, erreurs: { message: MESSAGE_URL_TROP_LONGUE } }
+  }
+
+  return { ok: true, mailto }
+}

--- a/src/@vitrine/views/HomeView/home-view.module.css
+++ b/src/@vitrine/views/HomeView/home-view.module.css
@@ -107,6 +107,43 @@
   align-items: flex-start;
 }
 
+/* Le formulaire et la porte de sortie, côte à côte au-delà de 60rem (issue #105).
+ *
+ * `auto-fit` plutôt qu'un point de rupture : le bloc de contact vit dans un corps de page
+ * dont la largeur dépend déjà d'un `max-width` et d'un padding, et une requête média sur
+ * la fenêtre se serait décalée de ces deux marges. La colonne du formulaire garde la
+ * priorité de largeur — c'est elle qu'on remplit.
+ *
+ * En une seule colonne, l'ordre du DOM place l'adresse APRÈS le formulaire, et cet ordre
+ * est le bon dans les deux sens : c'est celui de la tabulation, et c'est celui de la
+ * lecture. On tombe sur la porte de sortie quand on a vu ce dont elle est la sortie. */
+.grilleContact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 26rem), 1fr));
+  gap: var(--e-5);
+  align-items: start;
+  width: 100%;
+}
+
+.direct {
+  display: flex;
+  flex-direction: column;
+  gap: var(--e-2);
+  align-items: flex-start;
+}
+
+.directTitre {
+  font-size: var(--t-2);
+}
+
+.directTexte {
+  margin: 0;
+  max-width: var(--mesure-texte);
+  font-size: var(--t-note);
+  line-height: 1.55;
+  color: var(--encre-douce);
+}
+
 /* Apparence seule : le `transform` appartient à `MagneticAction`. */
 .action {
   display: inline-block;

--- a/src/@vitrine/views/HomeView/index.tsx
+++ b/src/@vitrine/views/HomeView/index.tsx
@@ -4,6 +4,7 @@
 import { MagneticAction } from '@/@shared/components/MagneticAction'
 import { Reveal } from '@/@shared/components/Reveal'
 import { SITE_IDENTITY } from '@/@shared/seo/site'
+import { ContactForm } from '../../components/_notPure/ContactForm'
 import { BoundaryList } from '../../components/BoundaryList'
 import { CertificationList } from '../../components/CertificationList'
 import { ChainDiagram } from '../../components/ChainDiagram'
@@ -14,6 +15,7 @@ import { ProofWall } from '../../components/ProofWall'
 import { SpaceEntries } from '../../components/SpaceEntries'
 import { PAGE_ACCUEIL, THESE_CHAINE } from '../../contenu/accueil'
 import { CERTIFICATIONS } from '../../contenu/certifications'
+import { CONTACT_DIRECT } from '../../contenu/contact'
 import { LIMITES } from '../../contenu/limites'
 import { PREUVES } from '../../contenu/preuves'
 import { MAX_GLASS_ACCUEIL, selectGlassSectionIds } from '../../services/glass-policy'
@@ -121,9 +123,22 @@ export function HomeView() {
               Vous écrivez à la personne qui fera le travail. Si ce n'est pas pour moi, je vous le
               dis aussi.
             </p>
-            <MagneticAction className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
-              {SITE_IDENTITY.email}
-            </MagneticAction>
+            {/* Le formulaire et l'adresse en clair sont côte à côte, et c'est une
+                obligation, pas une mise en page : le formulaire a besoin d'un client mail
+                installé sur le poste, ce qui n'est le cas ni en entreprise ni sur un
+                navigateur qui n'a que du webmail. Sans l'adresse à côté, ce visiteur-là
+                repartirait avec un bouton qui ne fait rien. */}
+            <div className={styles.grilleContact}>
+              <ContactForm destinataire={SITE_IDENTITY.email} titreId="contact-titre" />
+
+              <div className={styles.direct}>
+                <h3 className={styles.directTitre}>{CONTACT_DIRECT.titre}</h3>
+                <p className={styles.directTexte}>{CONTACT_DIRECT.texte}</p>
+                <MagneticAction className={styles.action} href={`mailto:${SITE_IDENTITY.email}`}>
+                  {SITE_IDENTITY.email}
+                </MagneticAction>
+              </div>
+            </div>
           </Reveal>
         </section>
       </div>

--- a/src/interfaces/IMailtoCompose.ts
+++ b/src/interfaces/IMailtoCompose.ts
@@ -1,0 +1,26 @@
+// IMailtoCompose.ts — jeromemarichez-fr
+// Le résultat de la composition d'une URL `mailto:` : l'URL, sa longueur, et le verdict
+// sur la limite que les clients mail imposent aux URL.
+
+/**
+ * Une URL `mailto:` composée, accompagnée de ce qu'il faut pour décider si on l'ouvre.
+ *
+ * `longueur` et `depasseLimite` ne sont pas redondants avec l'URL : le composant a besoin
+ * du verdict sans avoir à connaître la limite, et un test a besoin de la longueur pour
+ * situer un cas près du seuil sans recompter lui-même.
+ */
+export interface IMailtoCompose {
+  /** L'URL complète, prête à être ouverte. Toutes les valeurs y sont pourcent-encodées. */
+  url: string
+  /** Longueur de l'URL en unités de code UTF-16, une fois encodée. */
+  longueur: number
+  /**
+   * Vrai quand l'URL dépasse ce qu'un client mail accepte de façon fiable.
+   *
+   * Ce n'est pas la même borne que celle du champ de saisie : un message de 300 signes
+   * d'apostrophes typographiques tient largement dans la limite de caractères et produit
+   * pourtant 2 700 caractères d'URL. Le compteur borne ce que l'utilisateur voit, ce
+   * drapeau borne ce que le navigateur reçoit.
+   */
+  depasseLimite: boolean
+}

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -3,6 +3,9 @@
 // Les entités métier sont des interfaces (IXxx) dans des fichiers dédiés de ce dossier.
 // Convention : docs/architecture.md.
 
+import type { ContactField } from '@/schemas/contact.schema'
+import type { IMailtoCompose } from './IMailtoCompose'
+
 /** Les quatre pôles. `data` est le préalable de `ia` et de `sea-ux`. */
 export type PoleId = 'ingenierie-web' | 'data' | 'ia' | 'sea-ux'
 
@@ -68,3 +71,21 @@ export type ArticleFigureId = 'borne' | 'anteriorite' | 'appui' | 'gabarit' | 'l
  * un contenu.
  */
 export type ArticleSourceReseau = 'linkedin'
+
+/**
+ * Le verdict de préparation d'un message de contact.
+ *
+ * Union fermée plutôt que deux champs optionnels : il n'existe pas d'état où l'on aurait
+ * à la fois une URL à ouvrir et des erreurs à afficher, et le compilateur doit interdire
+ * de l'écrire. Le composant lit `ok` et n'a rien d'autre à vérifier.
+ *
+ * Le cas « URL trop longue » sort ici comme une erreur de champ, pas comme un troisième
+ * état : du point de vue du visiteur c'est le même geste que pour un message trop long,
+ * et lui inventer un traitement à part n'aurait servi qu'à compliquer le rendu.
+ */
+export type ContactPreparation =
+  | { ok: true; mailto: IMailtoCompose }
+  | { ok: false; erreurs: ContactErrors }
+
+/** Un message d'erreur au plus par champ : le premier rencontré, jamais une pile. */
+export type ContactErrors = Partial<Record<ContactField, string>>

--- a/src/schemas/contact.schema.ts
+++ b/src/schemas/contact.schema.ts
@@ -1,0 +1,65 @@
+// contact.schema.ts — jeromemarichez-fr
+// La saisie du formulaire de contact. Seule entrée externe du site : il n'y a pas de
+// serveur, donc pas d'API à valider — mais une saisie reste une donnée non maîtrisée,
+// et c'est elle qui part composer une URL `mailto:`.
+//
+// Le type est dérivé du schéma (z.infer), jamais écrit à la main. Aucun cast direct.
+
+import { z } from 'zod'
+import { formatNumberFr } from '@/utils/format-number-fr'
+
+/** Bornes de saisie. Exportées : le compteur du formulaire et les tests s'y adossent. */
+export const LONGUEUR_MIN_NOM = 2
+export const LONGUEUR_MAX_NOM = 80
+export const LONGUEUR_MIN_SUJET = 3
+export const LONGUEUR_MAX_SUJET = 120
+export const LONGUEUR_MIN_MESSAGE = 20
+export const LONGUEUR_MAX_MESSAGE = 1500
+
+/**
+ * Trois champs, et pas un de plus.
+ *
+ * Pas de champ « adresse de réponse » : le message part de la boîte du visiteur, donc son
+ * adresse voyage déjà dans l'en-tête. La redemander produirait deux adresses susceptibles
+ * de diverger, et une donnée collectée pour rien.
+ *
+ * `.trim()` s'applique avant les bornes : un champ rempli d'espaces est un champ vide, et
+ * il doit être refusé comme tel plutôt que compté comme rempli.
+ */
+export const contactSchema = z.object({
+  nom: z
+    .string()
+    .trim()
+    .min(LONGUEUR_MIN_NOM, 'Indiquez le nom sous lequel je vous réponds.')
+    .max(
+      LONGUEUR_MAX_NOM,
+      `Ce nom dépasse ${formatNumberFr(LONGUEUR_MAX_NOM)} caractères, il faut le raccourcir.`,
+    ),
+  sujet: z
+    .string()
+    .trim()
+    .min(LONGUEUR_MIN_SUJET, 'Donnez un sujet, même court : il devient l’objet du mail.')
+    .max(
+      LONGUEUR_MAX_SUJET,
+      `Ce sujet dépasse ${formatNumberFr(LONGUEUR_MAX_SUJET)} caractères. Gardez une seule ligne, le détail va dans le message.`,
+    ),
+  message: z
+    .string()
+    .trim()
+    .min(
+      LONGUEUR_MIN_MESSAGE,
+      'Le message est encore court. Quelques phrases sur votre situation suffisent.',
+    )
+    .max(
+      LONGUEUR_MAX_MESSAGE,
+      `Le message dépasse ${formatNumberFr(LONGUEUR_MAX_MESSAGE)} caractères. Résumez ici, vous complèterez dans votre client mail.`,
+    ),
+})
+
+export type ContactInput = z.infer<typeof contactSchema>
+
+/** Les champs du formulaire, dérivés du schéma : ajouter un champ met les deux à jour. */
+export type ContactField = keyof ContactInput
+
+/** L'ordre d'affichage et de parcours au clavier. Il fixe aussi l'ordre du résumé d'erreurs. */
+export const CHAMPS_CONTACT: readonly ContactField[] = ['nom', 'sujet', 'message']

--- a/src/utils/format-contact-counter.ts
+++ b/src/utils/format-contact-counter.ts
@@ -1,0 +1,26 @@
+// format-contact-counter.ts — jeromemarichez-fr
+// Le compteur de caractères du message de contact, rendu en français.
+
+import { formatNumberFr } from './format-number-fr'
+
+/**
+ * Rend l'état du compteur : ce qui reste, ou ce qui dépasse.
+ *
+ * Le champ n'est pas borné par `maxLength`, et ce n'est pas un oubli : un `maxLength`
+ * tronque un texte collé sans le dire, ce qui est exactement le piège que le formulaire
+ * doit éviter. Le visiteur peut donc dépasser, il le voit, et la validation le lui dit en
+ * toutes lettres au moment où il ouvre le mail.
+ *
+ * Le nombre passe par `formatNumberFr`, le même formateur que les messages du schéma :
+ * sans lui, la même limite s'écrirait « 1 500 » sous le champ et « 1500 » dans l'erreur,
+ * à deux centimètres d'écart.
+ */
+export function formatContactCounter(longueur: number, maximum: number): string {
+  const ecart = maximum - longueur
+
+  if (ecart < 0) {
+    return `${formatNumberFr(-ecart)} caractères de trop`
+  }
+
+  return `${formatNumberFr(ecart)} caractères restants sur ${formatNumberFr(maximum)}`
+}

--- a/src/utils/format-number-fr.ts
+++ b/src/utils/format-number-fr.ts
@@ -1,0 +1,16 @@
+// format-number-fr.ts — jeromemarichez-fr
+// Le rendu d'un entier en français. Un seul endroit, parce qu'un même nombre affiché de
+// deux façons sur un même écran se remarque.
+
+/**
+ * Formateur construit une seule fois : il est appelé à chaque frappe dans le champ de
+ * message, et instancier un `Intl.NumberFormat` par touche serait le seul coût mesurable
+ * du formulaire. Il porte l'espace insécable des milliers, que la locale française attend
+ * et qu'une concaténation manuelle n'aurait pas mise.
+ */
+const NOMBRE_FR = new Intl.NumberFormat('fr-FR')
+
+/** Rend un entier avec le séparateur de milliers français. */
+export function formatNumberFr(valeur: number): string {
+  return NOMBRE_FR.format(valeur)
+}

--- a/tests/fixtures/contact.fixture.json
+++ b/tests/fixtures/contact.fixture.json
@@ -1,0 +1,55 @@
+{
+  "_lisezmoi": "Jeu de données du formulaire de contact (jeromemarichez-fr) — PAS un mock. Les vrais services (contactSchema, encodeMailtoValue, composeContactMailto, prepareContactMail) et les vrais composants (ContactField, ContactForm) tournent sur ces saisies ; aucune doublure de module n'est utilisée. Le formulaire ne fait aucun appel réseau : il compose une URL mailto: et rien d'autre. Voir docs/testing.md.",
+  "_cas": {
+    "saisieNominale": "Une saisie ordinaire et valide. Elle sert de témoin : tout ce qui la refuserait est une régression, et son URL est le point de comparaison des cas d'encodage.",
+    "saisieEncodageDifficile": "Le cas qui casse un mailto: naïf, tous les pièges dans une seule saisie : accents (é, ô), apostrophe droite ('), apostrophe typographique (’), esperluette (&), dièse (#), plus (+), parenthèses, point d'exclamation, astérisque, et trois retours à la ligne. Attendu après relecture par new URL(...).searchParams : le texte revient IDENTIQUE, les retours à la ligne en CRLF. Le + doit sortir en %2B, jamais littéral — un + littéral est relu comme une espace par une part des clients mail.",
+    "saisieEspacesSeuls": "Les trois champs remplis d'espaces et de tabulations. Le .trim() du schéma s'applique AVANT les bornes : la saisie doit être refusée sur les trois champs, jamais comptée comme remplie.",
+    "saisieTropCourte": "Chaque champ juste sous sa borne basse. Trois erreurs attendues, une par champ, dans l'ordre nom, sujet, message.",
+    "saisieTropLongue": "Chaque champ juste au-dessus de sa borne haute. Le message compte 1501 caractères : à 1500 il passe, à 1501 il est refusé.",
+    "saisieUrlTropLongue": "Une saisie qui tient dans les bornes de caractères et dont l'URL encodée dépasse tout de même LONGUEUR_MAX_URL_MAILTO (1800). Le message est fait d'apostrophes typographiques, qui pèsent neuf caractères chacune une fois pourcent-encodées : 400 signes de saisie produisent plus de 3600 caractères d'URL. C'est le seul cas où la validation du schéma passe et où prepareContactMail refuse quand même, en posant l'erreur sur le champ message.",
+    "champsInconnus": "Une saisie qui porte un champ en trop. Le schéma ne doit pas le faire ressortir dans les erreurs de champ, et il ne doit jamais atteindre l'URL composée."
+  },
+  "destinataire": "jeromemarichez@ik.me",
+  "saisieNominale": {
+    "nom": "Marie Dupont",
+    "sujet": "Refonte du tunnel de commande",
+    "message": "Bonjour, notre tunnel de commande perd la moitie des paniers entre le panier et le paiement. Nous cherchons a savoir si le probleme est technique ou ergonomique, sous six semaines."
+  },
+  "saisieEncodageDifficile": {
+    "nom": "Jérôme O'Neill",
+    "sujet": "Audit data & SEA #2026 (urgent) + tracking",
+    "message": "Bonjour Jérôme,\nJ'ai un besoin R&D #tracking + CRM, et c’est urgent (deux semaines) !\nLe budget est de 50 % de l'enveloppe annuelle.\n\nMerci d'avance*"
+  },
+  "saisieEspacesSeuls": {
+    "nom": "     ",
+    "sujet": "\t\t  ",
+    "message": "                                   "
+  },
+  "saisieTropCourte": {
+    "nom": "M",
+    "sujet": "AB",
+    "message": "Trop court, merci."
+  },
+  "saisieTropLongue": {
+    "_lisezmoi": "Les valeurs sont donnees par leur motif et leur longueur cible, a construire dans le test : un fichier de donnees n'a pas a porter 1501 caracteres en dur.",
+    "nomMotif": "n",
+    "nomLongueur": 81,
+    "sujetMotif": "s",
+    "sujetLongueur": 121,
+    "messageMotif": "m",
+    "messageLongueur": 1501
+  },
+  "saisieUrlTropLongue": {
+    "_lisezmoi": "Le message est le motif ’ repete 400 fois : valide pour le schema (400 <= 1500), et plus de 3600 caracteres une fois encode.",
+    "nom": "Marie Dupont",
+    "sujet": "Un sujet ordinaire",
+    "messageMotif": "’",
+    "messageLongueur": 400
+  },
+  "champsInconnus": {
+    "nom": "Marie Dupont",
+    "sujet": "Refonte du tunnel de commande",
+    "message": "Bonjour, notre tunnel de commande perd la moitie des paniers. Nous cherchons a savoir pourquoi, sous six semaines.",
+    "copieCachee": "quelquun@example.invalid"
+  }
+}


### PR DESCRIPTION
Refs #105. Le site n'avait aucun formulaire : `document.querySelectorAll('form').length` valait 0 partout. Il en a un.

## Ce que je reprends du travail deja pose

Le socle etait sur le disque, non commite : schema Zod, service de composition, contenu, hook, utilitaire de compteur. Je l'ai evalue plutot que refait, et garde presque entierement. Deux defauts corriges :

- `contact.schema.ts` ne compilait pas : une apostrophe droite non echappee fermait une chaine en cote simple (`l'objet du mail`). Remplacee par l'apostrophe typographique, comme le reste du contenu.
- `use-contact-form.ts` n'incrementait jamais son compteur de refus. L'effet de renvoi du focus vers le resume d'erreurs ne se declenchait donc **jamais**, et le compteur, dont le commentaire expliquait pourtant qu'il devait remplacer un booleen, ne comptait rien.

## Le mecanisme

`next.config.mjs` pose `output: 'export'` : pas de route API, pas de Server Action. Le formulaire ne poste rien.

```
saisie -> contactSchema.safeParse -> composeContactMailto -> window.location.assign(url)
```

`prepareContactMail` est le seul point d'entree. Il rend une union fermee : soit une URL a ouvrir, soit des erreurs par champ. Il n'existe pas d'etat ou l'on aurait les deux, et le type l'interdit. Le hook n'a aucune regle, il appelle le service et range le resultat ; le composant ne connait ni le schema ni l'encodage.

Types derives du schema par `z.infer`. Aucun cast `as`. `SITE_IDENTITY.email` reste la source unique de l'adresse, passee en prop.

## L'encodage difficile

Seules les **valeurs** sont pourcent-encodees. Le `?` qui ouvre les champs et le `&` qui les separe sont la syntaxe de l'URL : les encoder produirait un objet nomme « subject=... » au lieu de deux champs. C'est l'erreur classique d'un `encodeURIComponent` applique a l'URL entiere.

Deux ajouts a `encodeURIComponent` :

- **les cinq `sub-delims`** `! ' ( ) *`. Legaux dans une URL au sens de la RFC 3986, donc epargnes, mais recopies tels quels dans la ligne de commande que certains systemes construisent pour appeler le client mail, ou une apostrophe droite ferme une chaine au mauvais endroit ;
- **les fins de ligne, normalisees en CRLF AVANT l'encodage.** Sans quoi un `\n` seul sortirait en `%0A` la ou le corps d'un mail attend `%0D%0A`.

Le reste est deja juste et ne doit pas etre defait : accents et apostrophes typographiques en UTF-8 pourcent-encode (`é` en `%C3%A9`, `’` en `%E2%80%99`), `&` en `%26`, `#` en `%23`, et `+` en `%2B` — celui-la compte, un `+` litteral est relu comme une espace par une part des clients.

Verifie par aller-retour : la saisie de `tests/fixtures/contact.fixture.json` (accents, `'`, `’`, `&`, `#`, `+`, parentheses, `!`, `*`, trois retours a la ligne) relue par `new URL(url).searchParams` revient identique, retours a la ligne en CRLF.

## Le corps trop long : ce que j'ai choisi

**Refuser et le dire**, plutot que tronquer ou tenter quand meme.

La limite de saisie (1 500 caracteres) et la limite d'URL (1 800) sont deux bornes distinctes, et il faut les deux : 400 apostrophes typographiques tiennent largement dans la premiere et produisent plus de 3 600 caracteres d'URL, parce qu'une apostrophe courbe pese neuf caracteres une fois encodee. Le compteur borne ce que le visiteur voit, le drapeau `depasseLimite` borne ce que le navigateur recoit.

1 800 n'est pas une norme : la RFC 6068 ne borne rien. C'est le plus petit denominateur observe cote systemes, le passage de l'URL au gestionnaire de protocole se faisant par une ligne de commande sur Windows. Le risque qu'on refuse de courir est que **la troncature est silencieuse** : le client mail s'ouvre, le message parait complet, et la derniere phrase manque.

L'echec sort comme une erreur sur le champ message, pas comme un troisieme etat : du point de vue du visiteur c'est le meme geste que pour un message trop long. Le message ne parle pas d'encodage, il dit le geste a faire et rappelle l'adresse a cote.

Meme logique pour le champ : **pas de `maxLength`**. Un `maxLength` tronque un texte colle sans le dire, ce qui est exactement le piege que ce formulaire doit eviter. Le visiteur peut depasser, le compteur le lui montre, la validation le lui dit en toutes lettres.

## Accessibilite

Le detail est dans `docs/accessibility.md`. L'essentiel :

- `label` **visible** et associe par champ, jamais un `placeholder` en guise de libelle ;
- le caractere obligatoire est **ecrit** (« (obligatoire) »), plus `required` natif. Pas d'asterisque, pas de couleur seule (WCAG 1.4.1). En casse normale dans un libelle en majuscules : « (OBLIGATOIRE) » se lit comme un avertissement et s'epelle sur certaines synthèses ;
- `aria-describedby` : l'aide d'abord, le compteur, l'erreur en dernier. Un lecteur d'ecran restitue dans l'ordre donne, et on veut entendre ce que le champ attend avant pourquoi ce qui y est ne convient pas ;
- `aria-invalid` sur le champ fautif. L'etat se dit trois fois : message ecrit, attribut, et seulement en dernier l'arete en `--cuivre` (6.02:1 en clair, 7.18:1 en sombre) ;
- **deux regions vivantes distinctes, dans le document des le premier rendu, vides.** Un `role="alert"` insere en meme temps que son texte n'est pas annonce de facon fiable ; une region deja la au chargement l'est. Effacees par `:empty`, jamais par une condition de rendu. Refus en `role="alert"` qui interrompt, reussite en `role="status"` qui attend une pause ;
- **le focus part au resume d'erreurs**, `tabIndex={-1}`, pas au premier champ fautif : le resume renvoie vers chaque champ par un vrai lien, on entend tout et on choisit quoi corriger ;
- **validation a la soumission seulement.** Valider a la frappe fait passer le champ en erreur au deuxieme caractere, et le lecteur d'ecran l'annonce ;
- `noValidate`, sinon le navigateur substitue ses propres bulles aux messages ecrits ;
- **l'adresse en clair en `mailto:` a cote du formulaire.** Ce n'est pas une redondance : sans client mail installe, le bouton ne fait rien, et ce visiteur doit repartir avec l'adresse ;
- le bouton d'envoi **ne se deplace pas** au survol (issue #137) : elevation et anneau interieur, deux changements de forme, jamais la teinte seule. L'appel a `MagneticAction` du bloc de contact est laisse **tel quel**, il appartient a `feature/sans-aimant`.

Ordre de tabulation verifie de bout en bout dans le navigateur, sur l'export statique servi : nom, sujet, message, bouton, envoi a Entree, focus au resume. Aucun piege, aucun arret parasite. Les deux themes sont controles.

## Le bloc de contact est du verre

`origin/dev` fusionne avant de styler. La PR #135 a fait du bloc de contact une surface de verre : je n'y ai pas touche. Les champs sont un **creux** dans le papier (`--fond-creux`, arete discrete), pas une carte posee dessus : empiler un second relief dans un panneau de verre ferait deux plans qui se disputent la meme lumiere.

Le formulaire et l'adresse sont cote a cote au-dela de 26rem par `auto-fit`, pas par une requete media : le bloc vit dans un corps de page dont la largeur depend deja d'un `max-width` et d'un padding, et une requete sur la fenetre se serait decalee de ces deux marges. En une colonne, l'adresse passe **apres** le formulaire, et cet ordre est le bon dans les deux sens : celui de la tabulation et celui de la lecture.

## RGPD

`docs/rgpd.md` porte la section. Aucun appel reseau sortant, aucun sous-traitant, aucun stockage (ni cookie, ni `localStorage`), aucune donnee ajoutee a ce que le visiteur ecrit. **Pas de champ « adresse de reponse »** : le mail part de la boite du visiteur, son adresse voyage deja dans l'en-tete, et la redemander serait collecter une donnee pour rien. Le seul traitement qui existe est celui qui existait deja : un mail recu dans une boite.

## Le second agent

Relecture par un agent sans contexte de redaction, a qui seuls les textes ont ete donnes. Aucun emoji, aucun tiret cadratin releve. Cinq remarques de ton et de clarte, **toutes integrees** :

1. « ce poste n'a pas de client mail » affirmait un diagnostic invérifiable, et sonnait comme un verdict sur l'equipement du lecteur. Devenu « c'est en general qu'aucun client mail n'est configure sur ce poste ».
2. « Beaucoup n'en ont pas » : referent absent, et « sur les webmails » ne se raccrochait pas grammaticalement. Reecrit.
3. « trop long pour etre **passe** a votre client mail » : tournure d'implementation. Devenu « transmis ».
4. « Ce nom depasse 80 caracteres. Raccourcissez-le. » : seul message de la serie a commander sans expliquer. Devenu une seule phrase.
5. « Il reste a completer avant d'ouvrir le mail : » : phrase bancale sans complement. Devenu « A completer avant d'ouvrir le mail : ».

Une sixieme remarque portait sur une incoherence que je n'avais pas vue : le compteur ecrivait « 1 500 » et l'erreur « 1500 », a deux centimetres d'ecart. Corrige en extrayant `formatNumberFr` dans `src/utils/`, utilise par le schema **et** par le compteur.

## Tests

Aucun fichier sous `tests/` n'est cree : les tests sont ecrits par Jerome MARICHEZ. Les **intentions** sont exposees dans le rapport de la tache. `tests/fixtures/contact.fixture.json` est pose : c'est un jeu de donnees, pas un test, et il porte les cas d'encodage difficiles ainsi que le cas « URL trop longue a saisie valide ».

## Verification

- `make lint` vert (limite 300 lignes incluse), `make type-check` vert, `make test` vert.
- **`make build` vert**, et le formulaire verifie dans l'export statique servi, pas seulement en `make dev` : `<form>` present dans `out/index.html`, `label`/`for`, `aria-describedby` et les deux regions vivantes dans le HTML pre-rendu.
- Parcours clavier, etat d'erreur et deux themes controles dans le navigateur sur cet export.

Aucune nouvelle dependance npm. Ni `next-env.d.ts` ni `package-lock.json` ne sont commites.

https://claude.ai/code/session_01Ku16fxvGEdhuGVgnYjXN6R
