### PR TITLE
chore: le plancher de performance passe a 80

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,17 @@ Ce fichier-ci porte les règles qui encadrent la façon de l'écrire et de le d�
 échéant) ; **Zod** pour la validation des entrées.
 
 **Contraintes produit non négociables** : rendu statique ou ISR et métadonnées par page
-(SEO), Lighthouse ≥ 95 sur les 4 catégories, accessibilité RGAA / WCAG AA testée dans
-`uat/`, mesure d'audience conforme RGPD avec consentement. Le site est la démonstration
-de ce qu'il vend : un défaut de perf ou d'accessibilité y coûte plus cher qu'ailleurs.
+(SEO), Lighthouse à **95 visé sur les 4 catégories**, accessibilité RGAA / WCAG AA testée
+dans `uat/`, mesure d'audience conforme RGPD avec consentement. Le site est la
+démonstration de ce qu'il vend : un défaut de perf ou d'accessibilité y coûte plus cher
+qu'ailleurs.
+
+**Le plancher bloquant de performance est à 80**, décidé par Jérôme MARICHEZ le
+2026-08-24 : « Pour le LCP j'autorise 80/100 mais pas moins » (issue #146). Sous 80, le
+budget échoue et rien ne se livre. **Accessibilité, bonnes pratiques et SEO ne bougent
+pas** : leur plancher reste 95. 80 n'est pas la cible : entre 80 et 95, le budget passe
+mais le rapport le signale, et le score reste à corriger. Valeurs exécutables dans
+`scripts/budgets/pages.mjs`, elles ne se recopient nulle part.
 
 > Projet géré par Jérôme MARICHEZ.
 

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,12 @@ test-system: ## Tests système (vrai serveur HTTP via listen(0))
 test-acceptance: ## Tests d'acceptation / UAT (runner Node natif)
 	node --test tests/acceptance/
 
-# Budgets exécutables — Lighthouse >= 95 sur les 4 categories et accessibilite WCAG AA.
+# Budgets exécutables — Lighthouse et accessibilite WCAG AA. Cible 95 sur les 4
+# categories ; plancher bloquant a 80 en performance (decision de Jerome MARICHEZ du
+# 2026-08-24, issue #146) et a 95 sur les trois autres.
 # Construisent l'export statique s'il manque, le servent, mesurent, et sortent en echec
-# en nommant la page et la categorie fautives. Seuils : scripts/budgets/pages.mjs.
+# en nommant la page et la categorie fautives. Un score entre plancher et cible passe et
+# se signale. Seuils et cibles : scripts/budgets/pages.mjs.
 # Prerequis local : npx puppeteer browsers install chrome (une fois).
 budgets: ## Budgets perf + accessibilite sur les pages representatives
 	node scripts/budgets.mjs

--- a/README.md
+++ b/README.md
@@ -472,8 +472,11 @@ certification.
   à la requête. Métadonnées, `canonical` et données structurées par page, sitemap et
   robots générés. Conséquence assumée : ni route API, ni ISR, ni Server Action
   (voir [architecture](./docs/architecture.md)).
