### PR TITLE
fix: l'accueil repasse au-dessus du seuil de performance

### DIFF
--- a/docs/ameliorations.md
+++ b/docs/ameliorations.md
@@ -7,7 +7,7 @@ le bénéfice attendu et l'effort estimé.
 |---|--------------|----------|--------|--------|
 | 1 | Compression du HTML en production (`gzip` dans `docker/nginx.conf`) | Budget de performance mobile : premier levier, de loin | faible | **fait** (issue #76) — 80/81/82 → 96/97/97 |
 | 2 | Stratégie de chargement des polices (sous-ensemble, `preload`, `size-adjust`) | LCP mobile | moyen | proposé — **c'est là que se joue désormais la marge** (voir plus bas) |
-| 3 | Réduction du JavaScript inutilisé (~153 Kio) et du JavaScript hérité (~43 Kio) | Budget de performance mobile | moyen | proposé |
+| 3 | Réduction du JavaScript inutilisé (~153 Kio) et du JavaScript hérité (~43 Kio) | Budget de performance mobile | moyen | **entamé** (issue #145) : Zod sorti du groupage client, 53 Kio de moins ; le reste est chiffré plus bas et revient à l'issue #80 |
 | 4 | Préchargement RSC de toutes les routes de pôle depuis l'accueil | Bande passante mobile après le LCP | faible | proposé |
 
 ## Budget de performance — diagnostic du 2026-08-22
@@ -87,3 +87,58 @@ strict nécessaire (variable, sous-ensemble latin, axe `opsz` seul depuis le ret
 `SOFT` et `WONK`, registre monospace confié à la pile système). Alléger davantage
 suppose d'arbitrer sur le dessin — `preload` sélectif, `size-adjust`, sous-ensemble de
 glyphes — et cet arbitrage revient à Jérôme MARICHEZ, pas à un lot de performance.
+
+## Résultat : Zod sorti du groupage client le 2026-08-24 (issue #145)
+
+L'accueil était retombé à **93** après l'arrivée du formulaire de contact. La mesure a
+désigné un coupable qu'aucune des hypothèses de départ ne visait.
+
+**Le LCP de l'accueil est son `h1`** (« Je construis, j'exploite, je mesure… »), et il se
+peint, sans bridage, **145 ms** après le premier octet. Le texte n'est donc lent nulle
+part : ce sont les octets qui l'entourent qui coûtent. Lighthouse simule le lien bridé en
+imputant au LCP **tout ce qui a fini de se charger avant cette peinture**, et il y avait
+**359 Kio** dans cette fenêtre pour un document de 20 Kio et 13 Kio de feuilles de style.
+
+Le plus gros poste réductible était **Zod, livré en entier au navigateur** : 294 Kio
+bruts, 68 Kio transférés, dont Lighthouse relevait **82 % jamais exécutés**. Le schéma de
+contact est le seul du site évalué côté client (il n'y a pas de serveur), et
+`import { z } from 'zod'` importe un objet de portée dont chaque constructeur reste
+atteignable par une propriété : rien ne s'élague au groupage. `zod/mini` est le même Zod,
+même noyau, même `safeParse`, mêmes `issues`, même `z.infer`, mais ses contrôles sont des
+fonctions passées à `check()`, donc élagables. **Le morceau passe de 68 à 13 Kio
+transférés.** La règle du `CLAUDE.md` est tenue à la lettre : la validation reste un
+schéma Zod dont le type est dérivé.
+
+| Page | Perf avant | Perf après | A11y | Bonnes prat. | SEO |
+|------|-----------|-----------|------|--------------|-----|
+| **accueil** | **93** | **95** | 100 | 100 | 100 |
+| `/services/ingenierie-web/` | 96 | 96 | 100 | 100 | 100 |
+| blog | 97 | 97 | 100 | 100 | 100 |
+| article | 97 | 97 | 100 | 100 | 100 |
+| article-avec-source | 97 | 97 | 100 | 100 | 100 |
+| realisations | 97 | 97 | 100 | 100 | 100 |
+| realisation | 97 | 97 | 100 | 100 | 100 |
+
+LCP de l'accueil : **3 169 ms → 2 933 ms**, mesuré à cinq passes, écart-type 20 ms, et
+**95 aux cinq passes**. Le blocage total tombe de 86 à 9 ms au passage, le JavaScript en
+moins n'ayant plus à être analysé. Les six autres pages ne perdent rien : elles ne rendent
+pas le formulaire, donc elles ne portaient pas Zod.
+
+**Méthode.** `node scripts/budgets.mjs`, Lighthouse mobile bridé (slow 4G : 150 ms de RTT,
+1 638 kbps, processeur ÷ 4), médiane de trois passes, sept pages. Le score de la catégorie
+performance ne dépend que de cinq métriques pondérées ; sur l'accueil, quatre étaient déjà
+à 100 et **le LCP portait à lui seul tout l'écart** (73/100 avant, 80/100 après).
+
+**Le `bfcache` était un défaut du harnais, pas du site.** Les deux motifs de refus que
+Lighthouse relevait sur chaque page venaient du `Cache-Control: no-store` que
+`scripts/serve-out.mjs` posait sur toute réponse, là où `docker/nginx.conf` sert
+`immutable` sur `/_next/static/` et `must-revalidate` ailleurs. Le serveur de mesure
+reflète désormais la production, comme il le fait déjà pour la compression : le budget
+condamnait le site pour un en-tête qu'aucun visiteur ne reçoit. Sans effet sur le score
+(`bf-cache` est un diagnostic de poids nul), vérifié avant et après.
+
+**Ce qui reste, et à qui.** Après ce lot, il reste **305 Kio** dans la fenêtre du LCP,
+dont **117 Kio de react-dom et du routeur d'App Router** (plancher du cadriciel, non
+réductible sans en changer) et **116 Kio des deux `woff2`**. Ces deux postes valent
+chacun plus que tout ce qui est encore réductible dans le code applicatif, et le second
+reste un arbitrage de dessin. Le détail chiffré est reporté à l'issue **#80**.

--- a/scripts/serve-out.mjs
+++ b/scripts/serve-out.mjs
@@ -129,6 +129,31 @@ async function resoudre(racine, cheminUrl) {
 }
 
 /**
+ * `Cache-Control`, repris de `docker/nginx.conf` — même sens de dépendance que la
+ * compression : la production décide, ce fichier reflète.
+ *
+ * Ce serveur répondait `no-store` à tout, ce que nginx ne fait nulle part. La divergence
+ * n'était pas neutre pour la mesure : Lighthouse relevait sur chaque page deux motifs de
+ * refus du `bfcache` (`MainResourceHasCacheControlNoStore` et
+ * `JsNetworkRequestReceivedCacheControlNoStoreResource`), tous deux causés par cet
+ * en-tête et par lui seul. Le budget condamnait donc le site pour un défaut du harnais.
+ *
+ * Aucun effet sur le score de performance : `bf-cache` est un audit de diagnostic, de
+ * poids nul dans la catégorie, et Lighthouse vide le cache entre deux passes — mesuré
+ * avant et après, les cinq métriques pondérées ne bougent pas (issue #145).
+ */
+const ENTETES_CACHE = {
+  /** `location /_next/static/` — noms versionnés par le build, donc immuables. */
+  immuable: { 'Cache-Control': 'public, max-age=31536000, immutable' },
+  /** `location /` — le HTML se revalide, sinon une mise en production reste invisible. */
+  revalide: { 'Cache-Control': 'public, max-age=0, must-revalidate' },
+}
+
+/** L'en-tête de cache que nginx poserait sur cette URL. */
+const cachePour = (cheminUrl) =>
+  cheminUrl.startsWith('/_next/static/') ? ENTETES_CACHE.immuable : ENTETES_CACHE.revalide
+
+/**
  * Décide de la compression exactement comme nginx : le client doit l'accepter, le type
  * doit figurer dans la liste, et la réponse doit peser au moins `gzip_min_length`.
  */
@@ -172,14 +197,15 @@ export async function demarrerServeurStatique({ racine, port = PORT_PAR_DEFAUT }
 
   const serveur = createServer(async (requete, reponse) => {
     try {
+      const cheminUrl = (requete.url ?? '/').split('?')[0]
       const fichier = await resoudre(dossier, requete.url ?? '/')
       if (fichier) {
-        await envoyer(requete, reponse, 200, fichier, { 'Cache-Control': 'no-store' })
+        await envoyer(requete, reponse, 200, fichier, cachePour(cheminUrl))
         return
       }
       const page404 = await fichierExistant(join(dossier, '404.html'))
       if (page404) {
-        await envoyer(requete, reponse, 404, page404, { 'Cache-Control': 'no-store' })
+        await envoyer(requete, reponse, 404, page404, ENTETES_CACHE.revalide)
         return
       }
       reponse.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })

--- a/src/@shared/typography/fonts.ts
+++ b/src/@shared/typography/fonts.ts
@@ -12,6 +12,30 @@
 // en capitales espacées, où la personnalité d'une fonte de labeur ne se lit pas. Il est
 // donc servi par la pile système, qui coûte zéro octet : voir `--police-mono-pile` dans
 // `globals.css`.
+//
+// ## Le préchargement reste actif, et ce n'est pas par défaut d'y avoir pensé
+//
+// Les deux `woff2` préchargés pèsent 67 et 49 ko : c'est le premier poste du chemin
+// critique de l'accueil, dont le LCP est le `h1`. Trois variantes ont donc été mesurées
+// pendant l'issue #145, sur l'accueil, tout le reste égal, cinq passes chacune :
+//
+//   les deux préchargées (ce fichier)  perf 95 aux cinq passes, LCP 2 933 ms ± 20
+//   aucune préchargée                  perf 94 à 96 selon la passe, LCP 2 337 à 2 989
+//   Inter seule préchargée             perf 94 à 96 selon la passe, LCP 2 959 ms
+//
+// Retirer le préchargement fait bien tomber le LCP, mais il le fait de façon instable, et
+// la raison est mécanique : Lighthouse impute au LCP tout ce qui a fini de se charger
+// avant la peinture observée. Non préchargée, une fonte n'est demandée qu'après l'analyse
+// des feuilles de style ; elle arrive alors tantôt avant cette peinture, tantôt après, et
+// le score bascule de trois points selon le côté où elle tombe. Préchargées, les deux
+// fontes arrivent toujours du même côté : le score ne bouge plus d'une passe à l'autre.
+// Un budget qui échoue une fois sur trois au hasard se fait désactiver en une semaine.
+//
+// Surtout, le préchargement sélectif est nommément un arbitrage de dessin, au même titre
+// que le sous-ensemble de glyphes ou le `size-adjust` : il revient à Jérôme MARICHEZ et
+// pas à un lot de performance. Voir `docs/ameliorations.md` et l'issue #80, qui portent
+// déjà ce poste. Ce fichier n'a donc pas changé de comportement, il porte seulement la
+// mesure pour que la question ne se rouvre pas sans elle.
 
 import { Fraunces, Inter } from 'next/font/google'
 

--- a/src/schemas/contact.schema.ts
+++ b/src/schemas/contact.schema.ts
@@ -4,8 +4,29 @@
 // et c'est elle qui part composer une URL `mailto:`.
 //
 // Le type est dérivé du schéma (z.infer), jamais écrit à la main. Aucun cast direct.
+//
+// ## Pourquoi `zod/mini` plutôt que `zod`
+//
+// Ce schéma est le seul du site à être évalué dans le navigateur : sans serveur, la
+// validation part avec la page. Or `import { z } from 'zod'` importe un objet de portée,
+// dont chaque constructeur reste atteignable par une propriété : rien ne s'élague au
+// groupage, et le site servait donc la totalité de Zod pour trois chaînes et six bornes.
+// Mesuré sur l'accueil (issue #145) : 294 ko bruts, 68 ko transférés, dont Lighthouse
+// relevait 82 % jamais exécutés. Ces octets arrivaient avant la peinture du titre, et
+// c'est le titre qui porte le LCP.
+//
+// `zod/mini` est le même Zod : même noyau (`zod/v4/core`), même `safeParse`, mêmes
+// `issues`, même `z.infer`. Seule l'écriture change — les contrôles sont des fonctions
+// passées à `check()` au lieu de méthodes chaînées — et cette écriture-là s'élague : ne
+// part que ce qui est nommé ici. La règle du `CLAUDE.md` est tenue à la lettre, la
+// validation reste un schéma Zod dont le type est dérivé.
+//
+// L'ordre des contrôles est significatif, et il reproduit exactement l'ancien
+// `.trim().min().max()` : `trim()` d'abord, les bornes ensuite, sur la valeur nettoyée.
+// C'est aussi la valeur nettoyée qui ressort dans `data`, donc celle qui compose le
+// `mailto:`.
 
-import { z } from 'zod'
+import * as z from 'zod/mini'
 import { formatNumberFr } from '@/utils/format-number-fr'
 
 /** Bornes de saisie. Exportées : le compteur du formulaire et les tests s'y adossent. */
@@ -23,36 +44,42 @@ export const LONGUEUR_MAX_MESSAGE = 1500
  * adresse voyage déjà dans l'en-tête. La redemander produirait deux adresses susceptibles
  * de diverger, et une donnée collectée pour rien.
  *
- * `.trim()` s'applique avant les bornes : un champ rempli d'espaces est un champ vide, et
+ * `trim()` s'applique avant les bornes : un champ rempli d'espaces est un champ vide, et
  * il doit être refusé comme tel plutôt que compté comme rempli.
  */
 export const contactSchema = z.object({
   nom: z
     .string()
-    .trim()
-    .min(LONGUEUR_MIN_NOM, 'Indiquez le nom sous lequel je vous réponds.')
-    .max(
-      LONGUEUR_MAX_NOM,
-      `Ce nom dépasse ${formatNumberFr(LONGUEUR_MAX_NOM)} caractères, il faut le raccourcir.`,
+    .check(
+      z.trim(),
+      z.minLength(LONGUEUR_MIN_NOM, 'Indiquez le nom sous lequel je vous réponds.'),
+      z.maxLength(
+        LONGUEUR_MAX_NOM,
+        `Ce nom dépasse ${formatNumberFr(LONGUEUR_MAX_NOM)} caractères, il faut le raccourcir.`,
+      ),
     ),
   sujet: z
     .string()
-    .trim()
-    .min(LONGUEUR_MIN_SUJET, 'Donnez un sujet, même court : il devient l’objet du mail.')
-    .max(
-      LONGUEUR_MAX_SUJET,
-      `Ce sujet dépasse ${formatNumberFr(LONGUEUR_MAX_SUJET)} caractères. Gardez une seule ligne, le détail va dans le message.`,
+    .check(
+      z.trim(),
+      z.minLength(LONGUEUR_MIN_SUJET, 'Donnez un sujet, même court : il devient l’objet du mail.'),
+      z.maxLength(
+        LONGUEUR_MAX_SUJET,
+        `Ce sujet dépasse ${formatNumberFr(LONGUEUR_MAX_SUJET)} caractères. Gardez une seule ligne, le détail va dans le message.`,
+      ),
     ),
   message: z
     .string()
-    .trim()
-    .min(
-      LONGUEUR_MIN_MESSAGE,
-      'Le message est encore court. Quelques phrases sur votre situation suffisent.',
-    )
-    .max(
-      LONGUEUR_MAX_MESSAGE,
-      `Le message dépasse ${formatNumberFr(LONGUEUR_MAX_MESSAGE)} caractères. Résumez ici, vous complèterez dans votre client mail.`,
+    .check(
+      z.trim(),
+      z.minLength(
+        LONGUEUR_MIN_MESSAGE,
+        'Le message est encore court. Quelques phrases sur votre situation suffisent.',
+      ),
+      z.maxLength(
+        LONGUEUR_MAX_MESSAGE,
+        `Le message dépasse ${formatNumberFr(LONGUEUR_MAX_MESSAGE)} caractères. Résumez ici, vous complèterez dans votre client mail.`,
+      ),
     ),
 })
 


### PR DESCRIPTION
Ramène l'accueil de **93 à 95**, la cible, en traitant la cause plutôt qu'en déplaçant le
symptôme. Référence : issue **#145**.

## Quel élément est le LCP, et pourquoi il était lent

Le LCP de l'accueil est son **`h1`** : « Je construis, j'exploite, je mesure. Le même
interlocuteur, du cadrage au run. » Lighthouse le nomme, et le mesure à **145 ms de délai
de rendu** sans bridage. Le texte n'est donc lent nulle part.

Ce qui coûtait, ce sont les octets qui l'entourent. Lighthouse simule le lien bridé en
imputant au LCP **tout ce qui a fini de se charger avant cette peinture** : il y avait
**359 Kio** dans cette fenêtre, pour un document de 20 Kio et 13 Kio de feuilles de style.

Le plus gros poste réductible : **Zod livré en entier au navigateur**, 294 Kio bruts,
68 Kio transférés, dont Lighthouse relevait **82 % jamais exécutés**. C'est l'essentiel
des 78 Kio de « JavaScript inutilisé » listés dans l'issue. `import { z } from 'zod'`
importe un objet de portée dont chaque constructeur reste atteignable par une propriété :
rien ne s'élague au groupage.

Le formulaire était donc bien innocent de ce qu'on lui reprochait (4,4 Kio de HTML, 33 ms
d'amorçage), mais il a tiré Zod dans le groupage de l'accueil, et ces octets-là arrivaient
avant la peinture du titre. La PR #141 avait mesuré le poids du balisage et le TBT, ce qui
est précisément pourquoi elle ne pouvait pas le voir : le coût n'était ni du balisage ni du
processeur, c'était de la bande passante prise devant le LCP.

## Ce qui change

**`zod/mini` à la place de `zod`** dans `src/schemas/contact.schema.ts`. C'est le même Zod :
même noyau `zod/v4/core`, même `safeParse`, mêmes `issues`, même `z.infer`. Seule
l'écriture change, les contrôles deviennent des fonctions passées à `check()`, et cette
écriture-là s'élague. **Le morceau passe de 68 à 13 Kio transférés.** L'ordre `trim()` puis
bornes est identique à l'ancien `.trim().min().max()`, et c'est toujours la valeur nettoyée
qui ressort dans `data`, donc celle qui compose le `mailto:`. La règle du `CLAUDE.md` est
tenue à la lettre : la validation reste un schéma Zod dont le type est dérivé.

**Le `bfcache` était un défaut du harnais, pas du site.** Les deux motifs de refus venaient
tous les deux du `Cache-Control: no-store` que `scripts/serve-out.mjs` posait sur toute
réponse, là où `docker/nginx.conf` sert `immutable` sur `/_next/static/` et
`must-revalidate` ailleurs. Le serveur de mesure reflète désormais la production, comme il
le fait déjà pour la compression, ce que son propre commentaire de tête demandait. **Sans
effet sur le score** : `bf-cache` est un diagnostic de poids nul, et Lighthouse vide le
cache entre deux passes. Vérifié avant et après, les cinq métriques pondérées ne bougent pas.

**`src/@shared/typography/fonts.ts` ne change pas de comportement.** Il porte seulement la
mesure des trois variantes de préchargement essayées, pour que la question ne se rouvre pas
sans elle (voir plus bas).

## Les sept pages, avant et après

`node scripts/budgets.mjs`, Lighthouse mobile bridé, médiane de trois passes.

| Page | Perf avant | Perf après | A11y | Bonnes prat. | SEO |
|------|-----------|-----------|------|--------------|-----|
| **accueil** | **93** | **95** | 100 | 100 | 100 |
| pole-ingenierie-web | 96 | 96 | 100 | 100 | 100 |
| blog | 97 | 97 | 100 | 100 | 100 |
| article | 97 | 97 | 100 | 100 | 100 |
| article-avec-source | 97 | 97 | 100 | 100 | 100 |
| realisations | 97 | 97 | 100 | 100 | 100 |
| realisation | 97 | 97 | 100 | 100 | 100 |

**LCP de l'accueil : 3 169 ms → 2 933 ms.** Le blocage total tombe de 86 à 9 ms au passage,
le JavaScript en moins n'ayant plus à être analysé. Sur l'accueil, quatre des cinq métriques
pondérées étaient déjà à 100 : **le LCP portait à lui seul tout l'écart** (73/100 avant,
80/100 après).

Aucune des six autres pages ne perd de point : elles ne rendent pas le formulaire, donc
elles ne portaient pas Zod. `axe-core` reste à **0 violation bloquante sur les sept pages**,
et les trois autres catégories à 100.

Vérification complète, sur les seuils à 95 pour les quatre catégories : `EXIT=0`.

## Ce que j'ai mesuré et écarté

**Le préchargement des polices**, essayé en trois variantes, cinq passes chacune, sur
l'accueil, tout le reste égal :

| Variante | Score | LCP |
|---|---|---|
| les deux préchargées (retenu) | **95 aux cinq passes** | 2 933 ms ± 20 |
| aucune préchargée | 94 à 96 selon la passe | 2 337 à 2 989 ms |
| Inter seule préchargée | 94 à 96 selon la passe | 2 959 ms |

Retirer le préchargement fait bien tomber le LCP, mais de façon **instable**, et la raison
est mécanique : non préchargée, une fonte n'est demandée qu'après l'analyse des feuilles de
style, donc elle arrive tantôt avant la peinture observée, tantôt après, et le score
bascule de trois points selon le côté où elle tombe. Préchargées, les deux fontes tombent
toujours du même côté. Un budget qui échoue une fois sur trois au hasard se fait désactiver
en une semaine.

Et surtout, `docs/ameliorations.md` et l'issue #80 nomment déjà le **`preload` sélectif**
comme un arbitrage de dessin qui revient à Jérôme MARICHEZ. Je ne l'ai donc pas pris.

**Le rendu différé du formulaire** (piste 2) n'a pas été nécessaire, et il aurait été un
mauvais marché : il ne retire que 13 Kio, au prix d'un formulaire qui disparaît du HTML
servi. **La route `/contact` dédiée** (piste 3) n'a pas été approchée : le formulaire reste
sur l'accueil.

**Aucun seuil n'a été abaissé** par cette PR. `scripts/budgets.mjs`, `scripts/budgets/pages.mjs`
et les workflows ne sont pas touchés.

## Ce qui reste, et ce qui part à l'issue #80

Après ce lot, il reste **305 Kio** dans la fenêtre du LCP :

- **117 Kio de react-dom et du routeur d'App Router**, plancher du cadriciel : une page
  d'App Router les embarque même sans aucun composant client. Non réductible sans changer
  de cadriciel.
- **116 Kio des deux `woff2`**, déjà nommés comme le premier poste par l'issue #80, et qui
  restent un arbitrage de dessin.
- **13 Kio de JavaScript hérité** (`Array.prototype.at`, `Object.fromEntries`, `Object.hasOwn`…)
  situés **dans le paquet précompilé de react-dom**. Next 16 vise déjà `chrome 111+` par
  défaut : un `browserslist` plus moderne ne les enlèverait pas.
- **Les quatre feuilles de style bloquantes** (300 ms annoncés) : `experimental.cssChunking`
  est déjà sur la valeur qui fusionne le plus sous Turbopack, les autres valeurs sont
  réservées à webpack ou produisent davantage de requêtes.

Les chiffres sont reportés en commentaire sur l'issue **#80**.

## Test à poser par Jérôme MARICHEZ

Aucun fichier de test n'est créé ici, conformément à la règle. Intentions proposées, niveau
**unitaire**, sur `tests/unitaire/contact-schema.spec.ts`, avec le jeu de données existant
`tests/fixtures/contact.fixture.json` :

- **Le passage à `zod/mini` ne change aucun comportement observable.** `contactSchema.safeParse`
  refuse un `nom` de 1 caractère et l'accepte à 2 ; refuse un `sujet` à 2 et l'accepte à 3 ;
  refuse un `message` à 19 et l'accepte à 20 ; refuse à 81, 121 et 1 501 caractères. Les
  bornes des deux côtés, sur les trois champs.
- **`trim()` s'applique avant les bornes.** Un champ rempli de trois espaces est refusé
  comme vide, avec le message de longueur minimale et non un autre.
- **La valeur nettoyée est celle qui ressort.** `safeParse({ nom: '  Jérôme  ' })` rend
  `'Jérôme'` dans `data`, donc c'est elle qui compose le `mailto:` en aval.
- **Le message d'erreur est bien celui du schéma**, pour chaque borne : c'est ce que l'écran
  affiche, et une bascule de bibliothèque est exactement le genre de changement qui peut le
  remplacer par un message générique en anglais sans que rien d'autre ne bouge.

Un test au niveau **système** serait aussi défendable sur le harnais de mesure, pour
verrouiller le correctif du `bfcache` : `scripts/serve-out.mjs` répond
`public, max-age=31536000, immutable` sur une URL sous `/_next/static/` et
`public, max-age=0, must-revalidate` sur `/`, et **jamais** `no-store` sur aucune des deux.
C'est la propriété qui empêcherait la divergence avec `docker/nginx.conf` de revenir.

## Vérifications

- `npm ci && npm run build && node scripts/budgets.mjs` : les sept pages passent sur les
  quatre catégories, `EXIT=0`.
- `make lint` : mes trois fichiers sont propres. Signalé à part, sans rapport avec cette PR :
  Biome est invoqué en version flottante (`@biomejs/biome@^2.0.0`) et la 2.5.7 fait
  désormais échouer `lint/performance/noImgElement` sur
  `src/@vitrine/components/CertificationList/index.tsx`, un fichier que cette PR ne touche
  pas. Le défaut est déjà sur `dev`.
- `make test` : vert (unitaire 2/2, intégration sans test).
- `npx tsc --noEmit` : vert.

`Closes #145` n'est pas écrit : les PR visent `dev`, la branche par défaut est `main`, et la
référence ne fermerait rien ici. L'issue est à fermer à la main.

https://claude.ai/code/session_01Ku16fxvGEdhuGVgnYjXN6R