-- **Performance** : Lighthouse ≥ 95 sur les 4 catégories, Core Web Vitals au vert —
-  le site est lui-même la démonstration de ce qui est vendu.
+- **Performance** : Lighthouse à 95 visé sur les 4 catégories, Core Web Vitals au vert.
+  Le site est lui-même la démonstration de ce qui est vendu. Le **plancher bloquant** de
+  la catégorie performance est à **80** depuis le 2026-08-24 (décision de Jérôme
+  MARICHEZ, issue #146) : sous 80 rien ne se livre, entre 80 et 95 le budget passe et le
+  rapport le signale. Accessibilité, bonnes pratiques et SEO gardent un plancher à 95.
 - **Accessibilité** : RGAA / WCAG AA, testée et non supposée (`uat/`).
 - **RGPD** : mesure d'audience conforme, consentement géré, aucune donnée personnelle
   collectée hors formulaire de contact explicite.

--- a/docs/ameliorations.md
+++ b/docs/ameliorations.md
@@ -14,7 +14,12 @@ le bénéfice attendu et l'effort estimé.
 
 Les budgets sont devenus exécutables (`make budgets`, voir [testing](./testing.md)). Leur
 première exécution rapporte **80 / 81 / 82** en performance mobile, contre un seuil de
-**95**. Le seuil n'a pas été touché : ce qui suit est ce qu'il faut corriger.
+**95** alors en vigueur. Le seuil n'a pas été touché ce jour-là : ce qui suit est ce
+qu'il faut corriger.
+
+*(Depuis, le 2026-08-24, le plancher bloquant de performance est passé à 80 sur décision
+de Jérôme MARICHEZ, issue #146 : « Pour le LCP j'autorise 80/100 mais pas moins ». La
+cible reste 95, et les pistes listées ici restent donc entières.)*
 
 Le profil des trois pages est identique et sans ambiguïté :
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -36,15 +36,18 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
   cent fois moins cher le jour où elle est écrite. Ce contrôle ne vaut **pas** un audit
   RGAA — il couvre la part mécanisable de WCAG AA, voir
   [accessibility](./accessibility.md).
-- **budgets (main)** : `make budgets` — axe **et** Lighthouse (≥ 95 sur les quatre
-  catégories, mobile émulé + réseau bridé, médiane de trois passes) sur les mêmes pages.
+- **budgets (main)** : `make budgets`, soit axe **et** Lighthouse (plancher bloquant : 80 en
+  performance depuis le 2026-08-24, 95 sur les trois autres catégories ; cible 95
+  partout ; mobile émulé + réseau bridé, médiane de trois passes) sur les mêmes pages.
   Placé sur `main` **parce qu'il est lent** : trois passes par page, et la variance de
   Lighthouse impose la répétition. Le payer à chaque PR vers `dev` taxerait tout le monde
   pour une métrique qui bouge rarement d'un commit à l'autre ; le placer sur la PR de
   mise en production le met là où la question se pose — *est-ce que ce qu'on publie tient
   les chiffres qu'on vend ?* Un `workflow_dispatch` permet de le lancer à la demande
-  depuis `dev` sans attendre la PR de production. Seuils : `scripts/budgets/pages.mjs`,
-  repris du `CLAUDE.md`. Détail : [testing](./testing.md).
+  depuis `dev` sans attendre la PR de production. Seuils et cibles :
+  `scripts/budgets/pages.mjs`, source unique. Un score entre le plancher et la cible ne
+  fait pas échouer le contrôle, il est listé nommément dans le rapport.
+  Détail : [testing](./testing.md).
 - **nginx (dev)** : `make nginx-check` — monte `docker/nginx.conf` là où le
   `Dockerfile` le copie et lance **`nginx -t`** dans l'image `nginx:1.29-alpine`. Placé
   sur `dev` **parce qu'il est rapide** : aucun build applicatif, un pull d'image et un

--- a/docs/design.md
+++ b/docs/design.md
@@ -559,7 +559,9 @@ faut au moins trois écarts-types de flou de matière autour du panneau.
 
 #### Ce qu'elle coûte, et où elle est donc coupée
 
-Lighthouse, mobile bridé, seuil ≥ 95 :
+Lighthouse, mobile bridé, relevé sous le seuil de 95 alors en vigueur (le plancher
+bloquant de performance est passé à 80 le 2026-08-24, issue #146 ; la cible reste 95, et
+l'arbitrage ci-dessous ne change pas) :
 
 | Accueil | Perf |
 |---|---|
@@ -965,7 +967,7 @@ on lisait, à des coordonnées qui ne le savaient pas ; celle-ci ne dit rien d'u
 | Pas de rasterisation géante | `.lavis-pole` dimensionne sa tache en **pixels** et la répète en Y : elle est rasterisée une fois, sur 1600 × 1100 px, jamais à la hauteur d'un gabarit de 6 000 px. `.lavis-bloc` ne sert que des blocs de la taille d'une carte. |
 | Aucune animation | Le lavis est statique. `prefers-reduced-motion` n'a rien à couper. |
 | Aucune information portée par la seule couleur | Le lavis est un décor : le nom du pôle, son libellé de place et son temps restent écrits en toutes lettres (WCAG 1.4.1). |
-| Lighthouse ≥ 95 | Mesuré après le lot : accueil 96, page de pôle 96, blog / article / réalisations 97 ; A11y, bonnes pratiques et SEO à 100. |
+| Lighthouse à la cible de 95 | Mesuré après le lot : accueil 96, page de pôle 96, blog / article / réalisations 97 ; A11y, bonnes pratiques et SEO à 100. (Le plancher bloquant de performance est passé à 80 le 2026-08-24, issue #146 ; la cible visée reste 95.) |
 
 ### Contraste — mesuré, pas supposé
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -134,10 +134,35 @@ La traversée de répertoire hors de `out/` est refusée.
 
 ## Budgets exécutables — performance et accessibilité
 
-Le `CLAUDE.md` pose deux contraintes produit non négociables : **Lighthouse ≥ 95 sur les
-quatre catégories** et **accessibilité WCAG AA**. Elles étaient écrites, elles ne sont
-plus seulement écrites : `make budgets` échoue quand le site descend sous le seuil, et
+Le `CLAUDE.md` pose deux contraintes produit non négociables : **Lighthouse à 95 visé sur
+les quatre catégories** et **accessibilité WCAG AA**. Elles étaient écrites, elles ne sont
+plus seulement écrites : `make budgets` échoue quand le site descend sous le plancher, et
 dit **quelle page** sur **quelle catégorie**.
+
+### Plancher, cible, et les trois états du rapport
+
+Le **plancher bloquant** de la catégorie performance est à **80** depuis le 2026-08-24 :
+« Pour le LCP j'autorise 80/100 mais pas moins » (décision de Jérôme MARICHEZ,
+issue #146). Accessibilité, bonnes pratiques et SEO gardent un plancher à 95. La
+**cible** reste 95 partout, y compris en performance.
+
+Le plancher n'est donc pas la cible, et le rapport distingue trois états au lieu de deux :
+
+| Marque | Ce qu'elle dit | Effet sur le budget |
+|--------|----------------|---------------------|
+| `✓` | le score atteint la cible | passe |
+| `~` | le score passe le plancher, sous la cible | passe, et le rapport le liste nommément |
+| `✗` | le score est sous le plancher | **échec**, rien ne se livre |
+
+Les scores en `~` sont repris sous le tableau, page par page et catégorie par catégorie :
+un tableau entièrement vert ne se relit pas, une ligne nommée si.
+
+Les valeurs vivent dans `scripts/budgets/pages.mjs` (`SEUILS_LIGHTHOUSE`,
+`CIBLES_LIGHTHOUSE`), source unique lue par la CI comme par la doc. La règle 8 du
+`CLAUDE.md` reste entière : l'assistant n'abaisse jamais un seuil pour faire passer un
+contrôle, aucun `|| true`, aucune catégorie exemptée, aucune page retirée de la mesure.
+Une révision de plancher ne vient que de Jérôme MARICHEZ, et s'écrit datée et attribuée
+dans le fichier qui la porte.
 
 Ce ne sont pas des tests au sens des quatre niveaux ci-dessus : ils ne décrivent pas un
 comportement attendu du code, ils mesurent une propriété du site rendu. Ils vivent donc

--- a/scripts/budgets.mjs
+++ b/scripts/budgets.mjs
@@ -1,8 +1,8 @@
 // budgets.mjs — jeromemarichez-fr
 //
-// Rend **exécutables** les deux promesses que le site affiche : Lighthouse ≥ 95 sur les
-// quatre catégories, et accessibilité WCAG AA. Une commande, un code de sortie, et le
-// nom de ce qui ne passe pas.
+// Rend **exécutables** les deux promesses que le site affiche : les scores Lighthouse
+// tenus sur les quatre catégories, et l'accessibilité WCAG AA. Une commande, un code de
+// sortie, et le nom de ce qui ne passe pas.
 //
 //   node scripts/budgets.mjs            (ou : make budgets)
 //   node scripts/budgets.mjs perf       (ou : make budget-perf)
@@ -13,8 +13,19 @@
 // ne reste que la mesure.
 //
 // Règle 8 du `CLAUDE.md` : le vert s'obtient par un site qui tient ses budgets, jamais
-// par un seuil qu'on abaisse. Aucun `|| true`, aucune catégorie exemptée, aucune page
-// retirée de la liste pour faire passer la CI.
+// par un seuil que l'assistant abaisse pour faire passer la CI. Aucun `|| true`, aucune
+// catégorie exemptée, aucune page retirée de la liste : ces trois-là restent interdits,
+// sans condition ni exception.
+//
+// Un seuil peut en revanche être **révisé par le propriétaire du projet**, et cela s'est
+// produit une fois : le plancher de performance est passé de 95 à 80 le 2026-08-24, sur
+// décision de Jérôme MARICHEZ (« Pour le LCP j'autorise 80/100 mais pas moins »,
+// issue #146). Les trois autres catégories restent à 95. La révision est écrite, datée
+// et attribuée dans `scripts/budgets/pages.mjs` — c'est ce qui la sépare d'une
+// régression maquillée, et la seule forme sous laquelle un seuil bouge ici.
+//
+// 80 est un plancher, pas une cible : le rapport distingue donc trois états, et un score
+// qui passe sans atteindre 95 se lit comme tel.
 
 import puppeteer from 'puppeteer'
 import { analyserPage } from './budgets/mesure-axe.mjs'

--- a/scripts/budgets/mesure-lighthouse.mjs
+++ b/scripts/budgets/mesure-lighthouse.mjs
@@ -1,14 +1,14 @@
 // mesure-lighthouse.mjs — jeromemarichez-fr
 //
-// Mesure Lighthouse d'une page servie, et verdict par rapport aux seuils du
-// `CLAUDE.md` (voir `scripts/budgets/pages.mjs`).
+// Mesure Lighthouse d'une page servie, et verdict par rapport aux planchers bloquants
+// et aux cibles déclarés dans `scripts/budgets/pages.mjs`.
 //
 // Le navigateur est fourni par l'appelant : lancer un Chrome par page coûterait plus
 // cher que la mesure elle-même, et ferait diverger les conditions d'exécution entre
 // deux pages du même rapport.
 
 import lighthouse from 'lighthouse'
-import { SEUILS_LIGHTHOUSE } from './pages.mjs'
+import { evaluerScores, SEUILS_LIGHTHOUSE } from './pages.mjs'
 
 /**
  * Profil de mesure. Mobile émulé et réseau bridé : c'est le cas défavorable, celui que
@@ -69,9 +69,9 @@ export async function mesurerPage({ page, url, portDebogage }) {
     scores[categorie] = mediane(brut)
   }
 
-  const echecs = Object.entries(SEUILS_LIGHTHOUSE)
-    .filter(([categorie, seuil]) => scores[categorie] < seuil)
-    .map(([categorie, seuil]) => ({ categorie, obtenu: scores[categorie], seuil }))
+  // Le verdict bloquant est calculé par `evaluerScores` : la même fonction, pure, qu'on
+  // peut soumettre à un jeu de scores fictif pour vérifier qu'elle refuse encore.
+  const echecs = evaluerScores(scores)
 
   // Les audits en échec de la catégorie performance : sans eux, un budget rouge dit
   // « c'est trop lent » sans jamais dire pourquoi, et personne ne le corrige.

--- a/scripts/budgets/pages.mjs
+++ b/scripts/budgets/pages.mjs
@@ -4,20 +4,73 @@
 // Source unique : `scripts/budgets.mjs`, la doc et la CI lisent ces valeurs, personne
 // ne les recopie.
 //
-// **Les seuils viennent du `CLAUDE.md`** (« Lighthouse ≥ 95 sur les 4 catégories »),
-// pas d'un arbitrage de confort. Les abaisser pour faire passer un contrôle est
-// explicitement interdit par la règle 8 du `CLAUDE.md` : c'est la page qu'on corrige,
-// jamais le budget. Un budget qu'on rabote ne protège plus de rien.
+// **Les seuils viennent du `CLAUDE.md` et de ses arbitrages**, pas d'un ajustement de
+// confort décidé au moment où un contrôle passe au rouge. La règle 8 du `CLAUDE.md`
+// interdit d'abaisser un seuil pour faire passer la CI : c'est la page qu'on corrige,
+// jamais le budget. Un budget qu'on rabote en douce ne protège plus de rien.
+//
+// Une révision de seuil par le propriétaire du projet n'est pas ce geste-là, à une
+// condition : qu'elle soit écrite, datée et attribuée, pour qu'on la distingue six mois
+// plus tard d'une régression maquillée. C'est le cas du plancher de performance
+// ci-dessous, et de lui seul. Ce qui reste interdit sans condition : un `|| true`, une
+// catégorie exemptée du contrôle, une page retirée de la liste mesurée.
 
 /**
- * Seuil minimal, par catégorie Lighthouse. Les quatre catégories sont contrôlées :
- * une accessibilité à 100 n'excuse pas une performance à 80.
+ * Seuil **bloquant**, par catégorie Lighthouse : sous cette valeur, le budget échoue et
+ * rien ne se livre. Les quatre catégories sont contrôlées, aucune n'est exemptée.
+ *
+ * Le plancher de **performance est à 80 depuis le 2026-08-24** : « Pour le LCP
+ * j'autorise 80/100 mais pas moins » (arbitrage de Jérôme MARICHEZ, issue #146). Les
+ * trois autres catégories ne bougent pas et restent à 95 : une performance tolérée à 82
+ * n'excuse aucune régression d'accessibilité, de bonnes pratiques ou de SEO.
  */
 export const SEUILS_LIGHTHOUSE = {
+  performance: 80,
+  accessibility: 95,
+  'best-practices': 95,
+  seo: 95,
+}
+
+/**
+ * Ce qu'on **vise**, par catégorie. « Mais pas moins » dit que 80 est un plancher, pas
+ * une cible : le site vend la performance tenue, et un score qui passe le plancher sans
+ * atteindre 95 doit se voir dans le rapport au lieu de se confondre avec un score
+ * confortable. Un écart entre la cible et le plancher ne bloque pas, il signale.
+ */
+export const CIBLES_LIGHTHOUSE = {
   performance: 95,
   accessibility: 95,
   'best-practices': 95,
   seo: 95,
+}
+
+/**
+ * Les trois états d'un score, dans l'ordre de gravité. `echec` seul fait échouer le
+ * budget ; `sousCible` passe le plancher mais reste sous la cible ; `tenu` est le score
+ * confortable.
+ *
+ * @param {string} categorie
+ * @param {number} score
+ * @returns {'echec' | 'sousCible' | 'tenu'}
+ */
+export function classerScore(categorie, score) {
+  if (score < SEUILS_LIGHTHOUSE[categorie]) return 'echec'
+  if (score < CIBLES_LIGHTHOUSE[categorie]) return 'sousCible'
+  return 'tenu'
+}
+
+/**
+ * Le verdict bloquant d'une page : la liste des catégories sous leur plancher, vide
+ * quand le budget est tenu. Fonction pure, sans Lighthouse ni navigateur, pour qu'on
+ * puisse lui soumettre un jeu de scores et vérifier qu'elle refuse encore ce qu'elle
+ * doit refuser.
+ *
+ * @param {Record<string, number>} scores
+ */
+export function evaluerScores(scores) {
+  return Object.entries(SEUILS_LIGHTHOUSE)
+    .filter(([categorie, seuil]) => scores[categorie] < seuil)
+    .map(([categorie, seuil]) => ({ categorie, obtenu: scores[categorie], seuil }))
 }
 
 /**

--- a/scripts/budgets/rapport.mjs
+++ b/scripts/budgets/rapport.mjs
@@ -2,8 +2,12 @@
 //
 // Mise en forme des résultats de budget. Un budget qui échoue doit dire **lequel** et
 // **sur quelle page** : un « échec » sans chiffre se contourne, un chiffre se corrige.
+//
+// Trois états, pas deux : le plancher de performance (80) n'est pas la cible (95), et un
+// 85 qui s'afficherait comme un 97 laisserait filer une dérive jusqu'au jour où elle
+// bloque. Ce qui passe le plancher sans atteindre la cible se lit d'un coup d'œil.
 
-import { SEUILS_LIGHTHOUSE } from './pages.mjs'
+import { CIBLES_LIGHTHOUSE, classerScore, SEUILS_LIGHTHOUSE } from './pages.mjs'
 
 const CATEGORIES = Object.keys(SEUILS_LIGHTHOUSE)
 const ETIQUETTES = {
@@ -12,6 +16,10 @@ const ETIQUETTES = {
   'best-practices': 'Bonnes prat.',
   seo: 'SEO',
 }
+
+// Une marque par état. `~` se distingue de `✓` sans crier comme `✗` : le score passe, il
+// ne se célèbre pas.
+const MARQUES = { tenu: '✓', sousCible: '~', echec: '✗' }
 
 const cadrer = (texte, largeur) => String(texte).padEnd(largeur)
 
@@ -23,14 +31,43 @@ export function afficherTableauLighthouse(resultats) {
   for (const resultat of resultats) {
     const cellules = CATEGORIES.map((categorie) => {
       const score = resultat.scores[categorie]
-      const marque = score < SEUILS_LIGHTHOUSE[categorie] ? '✗' : '✓'
-      return cadrer(`${marque} ${score}`, 12)
+      return cadrer(`${MARQUES[classerScore(categorie, score)]} ${score}`, 12)
     })
     console.log([cadrer(resultat.page.id, largeurId), ...cellules].join(' │ '))
   }
-  console.log(
-    `\nSeuils (CLAUDE.md) : ${CATEGORIES.map((c) => `${ETIQUETTES[c]} ≥ ${SEUILS_LIGHTHOUSE[c]}`).join(', ')}`,
+  const bornes = CATEGORIES.map((c) =>
+    SEUILS_LIGHTHOUSE[c] === CIBLES_LIGHTHOUSE[c]
+      ? `${ETIQUETTES[c]} ≥ ${SEUILS_LIGHTHOUSE[c]}`
+      : `${ETIQUETTES[c]} ≥ ${SEUILS_LIGHTHOUSE[c]} (cible ${CIBLES_LIGHTHOUSE[c]})`,
   )
+  console.log(`\nPlanchers bloquants : ${bornes.join(', ')}`)
+  console.log('Lecture : ✓ à la cible │ ~ passe le plancher, sous la cible │ ✗ sous le plancher')
+  afficherSousCible(resultats)
+}
+
+/**
+ * Les scores qui passent sans atteindre la cible. Ils ne font pas échouer le budget, et
+ * c'est précisément pour ça qu'ils doivent être nommés : personne ne relit un tableau
+ * vert.
+ */
+function afficherSousCible(resultats) {
+  const sous = resultats.flatMap((resultat) =>
+    CATEGORIES.filter(
+      (categorie) => classerScore(categorie, resultat.scores[categorie]) === 'sousCible',
+    ).map((categorie) => ({
+      page: resultat.page.id,
+      categorie,
+      score: resultat.scores[categorie],
+    })),
+  )
+  if (sous.length === 0) return
+  console.log('\nSous la cible, plancher tenu — à corriger, pas à oublier :')
+  for (const { page, categorie, score } of sous) {
+    console.log(
+      `  ~ ${page} — ${ETIQUETTES[categorie]} : ${score}, cible ${CIBLES_LIGHTHOUSE[categorie]}` +
+        ` (plancher ${SEUILS_LIGHTHOUSE[categorie]})`,
+    )
+  }
 }
 
 export function afficherEchecsLighthouse(resultats) {


### PR DESCRIPTION
Applique l'arbitrage de Jérôme MARICHEZ du 2026-08-24 sur le seuil de performance
Lighthouse. Référence : issue #146.

## La décision, mot pour mot

> Pour le LCP j'autorise 80/100
> mais pas moins

## Ce qui change

- **Le plancher bloquant de la catégorie performance passe de 95 à 80**
  (`scripts/budgets/pages.mjs`). Sous 80, le budget échoue et rien ne se livre.
- **Le commentaire de tête est corrigé, pas laissé tel quel.** Il visait exactement ce
  geste (« le vert s'obtient par un site qui tient ses budgets, jamais par un seuil qu'on
  abaisse ») et aurait contredit le code qu'il encadre. Il dit maintenant ce qui reste
  interdit sans condition, et à quelle condition un plancher peut être révisé : par le
  propriétaire du projet, par écrit, daté et attribué. La valeur porte sa date et son
  auteur dans le fichier même, dans le style des arbitrages du `CLAUDE.md`.
- **Trois états au lieu de deux dans le rapport**, parce que 80 est un plancher et non
  une cible :

  | Marque | Ce qu'elle dit | Effet |
  |--------|----------------|-------|
  | `✓` | le score atteint la cible (95) | passe |
  | `~` | le score passe le plancher, sous la cible | passe, et il est listé nommément sous le tableau |
  | `✗` | le score est sous le plancher | échec, rien ne se livre |

  Un 85 ne peut plus se confondre avec un 97, et les scores en `~` sont repris page par
  page sous le tableau : un tableau tout vert ne se relit pas, une ligne nommée si.
- Le verdict bloquant est extrait dans `evaluerScores`, fonction pure appelée par
  `mesurerPage`, pour qu'on puisse lui soumettre un jeu de scores sans lancer Lighthouse.
- Les mentions du seuil dans `CLAUDE.md`, `README.md`, `docs/testing.md`, `docs/ci-cd.md`,
  `docs/ameliorations.md`, `docs/design.md` et le `Makefile` disent l'état réel. Les
  relevés antérieurs gardent leurs chiffres et précisent sous quel seuil ils ont été pris :
  ce sont des mesures datées, pas des règles.

## Ce qui ne change pas

- **Accessibilité, bonnes pratiques et SEO restent à 95.** Elles sont à 100 sur les sept
  pages mesurées.
- **La cible reste 95 partout**, performance comprise. 80 bloque, 95 se vise.
- **Aucun `|| true`, aucune catégorie exemptée, aucune page retirée de la mesure.** Les
  sept pages et les quatre catégories sont toujours contrôlées, à chaque passage.
- Aucun test n'est touché, aucune configuration CI n'est affaiblie.
- La preuve « Lighthouse 98/100 » du contenu publié n'est pas touchée : elle porte sur une
  plateforme SaaS livrée à un client, et elle reste vraie.

## Mesure du 2026-08-24, sept pages, `node scripts/budgets.mjs perf`

```
Page                │ Perf         │ A11y         │ Bonnes prat. │ SEO
───────────────────────────────────────────────────────────────────────
accueil             │ ~ 93         │ ✓ 100        │ ✓ 100        │ ✓ 100
pole-ingenierie-web │ ✓ 96         │ ✓ 100        │ ✓ 100        │ ✓ 100
blog                │ ✓ 97         │ ✓ 100        │ ✓ 100        │ ✓ 100
article             │ ✓ 97         │ ✓ 100        │ ✓ 100        │ ✓ 100
article-avec-source │ ✓ 97         │ ✓ 100        │ ✓ 100        │ ✓ 100
realisations        │ ✓ 97         │ ✓ 100        │ ✓ 100        │ ✓ 100
realisation         │ ✓ 97         │ ✓ 100        │ ✓ 100        │ ✓ 100

Planchers bloquants : Perf ≥ 80 (cible 95), A11y ≥ 95, Bonnes prat. ≥ 95, SEO ≥ 95
Lecture : ✓ à la cible │ ~ passe le plancher, sous la cible │ ✗ sous le plancher

Sous la cible, plancher tenu — à corriger, pas à oublier :
  ~ accueil — Perf : 93, cible 95 (plancher 80)

✓ Budget performance (Lighthouse) : tenu
```

Code de sortie 0. L'accueil à 93 apparaît bien comme « passe le plancher, sous la cible »,
et il est nommé sous le tableau. Ce sont les mêmes chiffres que le relevé de référence du
2026-08-24 sur `dev` à `72885b1`.

## Comment j'ai prouvé que le contrôle échoue encore sous 80

Deux vérifications, l'une sur la fonction, l'autre de bout en bout.

**1. Jeu de scores fictifs soumis au verdict réel.** `evaluerScores` et `classerScore`
sont les fonctions qu'utilise `mesurerPage` ; un script jetable leur passe des scores
inventés, sans redéfinir aucun seuil (il lit ceux du dépôt) :

```
planchers : { performance: 80, accessibility: 95, 'best-practices': 95, seo: 95 }
cibles    : { performance: 95, accessibility: 95, 'best-practices': 95, seo: 95 }
perf 79 (sous le plancher)      -> budget ECHEC | perf « echec »     | performance 79 < 80
perf 80 (plancher pile)         -> budget TENU  | perf « sousCible »
perf 93 (accueil mesuré)        -> budget TENU  | perf « sousCible »
perf 97 (à la cible)            -> budget TENU  | perf « tenu »
perf 0  (page cassée)           -> budget ECHEC | perf « echec »     | performance 0 < 80
a11y 94 (les autres catégories) -> budget ECHEC | perf « tenu »      | accessibility 94 < 95
```

79 échoue, 80 passe : la borne est bien à 80, inclusive. Et une accessibilité à 94 fait
toujours échouer le budget, donc la révision n'a pas déteint sur les trois autres
catégories.

**2. Chaîne complète, jusqu'au code de sortie.** Un score sous le plancher doit faire
sortir le script en 1, pas seulement noircir une cellule. Comme les sept pages sont
au-dessus de 80, j'ai reproduit la condition en portant **temporairement** le plancher à
98 en local, hors de tout commit, puis en lançant `node scripts/budgets.mjs perf` : les
sept pages passent en `✗`, chaque page est nommée avec son écart et ses audits fautifs, et
le script rend **EXIT=1**. Le fichier a été restauré à 80 avant le commit (`git status`
propre, et le diff de la PR le montre à 80).

## Vérifications

- `node scripts/budgets.mjs perf` : passe sur les sept pages, code 0.
- `make lint` : vert, aucun fichier au-dessus de 300 lignes.
- `make test` : vert (unitaire 2/2, intégration sans test).
- `grep -rn "95" CLAUDE.md README.md docs/` : toutes les mentions du seuil disent l'état
  réel.

## Test à poser par Jérôme MARICHEZ

Aucun test n'est écrit ici, conformément à la règle. `evaluerScores` et `classerScore` ont
été isolées comme fonctions pures précisément pour être testables. Intention proposée pour
un test **unitaire** (`tests/unitaire/budgets-seuils.spec.ts`), sur un jeu de scores en
dur, sans Lighthouse ni navigateur :

- `classerScore('performance', 79)` vaut `echec`, `80` vaut `sousCible`, `94` vaut
  `sousCible`, `95` et `97` valent `tenu` (les bornes, des deux côtés).
- `classerScore('accessibility', 94)` vaut `echec` et `95` vaut `tenu` : les trois autres
  catégories n'ont pas bougé.
- `evaluerScores` rend une liste vide sur `{ performance: 80, accessibility: 95,
  'best-practices': 95, seo: 95 }` et nomme la catégorie fautive avec son score et son
  seuil dès qu'une valeur passe dessous.

Ce test verrouillerait la valeur du plancher : la changer sans arbitrage le ferait échouer.

https://claude.ai/code/session_01Ku16fxvGEdhuGVgnYjXN6R
