### PR TITLE
fix: plus de tiret cadratin dans les textes destines a etre lus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@ Site portfolio et vitrine de services de Jérôme Marichez, ingénieur logiciel 
 Le site raconte un parcours (ingénieur logiciel, 9 ans, passé par la chefferie de projet
 et l'AMOA) et vend quatre pôles qui s'appuient dessus. Promesse centrale, à faire
 apparaître partout : **un seul interlocuteur humain pour vos projets digitaux, du cadrage
-au run** — celui qui cadre est celui qui code, mesure et exploite, et il répond de tout.
+au run**. Celui qui cadre est celui qui code, mesure et exploite, et il répond de tout.
 La promesse porte sur l'**interlocuteur** et la **responsabilité**, jamais sur l'absence
-totale de tiers : sur un projet dont la taille le demande — c'est rare — Jérôme peut
+totale de tiers : sur un projet dont la taille le demande (c'est rare), Jérôme peut
 s'entourer de prestataires qu'il choisit, cadre et dont il répond.
 
-### Le modèle de l'offre — quatre pôles, un embranchement
+### Le modèle de l'offre : quatre pôles, un embranchement
 
 ```
 Ingénierie web  →  DATA  →  ( IA  et/ou  SEA & UX )
@@ -84,7 +84,7 @@ les certifications, l'arborescence des pages, les contraintes SEO / perf / a11y 
 est décrit dans le [`README.md`](./README.md) : c'est la **source de vérité du contenu**.
 Ce fichier-ci porte les règles qui encadrent la façon de l'écrire et de le développer.
 
-**Stack** : TypeScript — Next.js (App Router) (front) ; Node.js/TypeScript (back le cas
+**Stack** : TypeScript, avec Next.js (App Router) côté front ; Node.js/TypeScript (back le cas
 échéant) ; **Zod** pour la validation des entrées.
 
 **Contraintes produit non négociables** : rendu statique ou ISR et métadonnées par page
@@ -113,22 +113,22 @@ considération marketing.
 
 | Interdit | Formulation juste |
 |----------|-------------------|
-| « aucune sous-traitance », « 0 sous-traitant », toute promesse d'**absence totale de tiers** | **Un seul interlocuteur, du cadrage au run, qui répond de tout.** Aucune couche commerciale, aucun transfert de dossier, l'interlocuteur ne change pas. Sur un projet dont la taille le demande — **c'est rare, et la rareté se dit** — des prestataires viennent en renfort : Jérôme les choisit, les cadre et en répond ; le client ne gère personne d'autre que lui. *(Règle mise à jour à la demande explicite de Jérôme MARICHEZ, issue #40.)* |
-| ISTQB niveau **Avancé** / Automatisation de test | **ISTQB Foundation** uniquement — l'Avancé n'est pas obtenu |
+| « aucune sous-traitance », « 0 sous-traitant », toute promesse d'**absence totale de tiers** | **Un seul interlocuteur, du cadrage au run, qui répond de tout.** Aucune couche commerciale, aucun transfert de dossier, l'interlocuteur ne change pas. Sur un projet dont la taille le demande (**c'est rare, et la rareté se dit**), des prestataires viennent en renfort : Jérôme les choisit, les cadre et en répond ; le client ne gère personne d'autre que lui. *(Règle mise à jour à la demande explicite de Jérôme MARICHEZ, issue #40.)* |
+| ISTQB niveau **Avancé** / Automatisation de test | **ISTQB Foundation** uniquement : l'Avancé n'est pas obtenu |
 | Management, lead ou mentorat de **développeurs** | Encadrement d'**équipes marketing / SEO-SEA, de prestataires externes, d'alternants et de stagiaires**. Titre réel : « Lead Tech » chez MailingVox (équipe de 2 devs + 1 PO) |
 | « en collaboration avec l'Universitat de Barcelona » | Méthode d'extraction audio **publiée sur arXiv**, qu'il a **implémentée lui-même** puis industrialisée |
 | LangChain, LlamaIndex, tout **framework** RAG | Le **RAG comme technique** est confirmé (recherche vectorielle PostgreSQL + API OpenAI), fait **maison** |
 | AppsFlyer, Adjust, Amplitude, Tealium, Adobe Launch / Analytics | Côté mobile : **Firebase Analytics et Crashlytics uniquement**. Côté web : GTM (web et server-side), Measurement Protocol, GA, Matomo, CMP |
 | Meta Ads, LinkedIn Ads | Google Ads, Bing Ads, SEO / SEA / SMA |
 | GraphQL, NestJS, Prisma, Gherkin / Cucumber, PyTorch | Voir la stack réellement revendiquée dans le `README.md` |
-| Cluster **Kubernetes** administré en propre | Cloud Run, VM Compute Engine **auto-scalées**, cloud functions, Pub/Sub, Vertex AI — l'absence de K8s se dit telle quelle, c'est un argument de lucidité |
+| Cluster **Kubernetes** administré en propre | Cloud Run, VM Compute Engine **auto-scalées**, cloud functions, Pub/Sub, Vertex AI. L'absence de K8s se dit telle quelle, c'est un argument de lucidité |
 | GTM attribué à la période **Verhoeven Joaillier** | GTM appartient à la période **Acetelecom / MailingVox**. Chez Verhoeven : Google Analytics, A/B testing, heatmaps |
 
 **Points de vigilance supplémentaires :**
 
 - **Prézage** et **Llama 3** peuvent être **nommés** (autorisation explicite de Jérôme,
   2026-08-07). Restent hors ligne : le contenu du corpus, les données, les chiffres du
-  projet — le NDA couvre ceux-là.
+  projet. Le NDA couvre ceux-là.
 - Les **intitulés de poste historiques** (Verhoeven Joaillier, Truffle Capital) sont
   repris **à l'identique des CV**, sans réécriture pour coller à une offre de service.
 - Toute **certification affichée doit pointer vers son justificatif officiel**. Une URL
@@ -137,12 +137,12 @@ considération marketing.
   un lien mort.
 - Deux points de certification ont été **arbitrés par Jérôme MARICHEZ le 2026-08-20**, et
   ne sont donc plus à rouvrir : la certification **Google Ads est datée de 2021** (le CV
-  Tracking Specialist indiquait 2022 — c'est 2021 qui fait foi), et la certification
+  Tracking Specialist indiquait 2022, mais c'est 2021 qui fait foi), et la certification
   **Microsoft Ads est confirmée**, sans année connue : elle s'affiche donc sans millésime.
   `README.md` et `src/contenu/certifications.ts` appliquent déjà cet arbitrage.
 - Les **CV de référence** vivent dans `/Users/nicolasb/Documents/CV/`
   (`cv-ingenieur-fullstack.md`, `cv-ai-engineer.md`, `cv-tracking-specialist.md`) : en cas
-  de doute sur un chiffre, une date ou un périmètre, ce sont eux qui font foi — pas la
+  de doute sur un chiffre, une date ou un périmètre, ce sont eux qui font foi, pas la
   mémoire de l'assistant.
 
 ## Ligne éditoriale
@@ -179,7 +179,7 @@ considération marketing.
 
   Il propose une réécriture ; le premier agent l'intègre ou motive son refus dans la PR.
   *(Règle ajoutée à la demande explicite de Jérôme MARICHEZ, 2026-08-23.)*
-- **Le développement en IA augmentée** (Claude Code / Gemini — agents, hooks, skills,
+- **Le développement en IA augmentée** (Claude Code / Gemini : agents, hooks, skills,
   loop, serveurs MCP) **piloté par les tests (TDD)** est un différenciateur assumé : il
   apparaît partout où le site parle de programmation, jamais comme un détail
   d'outillage.
@@ -190,8 +190,8 @@ Le projet suit **toujours** un modèle à deux branches permanentes :
 
 | Branche | Rôle |
 |---------|------|
-| `main`  | Branche de **production** — code stable, déployable, jamais cassé. |
-| `dev`   | Branche d'**intégration** — développement courant, base des nouvelles fonctionnalités. |
+| `main`  | Branche de **production** : code stable, déployable, jamais cassé. |
+| `dev`   | Branche d'**intégration** : développement courant, base des nouvelles fonctionnalités. |
 
 ### Règles
 
@@ -207,16 +207,16 @@ Le projet suit **toujours** un modèle à deux branches permanentes :
    son type (`bug`, `feature`, `documentation`, `autre`) : le **template d'issue
    commun** du dépôt (`.github/ISSUE_TEMPLATE/issue.md` ou
    `.gitlab/issue_templates/issue.md`) est rempli intégralement, titre au format
-   `<type>: <résumé court>`, **jamais d'emoji** — pas d'issue en texte libre.
-5. **Fusion d'une PR — la nuance `dev` vs `main`.**
-   - **Vers `dev`** : dès que **tous les checks CI sont au vert**, la fusion est **autorisée en auto-merge** — l'assistant **peut fusionner lui-même** la PR.
-   - **Vers `main`** (mise en production) : passe **obligatoirement** par le skill `/merge-prod` — PR ouverte et remplie par l'assistant après vérification de la CI de `dev`, mais **l'assistant n'a PAS le droit de la fusionner** — seule une **validation humaine** (Jérôme MARICHEZ) peut merger dans `main`.
+   `<type>: <résumé court>`, **jamais d'emoji**. Pas d'issue en texte libre.
+5. **Fusion d'une PR : la nuance `dev` vs `main`.**
+   - **Vers `dev`** : dès que **tous les checks CI sont au vert**, la fusion est **autorisée en auto-merge**. L'assistant **peut fusionner lui-même** la PR.
+   - **Vers `main`** (mise en production) : passe **obligatoirement** par le skill `/merge-prod`. PR ouverte et remplie par l'assistant après vérification de la CI de `dev`, mais **l'assistant n'a PAS le droit de la fusionner**. Seule une **validation humaine** (Jérôme MARICHEZ) peut merger dans `main`.
 6. **Hotfix** : `hotfix/<nom>` depuis `main`, fusionné dans `main` **et** `dev`.
 7. **`main` est une branche protégée** : push direct interdit, PR obligatoire, checks CI au vert, revue approuvée. Détails : [`docs/git-workflow.md`](./docs/git-workflow.md).
-8. **Intégrité des contrôles — aucun truquage.** L'assistant ne doit **jamais** modifier, désactiver, supprimer, ignorer (`skip`/`xfail`) ou affaiblir un **test**, une **assertion**, ni un **fichier de configuration CI/CD** (workflows, seuils de couverture, linters, limite de lignes…) dans le but de faire passer artificiellement la CI ou de masquer une régression. Les checks passent au vert **par une correction réelle du code**. Une évolution légitime d'un test reste possible, mais doit être **justifiée et documentée** dans la PR.
-9. **Pipeline verte avant toute publication.** Aucun `git push` vers `main`/`dev`, aucune fusion de PR, aucun tag, aucune release, aucun `npm publish` tant que la pipeline du **commit courant** n'est pas **verte** — le hook `check-ci-before-publish.sh` interroge GitHub Actions (ou GitLab CI) et refuse une pipeline rouge **ou en cours**. Les contournements (`--no-verify`, `[skip ci]`, `gh pr merge --admin`, `gh run cancel`, `continue-on-error: true`, `allow_failure: true`, `|| true` sur un test) sont refusés sans condition. Détails : [`docs/ci-cd.md`](./docs/ci-cd.md).
+8. **Intégrité des contrôles : aucun truquage.** L'assistant ne doit **jamais** modifier, désactiver, supprimer, ignorer (`skip`/`xfail`) ou affaiblir un **test**, une **assertion**, ni un **fichier de configuration CI/CD** (workflows, seuils de couverture, linters, limite de lignes…) dans le but de faire passer artificiellement la CI ou de masquer une régression. Les checks passent au vert **par une correction réelle du code**. Une évolution légitime d'un test reste possible, mais doit être **justifiée et documentée** dans la PR.
+9. **Pipeline verte avant toute publication.** Aucun `git push` vers `main`/`dev`, aucune fusion de PR, aucun tag, aucune release, aucun `npm publish` tant que la pipeline du **commit courant** n'est pas **verte**. Le hook `check-ci-before-publish.sh` interroge GitHub Actions (ou GitLab CI) et refuse une pipeline rouge **ou en cours**. Les contournements (`--no-verify`, `[skip ci]`, `gh pr merge --admin`, `gh run cancel`, `continue-on-error: true`, `allow_failure: true`, `|| true` sur un test) sont refusés sans condition. Détails : [`docs/ci-cd.md`](./docs/ci-cd.md).
 10. **Pas d'auto-modification des règles.** L'assistant ne modifie **jamais** ce `CLAUDE.md`, un skill, un hook ou toute règle du projet **pour contourner** les consignes. Toute évolution de ces règles se fait à la demande explicite de Jérôme MARICHEZ.
-11. **CI en échec — corriger puis escalader.** L'assistant retente 2 à 3 fois en corrigeant réellement, puis **signale à Jérôme MARICHEZ** avec un diagnostic clair si le blocage persiste.
+11. **CI en échec : corriger puis escalader.** L'assistant retente 2 à 3 fois en corrigeant réellement, puis **signale à Jérôme MARICHEZ** avec un diagnostic clair si le blocage persiste.
 
 ## Politique de tests
 
@@ -234,12 +234,12 @@ Référence complète : [`docs/testing.md`](./docs/testing.md). Convention d'emp
 nommage `*.test.js|ts`, runner Node natif (`make test-acceptance`).
 
 La **qualité** des tests unitaires/intégration est mesurée par **Stryker**
-(mutation testing, `make test-mutation`) — ne jamais abaisser ses seuils.
+(mutation testing, `make test-mutation`). Ne jamais abaisser ses seuils.
 
 Règles :
 
 - **Le test précède le code.** Avant d'écrire une ligne d'implémentation, le
-  comportement attendu est couvert par un test — **au moins l'un des trois niveaux**
+  comportement attendu est couvert par un test, **au moins l'un des trois niveaux**
   (unitaire, intégration, système) selon ce que le comportement exige ; l'unitaire est
   le minimum dès qu'il y a de la logique. Le hook `require-test-first.sh` demande
   confirmation dès qu'un fichier source qu'aucun test ne couvre est écrit.
@@ -248,16 +248,16 @@ Règles :
   visé, jeu de données utilisé) et le contenu qu'il propose ; Jérôme MARICHEZ pose le
   fichier. Le hook refuse toute écriture d'un fichier de test par l'assistant.
   Délégation ponctuelle possible par Jérôme MARICHEZ (`TESTS_WRITABLE_BY_ASSISTANT=1` dans
-  l'environnement de la session) — et même alors, le test doit porter en tête un bloc
+  l'environnement de la session). Et même alors, le test doit porter en tête un bloc
   **`Intention : …`**. Les **jeux de données** ne sont pas des tests : l'assistant
   peut les préparer.
 - **Le code s'adapte au test, jamais l'inverse.** Faire passer un test ne justifie
   **jamais** d'en modifier l'intention (assertions affaiblies, cas supprimé, `skip`).
-  Si un test paraît faux, le signaler à Jérôme MARICHEZ — ne pas le réécrire.
+  Si un test paraît faux, le signaler à Jérôme MARICHEZ. Ne pas le réécrire.
 - **Intégration / e2e** : vérifier d'abord si un test pertinent existe ; sinon, si le
   composant le justifie (frontière API, accès base, auth ; parcours utilisateur critique
   pour e2e), **proposer** son intention à Jérôme MARICHEZ.
-- **Pas de mocks — des jeux de données.** Aucune doublure de module (`jest.mock`,
+- **Pas de mocks : des jeux de données.** Aucune doublure de module (`jest.mock`,
   `vi.mock`, `__mocks__`, `sinon.stub`, `mockResolvedValue`…) : les vrais services
   collaborent entre eux et tournent sur des **jeux de données réalistes** versionnés
   dans `tests/fixtures/` (`<entite>.fixture.json`). Seules les **frontières** se
@@ -267,7 +267,7 @@ Règles :
   applique la règle.
 - Les tests **conditionnent la fusion** vers `dev`.
 
-## Versionnage — Semantic Versioning
+## Versionnage : Semantic Versioning
 
 Le projet respecte **toujours** la convention **SemVer** (`MAJEUR.MINEUR.CORRECTIF`) :
 version dans `package.json` (point de vérité), releases taguées `vX.Y.Z`, incrément
@@ -282,7 +282,7 @@ indisponible) est **refusé**.
 
 ## Qualité du code
 
-- **Lint** : Biome (`make lint`) — la CI échoue si le lint échoue.
+- **Lint** : Biome (`make lint`). La CI échoue si le lint échoue.
 - **Limite de taille** : **aucun fichier source ne dépasse 300 lignes**
   (`scripts/check-max-lines.sh`, vérifié par hook local et par la CI).
   Si un fichier approche la limite : **extraire** (sous-composants, hooks, services),
@@ -299,15 +299,15 @@ indisponible) est **refusé**.
 - **Séparation métier / rendu (front)** : le front a **toujours** un dossier
   `services/` qui porte la **logique métier** (classes/fonctions pures, appels API,
   règles de gestion) ; les **hooks React** (`use-*.ts`) ne gèrent que la **logique de
-  rendu** (état d'UI, abonnements, orchestration des services pour les composants) —
-  jamais de règle métier dans un hook ou un composant.
+  rendu** (état d'UI, abonnements, orchestration des services pour les composants).
+  Jamais de règle métier dans un hook ou un composant.
 - **`utils/`** : un dossier `src/utils/` regroupe **toujours**
   les **utilitaires** transverses (formatage, helpers purs, sans état ni métier).
 - **Interfaces et types** : toutes les **interfaces d'entités** vivent dans le dossier
   `src/interfaces/` (un fichier par entité) et leur nom **commence toujours par `I`**
   (`IProduct`, `IUser`…). Les **alias de types purs** (unions, utilitaires) vont dans
-  `src/interfaces/types.ts` — uniquement des `type`, jamais d'interface.
-- **Validation des entrées — Zod (obligatoire)** : toute entrée externe (body/query
+  `src/interfaces/types.ts` : uniquement des `type`, jamais d'interface.
+- **Validation des entrées avec Zod (obligatoire)** : toute entrée externe (body/query
   d'API, formulaire, webhook, variables d'environnement) est validée par un schéma
   **Zod** avant usage. Les schémas vivent dans `schemas/` (un fichier par entité,
   `product.schema.ts` ; dans `shared/schemas/` si partagé front-back) et les types
@@ -357,14 +357,14 @@ Trois skills **obligatoires** encadrent le cycle de vie :
 |-------|-------|
 | `/create-issue` | **Obligatoire** pour créer toute issue (`bug`, `feature`, `documentation`, `autre`) : template d'issue commun rempli intégralement, titre `<type>: <résumé>`, jamais d'emoji. |
 | `/create-feat` | **Obligatoire** pour démarrer toute fonctionnalité : issue (via `/create-issue`) → branche depuis `dev` → worktree → subagent dédié → PR vers `dev`. |
-| `/merge-prod` | **Obligatoire** pour toute mise en production : vérifier la CI de `dev`, ouvrir la PR `dev` → `main`, surveiller les checks — **sans jamais merger** (validation humaine). |
+| `/merge-prod` | **Obligatoire** pour toute mise en production : vérifier la CI de `dev`, ouvrir la PR `dev` → `main`, surveiller les checks, **sans jamais merger** (validation humaine). |
 
 Ajouter ici les procédures récurrentes du projet (build, déploiement, fixes connus).
 
 ## Routage de modèles (subagents `.claude/agents/`)
 
 Le hook `route-task.sh` (UserPromptSubmit) classifie chaque demande et **recommande**
-un subagent adapté — voir [`docs/model-routing.md`](./docs/model-routing.md) :
+un subagent adapté (voir [`docs/model-routing.md`](./docs/model-routing.md)) :
 
 | Subagent | Modèle / effort | Tâches |
 |----------|-----------------|--------|

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 Site portfolio et vitrine de services de **Jérôme Marichez**, ingénieur-conseil indépendant à Lille :
 ingénierie web, data, IA, SEA & UX.
 
-**Stack** : TypeScript — Next.js (App Router).
+**Stack** : TypeScript, avec Next.js (App Router).
 
-Le site a deux fonctions et une seule promesse. Il **raconte un parcours** — ingénieur
-logiciel, 9 ans, passé par la chefferie de projet et l'AMOA — et il **vend une chaîne à quatre pôles**
+Le site a deux fonctions et une seule promesse. Il **raconte un parcours** (ingénieur
+logiciel, 9 ans, passé par la chefferie de projet et l'AMOA) et il **vend une chaîne à quatre pôles**
 qui s'appuie dessus. La promesse : *un seul interlocuteur humain pour vos projets
-digitaux, du cadrage au run*. Celui qui cadre est celui qui code, mesure et exploite —
+digitaux, du cadrage au run*. Celui qui cadre est celui qui code, mesure et exploite,
 et il répond de tout.
 
 Ce que la promesse **n'engage pas** : l'absence totale de tiers. Sur un projet dont la
-taille le demande — c'est rare — Jérôme s'entoure de prestataires qu'il choisit, qu'il
+taille le demande (c'est rare), Jérôme s'entoure de prestataires qu'il choisit, qu'il
 cadre et dont il répond. Le client, lui, ne gère personne d'autre que lui : aucune couche
 commerciale, aucun transfert de dossier, l'interlocuteur ne change pas. La page d'accueil
 le dit explicitement dans la section « Et si le projet dépasse une personne ? ».
@@ -35,7 +35,7 @@ décision rendue possible. Chaque bloc de service se termine sur ce que le clien
 
 ---
 
-## 🧩 Les quatre pôles — une chaîne qui s'embranche
+## 🧩 Les quatre pôles : une chaîne qui s'embranche
 
 *(Modèle arbitré par Jérôme MARICHEZ le 2026-08-21.)*
 
@@ -46,7 +46,7 @@ Ingénierie web  →  DATA  →  ( IA  et/ou  SEA & UX )
 Ce ne sont **pas quatre offres posées côte à côte au catalogue**, et ce n'est pas non
 plus une file de quatre étapes qu'il faudrait toutes acheter :
 
-- **Data est le passage obligé.** Ni IA ni SEA & UX ne se font sans elle — sans mesure,
+- **Data est le passage obligé.** Ni IA ni SEA & UX ne se font sans elle : sans mesure,
   l'IA devine et l'acquisition arbitre à l'aveugle.
 - **L'embranchement est inclusif.** IA seule, SEA & UX seule, ou les deux.
 - **IA et SEA & UX sont parallèles**, jamais successives. Aucun contenu, aucun visuel,
@@ -55,12 +55,12 @@ plus une file de quatre étapes qu'il faudrait toutes acheter :
 
 | Place | Pôle | Ce qu'il fait |
 |-------|------|---------------|
-| socle | **Ingénierie web** | construire le site, le SaaS, l'application mobile — et les exploiter |
+| socle | **Ingénierie web** | construire le site, le SaaS, l'application mobile, et les exploiter |
 | passage | **Data** | comprendre le métier, gouverner, bâtir ou reprendre la stratégie data, puis explorer |
-| suite | **IA** | choisir la solution — règle métier intégrée à l'existant, modèle, ou LLM |
+| suite | **IA** | choisir la solution : règle métier intégrée à l'existant, modèle, ou LLM |
 | suite | **SEA & UX** | trancher les parcours et les budgets sur la donnée, puis implémenter |
 
-### Les jointures — la dépendance est de matière, pas d'achat
+### Les jointures : la dépendance est de matière, pas d'achat
 
 Les trois arêtes du schéma sont une **entité du modèle** (`IJointure`), pas un champ du
 pôle amont : la donnée en ouvre deux, et un pôle ne peut pas porter une seule remise
@@ -72,8 +72,8 @@ sans en cacher une.
 | Data → IA | un métier formalisé, une donnée gouvernée, et la réponse au test de déterminisme : cette suite ne s'ouvre que si elle est non | la stratégie data est reprise telle quelle, elle ne se rachète pas |
 | Data → SEA & UX | la même donnée, tournée vers l'arbitrage | on arbitre dessus dès le premier jour, et rien n'oblige à prendre l'IA |
 
-Cette seconde colonne est ce qui distingue une dépendance de **matière** — vraie et
-acceptable — d'une dépendance d'**achat**, fausse et repoussante. Elle est rendue en
+Cette seconde colonne est ce qui distingue une dépendance de **matière** (vraie et
+acceptable) d'une dépendance d'**achat**, fausse et repoussante. Elle est rendue en
 tête de chaque page de pôle, là où l'objection naît.
 
 Les **charnières** du site sont le récit de ces jointures : des sections à part entière,
@@ -82,51 +82,51 @@ pourrait acheter à autant de fournisseurs différents. La chaîne n'est crédib
 parce que c'est la même personne à chaque poste : c'est l'argument de vente, pas un
 détail d'organisation.
 
-### Le fil IA — l’axe transverse
+### Le fil IA : l’axe transverse
 
 Un troisième type de section, le **fil**, traverse tous les pôles au lieu de s'insérer
 entre deux. Il lève une confusion que le site crée lui-même : l'IA y apparaît comme
 **offre** (le pôle IA) *et* comme **méthode de production** (partout). Le fil parle de la
-seconde, en quatre étapes — concevoir, construire, livrer, piloter — et se place avant le
+seconde, en quatre étapes (concevoir, construire, livrer, piloter) et se place avant le
 premier pôle pour que la méthode se lise avant les offres.
 
 Sa règle d'écriture est bloquante : **l'IA propose, les tests tranchent**. Le pilotage
 SEA reste attribué à la donnée et aux modèles (clustering, profilage), jamais à un agent
 autonome. Le fil ne cite aucune preuve qui ne soit déjà portée par un pôle.
 
-### Le socle — Ingénierie web
+### Le socle : Ingénierie web
 
 L'offre socle : concevoir, développer et exploiter un produit web ou mobile de bout en
 bout. Elle mobilise toutes les compétences du parcours.
 
-- **UI / UX** — maquettage et design system, catalogue de composants (Storybook),
+- **UI / UX** : maquettage et design system, catalogue de composants (Storybook),
   accessibilité **RGAA / WCAG / W3C**, refonte de parcours pilotée par la mesure
   (A/B testing, heatmaps, taux de rebond). *Preuve : panier moyen +50 % sur un
   e-commerce de joaillerie de luxe.*
-- **Front-end** — React, Next.js avec stratégie de rendu différenciée par type de page
+- **Front-end** : React, Next.js avec stratégie de rendu différenciée par type de page
   (CSR / SSR / SSG / ISR) pour arbitrer performance perçue, coût serveur et
   référencement ; Angular, Ionic (iOS / Android), Redux / Zustand / React Query,
   Tailwind, Material UI. *Preuve : Lighthouse 98/100.*
-- **Back-end** — Node.js / Express, API REST, webhooks, cloud functions, traitements
+- **Back-end** : Node.js / Express, API REST, webhooks, cloud functions, traitements
   asynchrones distribués (Google Cloud Pub/Sub), PostgreSQL (relationnel, séries
   temporelles, vectoriel), MySQL, Firebase, validation Zod.
-- **Architecture & exploitation** — arbitrage monolithe / microservices, Docker, CI/CD
+- **Architecture & exploitation** : arbitrage monolithe / microservices, Docker, CI/CD
   GitHub Actions, Google Cloud (Cloud Run, VM Compute Engine auto-scalées, cloud
   functions, Pub/Sub), Vercel, serveurs on-premise et IaaS. SLI / SLO / SLA, PCA et PRA
   testés, déploiements sans interruption de service.
-- **Qualité** — développement **piloté par les tests (TDD)**, Jest, Cypress, Playwright,
+- **Qualité** : développement **piloté par les tests (TDD)**, Jest, Cypress, Playwright,
   tests de mutation (Stryker), Postman, tests de performance et de charge,
   non-régression à chaque livraison. Certification **ISTQB Foundation**.
-- **Migrations sans coupure** — PHP 5 → 7 puis réécriture Node.js, jQuery → React,
+- **Migrations sans coupure** : PHP 5 → 7 puis réécriture Node.js, jQuery → React,
   Ionic 6 → 8 et Angular 15 → 19, chacune menée sans interruption ni gel de la roadmap.
-- **Chefferie de projet & AMOA** — recueil du besoin, spécifications, **BPMN 2.0**,
+- **Chefferie de projet & AMOA** : recueil du besoin, spécifications, **BPMN 2.0**,
   cartographie SI, matrice de risques, recette et tests d'acceptation (UAT),
   coordination d'une équipe marketing de 5 à 10 personnes et de 3 prestataires.
-- **Développement en IA augmentée** — Claude Code et Gemini au quotidien (agents,
+- **Développement en IA augmentée** : Claude Code et Gemini au quotidien (agents,
   hooks, skills, loop, serveurs MCP internes), piloté par les tests. Vélocité
   augmentée à effectif constant.
 
-### Le passage obligé — Data
+### Le passage obligé : Data
 
 **L'ordre est le contenu.** Ce pôle ne part pas de la technique, il y arrive. On comprend
 d'abord le métier, on gouverne ensuite, on bâtit alors la stratégie data, et on finit sur
@@ -157,47 +157,47 @@ qui on évite une dépense inutile, jamais un projet raté.
 Le test ne gouverne que la suite IA. **Le SEA & UX ne l'attend pas** : les deux suites
 restent parallèles et de rang égal.
 
-C'est aussi le pôle par lequel tout passe — et celui qui **se livre pour lui-même**. Un
+C'est aussi le pôle par lequel tout passe, et celui qui **se livre pour lui-même**. Un
 client peut s'arrêter au document produit ici, sans jamais acheter d'IA ni de SEA. Cette
 possibilité doit rester lisible partout : sans elle, le passage obligé se lit comme un
 péage.
 
-**1. Comprendre le métier — une prestation à part entière, pas une étape préparatoire.**
+**1. Comprendre le métier : une prestation à part entière, pas une étape préparatoire.**
 
-- **Faire émerger les règles métier existantes** — celles que les équipes appliquent
+- **Faire émerger les règles métier existantes**, celles que les équipes appliquent
   sans les avoir formalisées : recueil auprès de ceux qui les appliquent, mise par
   écrit, confrontation à l'historique. *Preuve : AMOA de la startup biotech Artedrone,
   besoin recueilli auprès des équipes scientifiques et dirigeantes et traduit en
   spécifications exploitables par des prestataires non spécialistes ; BPMN 2.0,
   cartographie SI.*
-- **Découvrir les profils de clients** — profilage par clustering (KNN) sur les données
+- **Découvrir les profils de clients** : profilage par clustering (KNN) sur les données
   réelles, restitution visuelle pensée pour la décision.
-- **Découvrir les insights métier** — reprise de l'historique, analyse exploratoire sous
+- **Découvrir les insights métier** : reprise de l'historique, analyse exploratoire sous
   Orange Data Mining, pondération et sélection des variables, élimination des
   corrélations fortes et du bruit. *Preuve : analyse de l'historique des inscriptions
-  ayant abouti à des règles anti-fraude — fraude en baisse, conversion en hausse.*
+  ayant abouti à des règles anti-fraude (fraude en baisse, conversion en hausse).*
 - **Livrable propre** : ce que la donnée dit de l'activité, les règles formalisées, les
   profils identifiés, les questions sans réponse. Le client peut s'arrêter là.
 
-**2. Gouvernance et législation — avant la technique, jamais après.**
+**2. Gouvernance et législation : avant la technique, jamais après.**
 
-- **Qui possède quoi** — cartographie des sources et de leur propriété, ce qui peut
+- **Qui possède quoi** : cartographie des sources et de leur propriété, ce qui peut
   sortir de chez le client et ce qui doit y rester.
-- **Ce qui a le droit d'être collecté et traité** — RGPD, base légale, consentement
+- **Ce qui a le droit d'être collecté et traité** : RGPD, base légale, consentement
   (CMP, déclenchement conditionnel des tags par catégorie), cadrage des traitements avec
   le juridique. *Preuve : conformité RGPD et DORA tenue en appels d'offres grands
   comptes (distribution, assurance, banque) ; cadrage RGPD des données clients chez un
   e-commerçant de joaillerie.*
-- **La contrainte oriente la solution** — une donnée qui ne peut pas sortir écarte
+- **La contrainte oriente la solution** : une donnée qui ne peut pas sortir écarte
   d'office un service tiers et ramène l'arbitrage entre modèle open-weight hébergé et
   règle explicite.
 
-**3. La stratégie data — la déployer, ou s'appuyer sur celle qui existe.**
+**3. La stratégie data : la déployer, ou s'appuyer sur celle qui existe.**
 
-- **Quand rien n'est en place** — définition des indicateurs à partir des questions du
+- **Quand rien n'est en place**, définition des indicateurs à partir des questions du
   métier, plan de collecte, pipelines d'ingestion, modélisation : PostgreSQL
   (relationnel, séries temporelles, vectoriel), MySQL, Firebase.
-- **Quand la donnée existe** — reprise de l'existant, agrégation et réconciliation
+- **Quand la donnée existe**, reprise de l'existant, agrégation et réconciliation
   multi-sources, dédoublonnage des identités, contrôles d'intégrité et de véracité dès
   l'ingestion, détection d'anomalies. La qualité est un **prérequis**, pas un correctif.
   *Preuve : système d'analyse multi-sources conforme RGPD mesurant la rentabilité client
@@ -221,11 +221,11 @@ péage.
   projet répondu. Le client repart avec la règle qui tranche et sans le budget d'un
   modèle à entraîner puis à maintenir.
 
-### Une des deux suites — IA
+### Une des deux suites : IA
 
 **La solution répond au problème posé au départ, pas à l'état de l'art**, et **elle
-n'est pas toujours de l'IA**. Ce pôle s'ouvre après la donnée — sans métier formalisé ni
-donnée gouvernée, un modèle apprend l'erreur de cadrage au lieu de la corriger — mais il
+n'est pas toujours de l'IA**. Ce pôle s'ouvre après la donnée (sans métier formalisé ni
+donnée gouvernée, un modèle apprend l'erreur de cadrage au lieu de la corriger), mais il
 ne se prend pas forcément : le SEA & UX s'ouvre en parallèle, et rien n'oblige à acheter
 de l'IA pour tirer parti de sa donnée.
 
@@ -234,13 +234,13 @@ l'étape 4 du pôle Data. Le site ne repose pas le test ici, il en reçoit le r�
 raconte ses deux issues. **Les quatre familles se nomment sans hiérarchie** : supervisé,
 non supervisé, LLM, agents. Aucune n'est un niveau au-dessus d'une autre.
 
-- **Réponse déterministe : une règle métier suffit** — moins chère à faire tourner, plus
+- **Réponse déterministe : une règle métier suffit**, moins chère à faire tourner, plus
   facile à expliquer à un régulateur, plus simple à corriger qu'un modèle. Intégrée aux
   systèmes existants, c'est un **livrable complet**. *Preuve : règles anti-fraude définies puis
-  implémentées dans le produit — fraude en baisse, conversion des inscriptions en
-  hausse, latence réduite ; flux commande, stock et facturation modélisés en BPMN puis
-  intégrés entre un ERP et un site marchand — survente évitée sur des pièces uniques.*
-- **Machine learning** — supervisé (classification, réseaux de neurones) ou non
+  implémentées dans le produit (fraude en baisse, conversion des inscriptions en
+  hausse, latence réduite) ; flux commande, stock et facturation modélisés en BPMN puis
+  intégrés entre un ERP et un site marchand (survente évitée sur des pièces uniques).*
+- **Machine learning** : supervisé (classification, réseaux de neurones) ou non
   supervisé selon ce que la donnée permet. Modèle supervisé anticipant les échecs de
   dépôt vocal, en production (TensorFlow, inférence en cloud functions) : extraction des
   caractéristiques du signal audio selon une méthode publiée sur **arXiv**, implémentée
@@ -258,24 +258,24 @@ non supervisé, LLM, agents. Aucune n'est un niveau au-dessus d'une autre.
   - **Le niveau cognitif** : un workflow agentique de bas niveau cognitif coûte moins
     cher qu'un LLM sollicité pour tout, parce que la donnée bien structurée a déjà fait
     une fois le travail que le modèle aurait facturé à chaque appel.
-- **LLM, quand le problème est du langage** — Claude (Vertex AI, API Anthropic), OpenAI,
+- **LLM, quand le problème est du langage** : Claude (Vertex AI, API Anthropic), OpenAI,
   Gemini, Llama. Context engineering, comparaison continue et arbitrage
   **coût / latence / qualité / confidentialité** par cas d'usage. Fine-tuning de
   **Llama 3** sur corpus métier pour l'application mobile *Prézage*, complété par un
   procédé maison d'augmentation du contexte proche du RAG. *Preuve : charge de travail
   des prestataires réduite.*
-- **RAG documentaire, fait maison** — réponse automatisée aux tickets de support de
+- **RAG documentaire, fait maison**. Réponse automatisée aux tickets de support de
   niveau 1 : recherche vectorielle PostgreSQL + API OpenAI, réponses ancrées sur la
   documentation interne et non sur la mémoire du modèle. **Aucun framework tiers.**
-- **Agents & interopérabilité** — conception, développement **et documentation** de
+- **Agents & interopérabilité**. Conception, développement **et documentation** de
   serveurs **MCP** et de plugins **n8n / Make / Zapier** : le produit devient appelable
   par un agent IA ou un scénario no-code chez le client.
-- **MLOps & cloud** — déploiement, versioning et monitoring de modèles, CI/CD Docker et
+- **MLOps & cloud** : déploiement, versioning et monitoring de modèles, CI/CD Docker et
   GitHub Actions, Vertex AI, Pub/Sub, Cloud Run, cloud functions, VM Compute Engine
-  auto-scalées. **Pas de cluster Kubernetes administré en propre** — l'absence se dit
+  auto-scalées. **Pas de cluster Kubernetes administré en propre**. L'absence se dit
   telle quelle.
 
-### L'autre suite — SEA & UX
+### L'autre suite : SEA & UX
 
 L'offre acquisition **et arbitrage**, tenue par un ingénieur des données. Elle s'ouvre
 elle aussi après la donnée, **en parallèle de l'IA et jamais après elle**. C'est ce qui
@@ -286,39 +286,39 @@ le code.
 > graphique. Jérôme ne vend **aucune** création visuelle, aucune direction artistique,
 > aucune maquette livrée en fichier. Ce qu'il vend, ce sont des **arbitrages** pris sur
 > la donnée : quel parcours, quelle étape supprimée, quel formulaire raccourci, quel
-> test A/B tranché, quelle page rendue en SSR plutôt qu'en CSR — puis implémentés par
+> test A/B tranché, quelle page rendue en SSR plutôt qu'en CSR, puis implémentés par
 > lui-même. Toute formulation qui laisserait planer un doute là-dessus est à réécrire.
 
-- **Mesure et taggage** — Google Tag Manager conteneur **web et server-side**,
+- **Mesure et taggage** : Google Tag Manager conteneur **web et server-side**,
   dataLayer, Measurement Protocol, plan de taggage et nomenclature d'événements
   standardisée, documentée et opposable. Google Analytics, Matomo, Search Console,
   et côté mobile Firebase Analytics / Crashlytics.
-- **Conformité by design** — RGPD, CMP et gestion du consentement (déclenchement
+- **Conformité by design** : RGPD, CMP et gestion du consentement (déclenchement
   conditionnel des tags par catégorie), cadrage des traitements avec le juridique.
   La conformité n'est pas une case à cocher après coup : elle conditionne l'architecture
   de collecte.
-- **LTV, pas one-shot** — système d'analyse multi-sources (SEO, SEA, IA) conforme RGPD :
+- **LTV, pas one-shot**. Système d'analyse multi-sources (SEO, SEA, IA) conforme RGPD :
   agrégation des sources d'acquisition, réconciliation et dédoublonnage des identités,
   mesure de la **rentabilité client à long terme**. Les budgets sont arbitrés sur la
   rentabilité réelle, pas sur les métriques natives des régies.
-- **Solutions sur mesure multi-source** — pas de connecteur générique : la donnée est
+- **Solutions sur mesure multi-source**. Pas de connecteur générique : la donnée est
   agrégée depuis les régies (Google Ads, Bing Ads), le produit et le CRM, puis
   réconciliée selon le modèle métier du client.
-- **Tableaux de bord personnalisés** — un dashboard par client et par produit, pas un
+- **Tableaux de bord personnalisés** : un dashboard par client et par produit, pas un
   gabarit. Data visualisation et **clustering / profilage clients** (KNN) pour rendre
   la décision lisible : ce que le dirigeant doit trancher apparaît, le reste
   disparaît.
-- **SEA & pilotage** — Google Ads, Bing Ads, SEO / SEA / SMA, A/B testing, optimisation
+- **SEA & pilotage** : Google Ads, Bing Ads, SEO / SEA / SMA, A/B testing, optimisation
   du taux de conversion. *Budgets pilotés : 100 000 € ADS/SEO chez Truffle Capital,
   ~25 000 € d'encadrement de prestataires SEA chez Verhoeven Joaillier.*
-- **Arbitrages UX** — refonte de parcours pilotée par la mesure : A/B testing des pages
+- **Arbitrages UX**. Refonte de parcours pilotée par la mesure : A/B testing des pages
   et des designs, heatmaps, taux de rebond, part de trafic mobile. Une étape disparaît
   parce que les chiffres le disent. *Preuve : panier moyen +50 % chez Verhoeven
   Joaillier.* Et comme c'est la même personne qui code, l'arbitrage décidé est
-  **implémenté**, pas transmis à un tiers — c'est ce qui boucle la chaîne sur
+  **implémenté**, pas transmis à un tiers : c'est ce qui boucle la chaîne sur
   l'ingénierie web.
-- **SEO technique** — stratégie de rendu Next.js par type de page, Core Web Vitals,
-  Lighthouse, accessibilité — le référencement traité comme une propriété du produit.
+- **SEO technique** (stratégie de rendu Next.js par type de page, Core Web Vitals,
+  Lighthouse, accessibilité) : le référencement traité comme une propriété du produit.
 
 ---
 
@@ -328,7 +328,7 @@ Le site porte une section **« Ce que je ne fais pas »** ([`src/contenu/limites
 Ce n'est pas un aveu, c'est l'argument qui rend le reste croyable : un prestataire qui
 sait tout faire ne sait rien faire.
 
-Chaque ligne y traduit une règle de véracité du [`CLAUDE.md`](./CLAUDE.md) — pas de
+Chaque ligne y traduit une règle de véracité du [`CLAUDE.md`](./CLAUDE.md) : pas de
 cluster Kubernetes administré en propre, pas de framework RAG tiers, pas de création
 graphique, une seule chaîne d'outillage de mesure mobile, ISTQB Foundation et rien
 au-delà.
@@ -341,8 +341,8 @@ celles qui ne sont pas couvertes.
 **État du contrôle** : la table des interdits du [`CLAUDE.md`](./CLAUDE.md) fait
 autorité, mais **aucun contrôle automatisé ne la vérifie à ce jour**. Le test
 d'intégration qui doit échouer dès qu'un terme proscrit réapparaît dans le contenu
-publié — `tests/integration/veracite-contenu.integration.spec.ts`, au nommage imposé
-par la [stratégie de tests](./docs/testing.md) — **reste à écrire**. Son intention
+publié, `tests/integration/veracite-contenu.integration.spec.ts`, au nommage imposé
+par la [stratégie de tests](./docs/testing.md), **reste à écrire**. Son intention
 complète (motifs couverts, jeu de données, cas limites) est spécifiée dans l'issue
 [#117](https://github.com/Jerome-Marichez/jeromemarichez2026/issues/117) et il revient
 à Jérôme MARICHEZ de le poser. D'ici là, la table s'applique à la relecture, pas à
@@ -355,12 +355,12 @@ la CI.
 Chaque certification doit être **cliquable vers son justificatif officiel**. Aucune URL
 n'ayant été fournie à ce jour, les sept certifications sont publiées **sans lien**, avec
 la mention « justificatifs communiqués sur demande » : un lien mort coûterait plus cher
-que l'absence de lien. Les millésimes ont été arbitrés par Jérôme le **2026-08-20** —
+que l'absence de lien. Les millésimes ont été arbitrés par Jérôme le **2026-08-20** :
 Google Ads en 2021 (le CV Tracking Specialist indiquait 2022) et Microsoft Ads
 confirmée, sans année connue.
 
 Une certification **se montre, elle ne se commente pas** : le rendu est un logo, un
-intitulé, un millésime — pas de paragraphe d'apport. Ce que chacune change dans la
+intitulé, un millésime. Pas de paragraphe d'apport. Ce que chacune change dans la
 prestation se dit dans les sections de pôle, à leur place, une fois.
 
 | Certification | Année | Lien officiel | Logo |
@@ -369,9 +369,9 @@ prestation se dit dans les sections de pôle, à leur place, une fois.
 | ISTQB **Foundation** (niveau Avancé **non** obtenu) | 2026 | *à fournir* | *à fournir* |
 | Google Analytics Individual Qualification (GAIQ) | 2021 | *à fournir* | `google-analytics.svg` |
 | Google Ads | 2021 | *à fournir* | `google-ads.svg` |
-| Microsoft Ads | — | *à fournir* | *à fournir* |
-| WeLoveDev — Top 5 % React | 2023 | *à fournir* | *à fournir* |
-| EF SET — Anglais B2 (CECRL) | — | *à fournir* | *à fournir* |
+| Microsoft Ads | *non renseignée* | *à fournir* | *à fournir* |
+| WeLoveDev, Top 5 % React | 2023 | *à fournir* | *à fournir* |
+| EF SET, Anglais B2 (CECRL) | *non renseignée* | *à fournir* | *à fournir* |
 
 Les logos suivent la **même règle que les justificatifs** : aucun fichier inventé, aucune
 image cassée. Tant qu'un logo manque, la certification s'affiche en toutes lettres. La
@@ -385,7 +385,7 @@ ce qu'il faut réunir pour les quatre logos manquants.
 
 | Route | Rôle |
 |-------|------|
-| `/` | **Vitrine, pas catalogue déplié.** Accroche et promesse d'interlocuteur unique, le schéma de la chaîne et de son embranchement, les **quatre portes** — nom du pôle, promesse, une preuve chiffrée, lien vers sa page —, les deux objections traitées (« et si je disparais ? » et « et si le projet me dépasse ? »), preuves chiffrées, limites assumées, certifications, et un **formulaire de contact** qui compose un `mailto:` avec l'adresse affichée en clair à côté. Le **détail de chaque pôle** vit sur `/services/<pole>/`, qui le disait déjà en plus long ; le **fil IA transverse** est descendu sur `/services/ingenierie-web/`, la page où le site dit comment le code est produit |
+| `/` | **Vitrine, pas catalogue déplié.** Accroche et promesse d'interlocuteur unique, le schéma de la chaîne et de son embranchement, les **quatre portes** (nom du pôle, promesse, une preuve chiffrée, lien vers sa page), les deux objections traitées (« et si je disparais ? » et « et si le projet me dépasse ? »), preuves chiffrées, limites assumées, certifications, et un **formulaire de contact** qui compose un `mailto:` avec l'adresse affichée en clair à côté. Le **détail de chaque pôle** vit sur `/services/<pole>/`, qui le disait déjà en plus long ; le **fil IA transverse** est descendu sur `/services/ingenierie-web/`, la page où le site dit comment le code est produit |
 | `/services/ingenierie-web` | Le socle en détail |
 | `/services/data` | Le passage obligé en détail |
 | `/services/ia` | Une des deux suites en détail |
@@ -400,9 +400,9 @@ ce qu'il faut réunir pour les quatre logos manquants.
 Chaque page de service porte ses propres métadonnées SEO, ses données structurées
 (`schema.org/Service` et `ProfessionalService`) et un appel à contact contextualisé.
 
-### L'espace `/realisations/` — le nom est un arbitrage de véracité
+### L'espace `/realisations/` : le nom est un arbitrage de véracité
 
-**Deux postes salariés et une mission en indépendant** — Lead Tech chez Acetelecom /
+**Deux postes salariés et une mission en indépendant** : Lead Tech chez Acetelecom /
 MailingVox (2023-2026, salarié), Développeur Full Stack chez Verhoeven Joaillier
 (2019-2022, salarié, poste unique), Développeur web & Chef de projet digital chez Truffle
 Capital (2017-2019, **en auto-entrepreneur** : Truffle Capital était donc un client).
@@ -412,7 +412,7 @@ cadre de la mission Truffle. Nommer l'espace « cas clients » ferait passer dix
 treize pour une relation commerciale qui n'a jamais existé, et réécrirait des intitulés de
 poste que le [`CLAUDE.md`](./CLAUDE.md) impose de reprendre à l'identique des CV.
 
-L'espace s'appelle donc **`/realisations/`**, et **chaque fiche porte son cadre** —
+L'espace s'appelle donc **`/realisations/`**, et **chaque fiche porte son cadre** :
 statut, intitulé exact, période, taille d'équipe. Le cadre est **obligatoire dans le
 type** (`IRealisationCadre`, aucun champ optionnel, `statut` compris) : c'est le
 compilateur, et non la relecture, qui interdit qu'une fiche paraisse sans dire d'où elle
@@ -420,55 +420,55 @@ vient ni à quel titre. Le `statut` a été ajouté après coup : sans lui, l'es
 « trois postes salariés » pendant plusieurs versions (issue #107).
 
 **Deux gabarits, et c'est structurant.** Trois fiches seulement portent un chiffre : ce
-sont les trois du mur de preuves — +50 % de panier moyen, 98/100 Lighthouse, 100 000 € de
-budget ADS/SEO **piloté**. Le mur de preuves les **lit sur la fiche** au lieu de les
+sont les trois du mur de preuves (+50 % de panier moyen, 98/100 Lighthouse, 100 000 € de
+budget ADS/SEO **piloté**). Le mur de preuves les **lit sur la fiche** au lieu de les
 recopier (`IProof.fiche` n'accepte qu'une `IRealisationChiffree`), donc le nombre n'est
 écrit qu'une fois dans le dépôt. Les dix autres fiches sont **sans chiffre** et portent au
-mieux un résultat directionnel — « fraude en baisse », « routes vocales coûteuses
-évitées » — jamais quantifié ; deux d'entre elles n'ont aucun résultat et l'écrivent noir
+mieux un résultat directionnel (« fraude en baisse », « routes vocales coûteuses
+évitées »), jamais quantifié ; deux d'entre elles n'ont aucun résultat et l'écrivent noir
 sur blanc. Même doctrine que les certifications publiées sans lien plutôt qu'avec un lien
 mort.
 
 Le rattachement aux pôles est un `readonly PoleId[]` **non contraint**. Le modèle décrit
 l'offre d'aujourd'hui, pas un historique : un type qui exigerait `data` partout forcerait à
 réétiqueter des travaux de 2017 pour satisfaire le compilateur. Deux formes portent
-l'argument — `['ingenierie-web', 'data', 'sea-ux']` **sans IA** montre qu'on n'est pas
+l'argument : `['ingenierie-web', 'data', 'sea-ux']` **sans IA** montre qu'on n'est pas
 obligé d'acheter de l'IA, `['data']` seul que la donnée se livre pour elle-même.
 
 Une **réalisation n'est pas datée** : ce qui la situe dans le temps est la période du poste
 sous lequel elle a été menée, et cette période appartient au contenu de la fiche. Ses
 métadonnées passent donc par `buildPageMetadata`, pas par `buildArticleMetadata` qui
 exigerait une date de publication qu'il faudrait inventer. Les données structurées sont
-volontairement pauvres — `CollectionPage` + `ItemList` sur la liste, `WebPage` avec
+volontairement pauvres. `CollectionPage` + `ItemList` sur la liste, `WebPage` avec
 `isPartOf` sur la fiche : **ni `Service` ni `CreativeWork`**, aucun type qui affirmerait
 une prestation vendue ou une œuvre détenue.
 
 Le **blog** n'est pas un quatrième pôle et la navigation le sépare de la chaîne : ce sont
 des notes courtes sur des décisions techniques réelles. Chaque article porte ses propres
 métadonnées, un `schema.org/BlogPosting`, un fil d'Ariane `Accueil → Blog → article` et sa
-**date** — c'est la seule partie du site dont le sitemap publie une date par page. Chaque
-article porte aussi une **figure construite** — du SVG rendu au serveur, jamais un fichier
-d'image — et, quand il en a une, un lien vers sa **publication d'origine**. Le modèle de
+**date** : c'est la seule partie du site dont le sitemap publie une date par page. Chaque
+article porte aussi une **figure construite** (du SVG rendu au serveur, jamais un fichier
+d'image) et, quand il en a une, un lien vers sa **publication d'origine**. Le modèle de
 l'entité est décrit dans [`docs/data-model.md`](./docs/data-model.md), la grammaire des
 figures dans [`docs/design.md`](./docs/design.md).
 
 Un article peut reprendre un post publié ailleurs. Il le **porte**, il ne le réécrit pas :
 le titre, le plan et les formulations de l'auteur passent tels quels, et seules deux choses
-les modifient. La **mise à la forme** d'abord — orthographe, syntaxe, chapô, sections
+les modifient. La **mise à la forme** d'abord : orthographe, syntaxe, chapô, sections
 titrées. La **véracité** ensuite : les règles s'y appliquent mot pour mot, et un post plus
-large que ce qui est établi se **réécrit à la baisse** — c'est ce qui s'est passé pour
+large que ce qui est établi se **réécrit à la baisse**. C'est ce qui s'est passé pour
 « J'ai open-sourcé mon plugin Claude Code », dont le post d'origine annonçait une CI plus
-validée qu'elle ne l'est. La ligne éditoriale du site — vendre une décision, finir sur ce
-que le lecteur peut trancher — vaut pour un article **écrit pour le site** ; elle
+validée qu'elle ne l'est. La ligne éditoriale du site (vendre une décision, finir sur ce
+que le lecteur peut trancher) vaut pour un article **écrit pour le site** ; elle
 n'autorise pas à refaire l'angle d'un texte repris (issue #121). Deux conséquences valables
 partout : aucun appel à l'action de réseau social (étoile, partage, contribution) n'entre
 dans le contenu publié, et un article dont l'**URL d'origine n'a pas été fournie se publie
-sans source** plutôt qu'avec une adresse approchée — même règle que les justificatifs de
-certification.
+sans source** plutôt qu'avec une adresse approchée (même règle que les justificatifs de
+certification).
 
 ## ✅ Contraintes produit
 
-- **SEO** : **export statique intégral** (`output: 'export'`) — aucune page n'est rendue
+- **SEO** : **export statique intégral** (`output: 'export'`). Aucune page n'est rendue
   à la requête. Métadonnées, `canonical` et données structurées par page, sitemap et
   robots générés. Conséquence assumée : ni route API, ni ISR, ni Server Action
   (voir [architecture](./docs/architecture.md)).
@@ -482,7 +482,7 @@ certification.
   collectée hors formulaire de contact explicite.
 
 Le contenu éditorial doit respecter les **règles de véracité** listées dans
-[`CLAUDE.md`](./CLAUDE.md) — ce qui n'est pas revendicable n'est pas écrit, même quand
+[`CLAUDE.md`](./CLAUDE.md) : ce qui n'est pas revendicable n'est pas écrit, même quand
 la formule serait vendeuse.
 
 ---
@@ -523,7 +523,7 @@ make type-check       # types TypeScript (tsc --noEmit), sans émission
 make test             # unitaires + intégration
 make test-unit        # unitaires
 make test-int         # intégration
-make test-e2e         # e2e (navigateur) — construit et sert `out/`, puis Cypress
+make test-e2e         # e2e (navigateur) : construit et sert `out/`, puis Cypress
 make test-system      # système (vrai serveur HTTP)
 make test-acceptance  # acceptation / non-fonctionnels (uat/)
 make test-mutation    # mutation (Stryker)

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -20,7 +20,7 @@ Conformité **WCAG 2.1 AA** sur les parcours principaux.
   mesurées et tabulées dans [`design.md`](./design.md) :
   `--accent-vif` est **non-texte uniquement**, il est entre 3.5:1 et 3.9:1 en thème clair.
 - **La couleur n'est jamais le seul porteur d'information** (WCAG 1.4.1). La teinte de
-  pôle double une information déjà écrite — le nom du pôle, sa place, son temps. La
+  pôle double une information déjà écrite : le nom du pôle, sa place, son temps. La
   limite connue de cette palette sous vision dichromate est documentée dans `design.md`,
   chiffres à l'appui, plutôt que passée sous silence.
 - **Images** : `alt` pertinent (ou vide si décorative).
@@ -48,13 +48,13 @@ Conformité **WCAG 2.1 AA** sur les parcours principaux.
 
 Trois niveaux, et il est important de ne pas les confondre :
 
-1. **Lint** — règles a11y de Biome, à l'écriture. Attrape les fautes de balisage
+1. **Lint** : règles a11y de Biome, à l'écriture. Attrape les fautes de balisage
    évidentes (`div` cliquable, `alt` manquant) avant même le build.
-2. **Contrôle automatisé** — `make budget-a11y` : axe-core (Deque) sur les pages
+2. **Contrôle automatisé** avec `make budget-a11y` : axe-core (Deque) sur les pages
    représentatives, dans un vrai navigateur. Une violation d'impact `critical` ou
    `serious` fait **échouer** le contrôle, et il tourne sur **chaque PR vers `dev`**
    (`ci-dev-a11y`).
-3. **Audit manuel** — clavier et lecteur d'écran sur les parcours critiques. **Rien ne
+3. **Audit manuel** : clavier et lecteur d'écran sur les parcours critiques. **Rien ne
    le remplace.**
 
 ### Ce que le contrôle automatique ne dit pas
@@ -62,7 +62,7 @@ Trois niveaux, et il est important de ne pas les confondre :
 axe-core ne détecte que la part **mécanisable** de WCAG : Deque annonce environ 57 % des
 problèmes sur ses propres jeux de mesure, la pratique retient plutôt un tiers. Un
 `make budget-a11y` vert ne signifie **pas** que le site est conforme RGAA, et le site ne
-doit nulle part le laisser entendre — ce serait exactement le genre d'affirmation sans
+doit nulle part le laisser entendre : ce serait exactement le genre d'affirmation sans
 preuve que le `CLAUDE.md` s'interdit.
 
 Restent hors de portée d'axe, et donc à la charge de l'audit manuel :
@@ -70,11 +70,11 @@ Restent hors de portée d'axe, et donc à la charge de l'audit manuel :
 - la **pertinence** d'une alternative textuelle, d'un intitulé de lien, d'un titre ;
 - l'**ordre de lecture** et la cohérence de la hiérarchie de titres ;
 - l'utilisabilité réelle **au clavier** d'un composant riche (piège de focus, raccourci) ;
-- le **focus visible** en conditions réelles — axe ne juge pas la visibilité d'un
+- le **focus visible** en conditions réelles : axe ne juge pas la visibilité d'un
   contour ;
 - `prefers-reduced-motion` : axe ne le teste pas. Le respect de la préférence est vérifié
   à la main sur la scène d'accueil ;
-- **WCAG 2.2.2 (Pause, Stop, Hide)** — le mécanisme de mise en pause des animations. Un
+- **WCAG 2.2.2 (Pause, Stop, Hide)** : le mécanisme de mise en pause des animations. Un
   contrôle automatique ne sait pas dire si l'utilisateur peut réellement arrêter le
   mouvement ; c'est un point d'audit manuel explicite sur ce site ;
 - les **contrastes** au-delà du cas simple texte sur fond uni : les seize valeurs de la
@@ -82,7 +82,7 @@ Restent hors de portée d'axe, et donc à la charge de l'audit manuel :
   `--accent-vif` y est déclaré **non-texte uniquement**. axe ne peut pas connaître cette
   intention.
 
-### Le lavis de pôle — contrastes relevés
+### Le lavis de pôle : contrastes relevés
 
 Depuis l'issue #104, le fond papier porte un **lavis pastel de la teinte du pôle** sous
 tout bloc qui parle d'un pôle : les quatre pages `/services/<pole>/` sur toute leur
@@ -115,20 +115,20 @@ future du lavis demande de rouvrir d'abord la palette des `-vif`.
 Trois points relevés, à garder en tête :
 
 - le **verre** (`GlassSurface`) floute ce lavis : un fond plus coloré change ce qu'il
-  rend. Contrôlé sur les quatre teintes — `--encre-douce` sur un panneau posé sur le
+  rend. Contrôlé sur les quatre teintes : `--encre-douce` sur un panneau posé sur le
   lavis le plus dense vaut **6.79 à 6.82:1** en clair, **5.23 à 5.28:1** en sombre ;
 - le lavis est un **décor** : aucune information n'y est portée par la seule couleur
   (WCAG 1.4.1). Le nom du pôle, son libellé de place et son temps restent écrits en
-  toutes lettres à côté. Le survol d'une porte, lui, ne se dit plus par le fond — celui-ci
-  est au plafond de contraste — mais par l'arête qui se ferme **et** l'invite qui se
+  toutes lettres à côté. Le survol d'une porte, lui, ne se dit plus par le fond (celui-ci
+  est au plafond de contraste) mais par l'arête qui se ferme **et** l'invite qui se
   souligne ;
-- **`--accent` dilué à 45 %** — le chiffre de place de `PoleHero`, le filet de preuve de
-  `PoleEntries` — est à **1,9 à 2,5:1** sur le fond, et l'était déjà avant le lavis (qui
+- **`--accent` dilué à 45 %** (le chiffre de place de `PoleHero`, le filet de preuve de
+  `PoleEntries`) est à **1,9 à 2,5:1** sur le fond, et l'était déjà avant le lavis (qui
   lui coûte 0,07 point, la teinte et le fond bougeant ensemble). Les deux sont décoratifs
   et l'information qu'ils accompagnent est écrite à côté, mais le point est **ouvert** et
   n'a pas été traité par ce lot.
 
-### La chaîne et les derniers porteurs — contrastes relevés (issue #114)
+### La chaîne et les derniers porteurs : contrastes relevés (issue #114)
 
 Le lavis s'étend à `ChainDiagram`, dont les plaques sont **du verre** : le lavis passe sous
 le voile plutôt que devant, et ses parts compensent ce que le voile absorbe. Le mécanisme
@@ -137,10 +137,10 @@ servi** (`next dev`, viewport 1440, capture PNG décodée, deux thèmes).
 
 **La non-composition, prouvée sur le rendu et non déduite.** Deux témoins ont été rendus
 dans la page à côté de la vraie chaîne : *A*, une plaque IA hors de toute chaîne (un seul
-lavis) ; *B*, la même plaque IA dans un conteneur peint au lavis de la donnée — c'est-à-dire
+lavis) ; *B*, la même plaque IA dans un conteneur peint au lavis de la donnée, c'est-à-dire
 exactement ce qu'aurait produit un lavis posé sur le maillon.
 
-| Thème | Plaque IA réelle (dans le maillon « data ») | Témoin A — un lavis | Témoin B — deux lavis | Écart réel↔A | Écart réel↔B |
+| Thème | Plaque IA réelle (dans le maillon « data ») | Témoin A : un lavis | Témoin B : deux lavis | Écart réel↔A | Écart réel↔B |
 |---|---|---|---|---|---|
 | clair | `#E4DFDC` | `#E4DFDC` | `#DEDCDA` | **0 niveau** | 6 niveaux |
 | sombre | `#191A22` | `#191A22` | `#181D25` | **0 niveau** | 3 niveaux |
@@ -148,7 +148,7 @@ exactement ce qu'aurait produit un lavis posé sur le maillon.
 La plaque réelle est **au niveau près** identique au cas « un seul lavis », et distincte du
 cas « deux lavis ». Le `<li data-pole="data">` a par ailleurs
 `background-color: rgba(0,0,0,0)` et `background-image: none` en style calculé : il ne
-peint rien. Contrôle croisé sur le fond, à la même abscisse — la gouttière entre les deux
+peint rien. Contrôle croisé sur le fond, à la même abscisse : la gouttière entre les deux
 branches, *dans* le maillon « data », vaut `#E5E1D8` ; le gap de la chaîne, *hors* de tout
 `<li>`, vaut `#E6E2D9`. L'écart d'un niveau est celui du dégradé d'atelier, pas un lavis.
 
@@ -170,7 +170,7 @@ Contrastes sur la couleur **composée réellement lue** au centre de chaque plaq
 | sombre | SEA & UX | `#171C1A` | 14.01:1 | 6.75:1 | 7.08:1 | 8.95:1 |
 
 Les deux cas les plus serrés sont le SEA & UX et la donnée, à 4,82:1 pour du texte
-(seuil 4.5:1) et 3,09:1 pour du non-texte (seuil 3:1) — tenus, dans les deux thèmes.
+(seuil 4.5:1) et 3,09:1 pour du non-texte (seuil 3:1) : tenus, dans les deux thèmes.
 
 **Un défaut antérieur, trouvé et corrigé.** `PoleTagList` portait un lavis écrit à la main
 à 8 %, au-dessus du plafond, et **sous du texte de sa propre teinte**. Mesuré en thème
@@ -185,16 +185,16 @@ clair sur `/realisations/` :
 
 Deux valeurs étaient **sous le seuil** avant ce lot : le texte de la donnée à 4,30:1
 (WCAG 1.4.3) et son filet à 2,76:1 (WCAG 1.4.11), celui du SEA & UX à 2,97:1. L'aplat est
-retiré et le filet passe de `--accent-vif` à `--accent` — raisonnement et alternatives
+retiré et le filet passe de `--accent-vif` à `--accent` : raisonnement et alternatives
 mesurées dans [`design.md`](./design.md). En thème sombre, aucune de ces valeurs n'était en
 défaut (6,05 à 6,60:1) et toutes montent (6,76 à 7,41:1).
 
 **Les pages de pôle et les portes de l'accueil sont inchangées** : `.lavis-pole` et
-`.lavis-bloc` n'ont pas bougé. Relevé de contrôle en thème clair — `--encre-douce` de 6,80
+`.lavis-bloc` n'ont pas bougé. Relevé de contrôle en thème clair : `--encre-douce` de 6,80
 à 6,83:1 et `--accent-vif` de 3,73 à 3,75:1 sur les quatre pages ; en sombre, 7,22 à 7,25:1
 et 8,98 à 9,02:1.
 
-### Le verre des bandes collantes — contrastes relevés
+### Le verre des bandes collantes : contrastes relevés
 
 Depuis l'issue #115, l'en-tête du site et la barre de pôle laissent passer nettement plus
 de fond qu'avant : leur voile descend de 88 → 86 % (clair) et 73 % (sombre) pour
@@ -202,7 +202,7 @@ l'en-tête, de 82 → 76 % et 58 % pour la barre. Le texte d'une bande passe don
 qui défile derrière elle**, et son contraste varie avec le contenu de la page à cet
 instant : il ne peut pas se calculer sur une couleur de fond fixe.
 
-Le relevé est fait **au pixel sur le rendu servi**, page entière balayée au pas de 24px —
+Le relevé est fait **au pixel sur le rendu servi**, page entière balayée au pas de 24px :
 un pas plus large saute le pire cas, qui ne dure qu'une trentaine de pixels de
 défilement. Méthode complète et pièges de mesure dans [`design.md`](./design.md).
 
@@ -221,11 +221,11 @@ verre et reste à 6.02:1 en clair, 7.18:1 en sombre.
 Deux points à garder en tête :
 
 - **le plafond est atteint sur l'en-tête en thème clair.** Les 88 % d'avant n'étaient pas
-  prudents, ils étaient déjà le plancher — `--pole-data` à 13px n'y valait que 4.74:1. Ce
+  prudents, ils étaient déjà le plancher : `--pole-data` à 13px n'y valait que 4.74:1. Ce
   qui bloque est identifié : les quatre chiffres de temps de l'en-tête, en `--accent` à
   13px, passent au-dessus de l'aplat d'`--accent` du bouton d'action du seuil. Deux
   couleurs de la même famille, donc de luminances voisines. Le même en-tête tiendrait un
-  voile de 68 % avec `--encre-douce` et de 30 % avec `--encre` — mais ce serait renoncer à
+  voile de 68 % avec `--encre-douce` et de 30 % avec `--encre`, mais ce serait renoncer à
   ce que l'en-tête soit la légende de la palette du site, et c'est un arbitrage de système
   de design, pas de verre ;
 - **axe-core ne voit rien de tout cela.** Il juge le contraste d'un texte sur une couleur
@@ -288,19 +288,19 @@ dans le CSS et qu'axe-core n'en juge presque aucun.
 
 ### Pages contrôlées
 
-Les mêmes que les budgets de performance — accueil, page de pôle, liste du blog, page
-d'article, index et fiche de réalisation — parce qu'un gabarit non mesuré est un gabarit
+Les mêmes que les budgets de performance (accueil, page de pôle, liste du blog, page
+d'article, index et fiche de réalisation) parce qu'un gabarit non mesuré est un gabarit
 non protégé. La liste vit dans `scripts/budgets/pages.mjs`.
 
 | Parcours | Audit | État |
 |----------|-------|------|
-| Accueil, pôle, blog, article, réalisations | axe-core (`ci-dev-a11y`) | **0 violation** — dernière exécution 2026-08-23, avec le lavis de pôle |
-| Contrastes sur le lavis de pôle | mesure au pixel, deux thèmes | **tenu** — 2026-08-23, voir le tableau ci-dessus |
-| Contrastes sur le lavis de feuille (`ChainDiagram`) | mesure au pixel, deux thèmes | **tenu** — 2026-08-23, pire cas 4,82:1 (texte) et 3,09:1 (non-texte) |
-| Non-composition des lavis dans `ChainDiagram` | témoins rendus + mesure au pixel | **prouvée** — 2026-08-23, écart nul avec le cas « un seul lavis » |
-| Étiquettes de pôle (`PoleTagList`) | mesure au pixel, deux thèmes | **corrigé** — 2026-08-23, deux valeurs étaient sous le seuil |
-| Contrastes sur les bandes de verre | mesure au pixel, page balayée, deux thèmes | **tenu** — 2026-08-24, rejoué après intégration de `dev`, marges de 0,10 à 0,35 point |
+| Accueil, pôle, blog, article, réalisations | axe-core (`ci-dev-a11y`) | **0 violation**, dernière exécution 2026-08-23, avec le lavis de pôle |
+| Contrastes sur le lavis de pôle | mesure au pixel, deux thèmes | **tenu**, 2026-08-23, voir le tableau ci-dessus |
+| Contrastes sur le lavis de feuille (`ChainDiagram`) | mesure au pixel, deux thèmes | **tenu**, 2026-08-23, pire cas 4,82:1 (texte) et 3,09:1 (non-texte) |
+| Non-composition des lavis dans `ChainDiagram` | témoins rendus + mesure au pixel | **prouvée**, 2026-08-23, écart nul avec le cas « un seul lavis » |
+| Étiquettes de pôle (`PoleTagList`) | mesure au pixel, deux thèmes | **corrigé**, 2026-08-23, deux valeurs étaient sous le seuil |
+| Contrastes sur les bandes de verre | mesure au pixel, page balayée, deux thèmes | **tenu**, 2026-08-24, rejoué après intégration de `dev`, marges de 0,10 à 0,35 point |
 | Formulaire de contact : ordre de tabulation, envoi au clavier, deux thèmes | manuel | **tenu** le 2026-08-24, du premier champ à l'envoi, sur l'export statique |
 | Formulaire de contact : lecteur d'écran | manuel | _à réaliser_ |
 | Clavier + lecteur d'écran (reste du site) | manuel | _à réaliser_ |
-| WCAG 2.2.2 — pause des animations | manuel | _à réaliser_ |
+| WCAG 2.2.2 : pause des animations | manuel | _à réaliser_ |

--- a/docs/ameliorations.md
+++ b/docs/ameliorations.md
@@ -5,12 +5,12 @@ le bénéfice attendu et l'effort estimé.
 
 | # | Amélioration | Bénéfice | Effort | Statut |
 |---|--------------|----------|--------|--------|
-| 1 | Compression du HTML en production (`gzip` dans `docker/nginx.conf`) | Budget de performance mobile : premier levier, de loin | faible | **fait** (issue #76) — 80/81/82 → 96/97/97 |
-| 2 | Stratégie de chargement des polices (sous-ensemble, `preload`, `size-adjust`) | LCP mobile | moyen | proposé — **c'est là que se joue désormais la marge** (voir plus bas) |
+| 1 | Compression du HTML en production (`gzip` dans `docker/nginx.conf`) | Budget de performance mobile : premier levier, de loin | faible | **fait** (issue #76) : 80/81/82 → 96/97/97 |
+| 2 | Stratégie de chargement des polices (sous-ensemble, `preload`, `size-adjust`) | LCP mobile | moyen | proposé : **c'est là que se joue désormais la marge** (voir plus bas) |
 | 3 | Réduction du JavaScript inutilisé (~153 Kio) et du JavaScript hérité (~43 Kio) | Budget de performance mobile | moyen | **entamé** (issue #145) : Zod sorti du groupage client, 53 Kio de moins ; le reste est chiffré plus bas et revient à l'issue #80 |
 | 4 | Préchargement RSC de toutes les routes de pôle depuis l'accueil | Bande passante mobile après le LCP | faible | proposé |
 
-## Budget de performance — diagnostic du 2026-08-22
+## Budget de performance : diagnostic du 2026-08-22
 
 Les budgets sont devenus exécutables (`make budgets`, voir [testing](./testing.md)). Leur
 première exécution rapporte **80 / 81 / 82** en performance mobile, contre un seuil de
@@ -50,18 +50,18 @@ service, pas de code applicatif.
 
 Ce correctif touche la configuration de production (`docker/nginx.conf`, et
 `scripts/serve-out.mjs` pour que la mesure reste fidèle à ce que sert nginx). Il sort du
-périmètre du lot qui a rendu les budgets exécutables, et fait l'objet d'un lot distinct —
+périmètre du lot qui a rendu les budgets exécutables, et fait l'objet d'un lot distinct :
 c'est justement le budget qui l'a mis au jour, le jour de sa mise en service.
 
 En profil **desktop** non bridé, les mêmes pages sortent à **99 / 100 / 100 / 100** : le
 site n'est pas lent dans l'absolu, il l'est sur un mobile en 4G médiocre. C'est le cas
 qui compte, et c'est celui que le budget mesure.
 
-## Résultat — compression activée le 2026-08-22 (issue #76)
+## Résultat : compression activée le 2026-08-22 (issue #76)
 
 Le diagnostic ci-dessus est confirmé jusqu'au bout : c'était bien du transfert, et rien
-d'autre. `gzip` déclaré dans `docker/nginx.conf` — réglages et justifications dans
-[docker](./docker.md#compression) — suffit à faire passer les trois pages.
+d'autre. `gzip` déclaré dans `docker/nginx.conf` (réglages et justifications dans
+[docker](./docker.md#compression)) suffit à faire passer les trois pages.
 
 | Page | Perf avant | Perf après | A11y | Bonnes prat. | SEO |
 |------|-----------|-----------|------|--------------|-----|
@@ -69,14 +69,14 @@ d'autre. `gzip` déclaré dans `docker/nginx.conf` — réglages et justificatio
 | `/services/ingenierie-web/` | 81 | **97** | 100 | 100 | 100 |
 | article de blog | 82 | **97** | 100 | 100 | 100 |
 
-L'`index.html` de l'accueil passe de **119 998 à 22 215 octets sur le fil — 81 % de
+L'`index.html` de l'accueil passe de **119 998 à 22 215 octets sur le fil, soit 81 % de
 moins**. Aucune ligne de code applicatif n'a bougé, aucun composant n'a été supprimé,
 aucune police n'a été touchée : le site était correctement construit, il était mal
 servi. C'est le genre de défaut qu'aucune revue de code ne trouve et qu'une mesure
 trouve le premier jour.
 
 **Ce que la mesure ne dit pas encore.** Le budget est tenu, mais la marge de l'accueil
-est d'**un point**. Les deux `woff2` du chemin critique (67 et 49 Kio) n'ont pas bougé —
+est d'**un point**. Les deux `woff2` du chemin critique (67 et 49 Kio) n'ont pas bougé :
 ils sont déjà compressés à la source et le gzip ne les touche pas, à dessein. Ils
 restent donc le premier poste du chemin critique, et c'est la piste 2 qui porte la
 marge suivante, pas la piste 3.
@@ -85,8 +85,8 @@ Les polices n'ont **pas** été retouchées ici, et c'est délibéré : Fraunces
 un choix de design documenté dans [design](./design.md#typographie), déjà réduit au
 strict nécessaire (variable, sous-ensemble latin, axe `opsz` seul depuis le retrait de
 `SOFT` et `WONK`, registre monospace confié à la pile système). Alléger davantage
-suppose d'arbitrer sur le dessin — `preload` sélectif, `size-adjust`, sous-ensemble de
-glyphes — et cet arbitrage revient à Jérôme MARICHEZ, pas à un lot de performance.
+suppose d'arbitrer sur le dessin (`preload` sélectif, `size-adjust`, sous-ensemble de
+glyphes) et cet arbitrage revient à Jérôme MARICHEZ, pas à un lot de performance.
 
 ## Résultat : Zod sorti du groupage client le 2026-08-24 (issue #145)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,18 +12,18 @@ Visiteur ──► Fichiers statiques servis par nginx  ── offres, parcours,
 
 **Conséquence structurante** : `next.config.mjs` porte `output: 'export'`. `next build`
 n'écrit pas un serveur, il écrit un site complet dans `out/`. Ce n'est pas un réglage de
-déploiement, c'est une contrainte d'architecture — elle ferme, définitivement tant qu'elle
+déploiement, c'est une contrainte d'architecture. Elle ferme, définitivement tant qu'elle
 tient :
 
 | Fermé | Pourquoi ça n'est pas un manque ici |
 |-------|-------------------------------------|
-| Routes API (`/api/*`) | Le seul besoin identifié était le formulaire de contact — voir ci-dessous |
+| Routes API (`/api/*`) | Le seul besoin identifié était le formulaire de contact, voir ci-dessous |
 | ISR et revalidation | Le contenu change quand Jérôme le réécrit, donc au build |
 | Server Actions | Même raison : aucune écriture côté serveur |
 | Optimiseur `next/image` | Les images sont optimisées au build, pas à la requête |
 
 **Le formulaire de contact est donc reporté.** L'accueil et le pied de page portent un
-`mailto:` direct, ce qui est cohérent avec la promesse du site — *vous écrivez à la
+`mailto:` direct, ce qui est cohérent avec la promesse du site : *vous écrivez à la
 personne qui fera le travail*. Le jour où un formulaire s'impose, il faudra soit un
 service tiers, soit un back séparé, soit renoncer à l'export : c'est un arbitrage à
 prendre en connaissance de cause, pas un détail de configuration.
@@ -41,7 +41,7 @@ statique leur impose les mêmes règles :
 - **Le sitemap devient composé.** `INDEXABLE_ROUTES` (`src/routes`) n'énumère que les
   routes **fixes** ; les URL d'articles et de fiches ne sont pas des routes mais des
   instances de deux routes, et leur nombre change à chaque publication.
-  `src/seo/sitemap-entries` les ajoute avec **une date par article** — et donne à
+  `src/seo/sitemap-entries` les ajoute avec **une date par article**, et donne à
   `/blog` la date de son article le plus récent, parce que c'est exactement ce qui la fait
   changer. C'est le seul module de `src/seo/` qui lit le contenu éditorial : un
   sitemap est par définition l'inventaire du contenu publié, il n'y a pas d'autre source
@@ -56,7 +56,7 @@ statique leur impose les mêmes règles :
   preuves passent tous par elles. Dans un export statique, une URL canonique fausse reste
   fausse jusqu'au prochain build.
 - **Un seul fil d'Ariane.** `buildBreadcrumbSchema` accepte les niveaux qui suivent
-  l'accueil — celui-ci est un invariant du site, il est posé par la fonction et ne peut
+  l'accueil : celui-ci est un invariant du site, il est posé par la fonction et ne peut
   pas être oublié par un appelant. La même liste alimente le fil **visible**
   (`src/components/Breadcrumb`) : l'affiché et le déclaré ne peuvent pas diverger.
 - **Ni le blog ni les réalisations ne sont des pôles**, et la navigation le dit : ils
@@ -69,14 +69,14 @@ La liste déclare une `CollectionPage` dont le `mainEntity` est une `ItemList` ;
 fiche déclare une `WebPage` rattachée par `isPartOf`. **Ni `Service`, ni `CreativeWork`,
 ni `Project`** : le premier affirmerait une prestation vendue, le deuxième une œuvre dont
 on détiendrait les droits, le troisième une entreprise autonome. Aucune de ces trois
-affirmations n'est vraie d'un travail mené sous contrat de travail — et le JSON-LD est
+affirmations n'est vraie d'un travail mené sous contrat de travail, et le JSON-LD est
 d'autant plus tentant à gonfler qu'il n'est lu que par des moteurs.
 
 ### Métadonnées : la fusion de Next est **de surface**
 
 C'est le piège le plus coûteux de l'App Router, parce qu'il est silencieux : rien
 n'échoue, ni au build ni au lint. Next fusionne les objets `metadata` des segments d'une
-route **en surface**. Un champ imbriqué — `openGraph`, `robots`, `twitter` — déclaré par
+route **en surface**. Un champ imbriqué (`openGraph`, `robots`, `twitter`) déclaré par
 un segment enfant **remplace intégralement** celui du layout ; il ne le complète pas.
 
 Une page qui n'exportait que son URL de partage :
@@ -86,7 +86,7 @@ openGraph: { url: page.route }   // ✗ efface og:image, og:site_name et og:loca
 ```
 
 perdait donc le visuel et l'identité du site posés par `src/app/layout.tsx`. Partagée sur
-un réseau social, elle sortait en **lien nu** — sans image et sans nom de site (issue
+un réseau social, elle sortait en **lien nu**, sans image et sans nom de site (issue
 #60). Le défaut ne se voit pas dans le code source de la page : il ne se constate que
 dans le HTML généré.
 
@@ -99,7 +99,7 @@ Les règles qui en découlent :
 - **Le socle s'étale dans le constructeur commun, jamais page par page.** Les deux
   fonctions de `src/seo/page-metadata` (`buildPageMetadata` et
   `buildArticleMetadata`) écrivent `{ ...SITE_OPEN_GRAPH, url: … }`, et toutes les pages
-  passent par elles. Une route ajoutée demain hérite sans y penser — c'est la seule
+  passent par elles. Une route ajoutée demain hérite sans y penser : c'est la seule
   raison pour laquelle ces constructeurs existent.
 - **Ce qui est propre à la page vient après le spread** : `url` toujours, `type:
   'article'` et les dates pour un billet de blog.
@@ -109,7 +109,7 @@ Les règles qui en découlent :
 - **`openGraph.images` échappe à `trailingSlash`.** Next n'applique cette règle qu'à
   `openGraph.url` ; les images sont seulement résolues contre `metadataBase`. Le chemin
   `/opengraph-image` tombe donc bien sur le fichier produit par l'export, qui n'a ni
-  extension ni barre finale — et que `docker/nginx.conf` doit typer à la main, faute de
+  extension ni barre finale, et que `docker/nginx.conf` doit typer à la main, faute de
   suffixe à lire.
 - **La vérification se fait sur le HTML généré**, jamais sur le code source :
   `make build`, puis inspecter les balises `og:` de `out/<route>/index.html`. Une page
@@ -144,7 +144,7 @@ est décrit dans [data-model](./data-model.md).
 **Les illustrations sont de la donnée aussi.** Le site ne sert aucune image matricielle :
 l'illustration d'un article n'est pas un chemin de fichier mais une **valeur d'union close**
 (`IArticle.figure`), rendue en SVG au serveur par `src/components/ArticleFigure`. Un
-article ne peut donc pas réclamer une figure qui n'existe pas — le compilateur le dit avant
+article ne peut donc pas réclamer une figure qui n'existe pas : le compilateur le dit avant
 le build, et aucune ressource ne peut manquer à l'exécution. La grammaire de ces figures est
 décrite dans [design](./design.md).
 
@@ -170,32 +170,32 @@ décrite dans [design](./design.md).
 - **`services/` vs hooks** : la logique **métier** vit dans `src/services/`
   (règles de gestion, appels API) ; les **hooks React** ne portent que la logique
   de **rendu** (état d'UI, orchestration des services pour les composants).
-- **`src/utils/`** : utilitaires transverses (helpers purs, formatage) — sans état,
+- **`src/utils/`** : utilitaires transverses (helpers purs, formatage), sans état,
   sans logique métier.
 - **Interfaces & types** : `src/interfaces/` regroupe **toutes** les interfaces
-  d'entités — une interface par fichier, nom préfixé par `I` (`IProduct`, `IUser`…) ;
+  d'entités, une interface par fichier, nom préfixé par `I` (`IProduct`, `IUser`…) ;
   `src/interfaces/types.ts` regroupe les **alias de types purs** (unions, utilitaires),
   jamais d'interface dedans.
-- **Validation des entrées — Zod (obligatoire)** : toute entrée externe (formulaire,
+- **Validation des entrées avec Zod (obligatoire)** : toute entrée externe (formulaire,
   réponse d'API, query params, env) passe par un schéma Zod de `src/schemas/`
   (`product.schema.ts`) ; type dérivé par `z.infer`, jamais de cast direct.
 - **État** : privilégier l'état local + hooks ; un store global uniquement si justifié.
-- **Composants** : max 300 lignes — extraire sous-composants et hooks personnalisés.
+- **Composants** : max 300 lignes, extraire sous-composants et hooks personnalisés.
 
 ## API (routes du framework)
 
-- **Découpage** : routes → services → repositories — les routes ne portent aucune
+- **Découpage** : routes → services → repositories. Les routes ne portent aucune
   logique métier.
-- **Validation — Zod (obligatoire)** : chaque body/query/webhook est validé à la
+- **Validation avec Zod (obligatoire)** : chaque body/query/webhook est validé à la
   frontière par un schéma de `src/schemas/`.
 
 ## Choix techniques et justifications
 
 | Choix | Alternatives considérées | Justification |
 |-------|--------------------------|---------------|
-| **Next.js (App Router)** | Vite + React, Astro | Rendu statique et métadonnées par page nativement, stratégie de rendu arbitrable route par route — exactement l'argument SEO vendu dans l'offre. C'est aussi la stack mise en avant sur le site : la cohérence compte. |
+| **Next.js (App Router)** | Vite + React, Astro | Rendu statique et métadonnées par page nativement, stratégie de rendu arbitrable route par route, exactement l'argument SEO vendu dans l'offre. C'est aussi la stack mise en avant sur le site : la cohérence compte. |
 | **Rendu statique (SSG) par défaut** | SSR systématique | Contenu éditorial quasi figé. Coût serveur nul, TTFB minimal, Core Web Vitals au vert sans effort d'optimisation ultérieur. |
 | **Pas de base de données** | CMS headless (Strapi), Notion API | Le contenu change quelques fois par an et n'a qu'un seul auteur. Le versionner dans le dépôt le rend relisible en revue de PR et supprime une dépendance d'exploitation. À réévaluer si la publication devient fréquente. |
-| **Contenu typé en TypeScript** | Fichiers Markdown / MDX | Les entités (offre, expérience, certification) ont une forme stricte que le typage fait respecter — un lien de certification manquant devient une erreur de compilation, pas une page publiée avec un lien mort. |
+| **Contenu typé en TypeScript** | Fichiers Markdown / MDX | Les entités (offre, expérience, certification) ont une forme stricte que le typage fait respecter : un lien de certification manquant devient une erreur de compilation, pas une page publiée avec un lien mort. |
 | **Zod sur `/api/contact`** | Validation manuelle | Seule entrée externe du site, donc seule surface d'attaque : elle est validée à la frontière, type dérivé par `z.infer`. |
 | **Hébergement** | _à trancher_ | Vercel (affinité Next.js, previews par PR) ou le VPS Hetzner existant. Décision à prendre avant la première mise en production. |

--- a/docs/captures/README.md
+++ b/docs/captures/README.md
@@ -1,7 +1,7 @@
 # Captures de référence
 
 Planches **avant / après** attachées à une décision de design documentée. Ce ne sont pas
-des pages de documentation : ce sont les **pièces** d'un raisonnement qui vit ailleurs —
+des pages de documentation : ce sont les **pièces** d'un raisonnement qui vit ailleurs :
 ici [`docs/design.md`](../design.md).
 
 Elles ne sont **pas servies** : `next.config.mjs` exporte `src/app` et `public`, jamais
@@ -29,8 +29,8 @@ Deux pièges, rencontrés et corrigés dans le script :
 
 | Fichier | Ce qu'elle montre | Issue |
 |---|---|---|
-| `115-verre-bandes.png` | l'en-tête et la barre de pôle empilés, à la position où la mesure a trouvé le pire fond sous la barre — `/services/data/`, 4440px | #115 |
-| `115-verre-entete.png` | l'en-tête seul, à la position du pire cas en thème clair : l'aplat d'accent du bouton du seuil passe dessous — accueil, 528px | #115 |
+| `115-verre-bandes.png` | l'en-tête et la barre de pôle empilés, à la position où la mesure a trouvé le pire fond sous la barre (`/services/data/`, 4440px) | #115 |
+| `115-verre-entete.png` | l'en-tête seul, à la position du pire cas en thème clair : l'aplat d'accent du bouton du seuil passe dessous (accueil, 528px) | #115 |
 | `115-verre-actions.png` | les deux actions du seuil : l'action principale reste un aplat, l'action secondaire devient une pastille de verre | #115 |
 | `115-verre-contact.png` | le bloc de contact, qui passe d'un voile sans flou à un vrai panneau de verre | #115 |
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -11,30 +11,30 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
 
 ## Jobs
 
-- **lint** : `make lint` — Biome sur tout le dépôt + `scripts/check-max-lines.sh`
+- **lint** : `make lint`, Biome sur tout le dépôt + `scripts/check-max-lines.sh`
   (échec si un fichier source dépasse **300 lignes**).
-- **type-check (dev)** : `make type-check` — `tsc --noEmit`, vérification des types
+- **type-check (dev)** : `make type-check` (`tsc --noEmit`), vérification des types
   **sans émission de fichiers**. Un type faux fait échouer la PR vers `dev`, là où il
   n'était auparavant détecté qu'au `make build` de `ci-main-build`, au moment de la mise
   en production. Le job est **séparé de `ci-dev-lint`** parce qu'il exécute `make install`
   au préalable : `tsc` a besoin des types de Next, React et Jest, quand `ci-dev-lint`
   tourne volontairement sans installation (Biome via `npx`). Le périmètre est celui de
-  `tsconfig.json` : `cypress.config.ts` et `tests/e2e` restent **exclus** — les types de
+  `tsconfig.json` : `cypress.config.ts` et `tests/e2e` restent **exclus**. Les types de
   Cypress y chargent le `expect()` de Chai, qui écrase celui de Jest ; Cypress
   type-vérifie ses propres specs.
 - **tests (dev)** : unitaires + intégration, front et back.
-- **e2e (main)** : `make test-e2e` — le harnais `scripts/e2e.mjs` construit l'export
+- **e2e (main)** : `make test-e2e`, le harnais `scripts/e2e.mjs` construit l'export
   statique si `out/` manque, le sert sur `127.0.0.1:E2E_PORT` (4173 par défaut) avec les
   règles de résolution de `docker/nginx.conf`, **attend que le port réponde** (sonde
-  HTTP, pas de `sleep`), lance Cypress headless, puis arrête le serveur — y compris en
+  HTTP, pas de `sleep`), lance Cypress headless, puis arrête le serveur, y compris en
   cas d'échec, sans processus orphelin. Le code de sortie du harnais est celui de
   Cypress : aucun échec n'est absorbé. Détail : [testing](./testing.md).
-- **a11y (dev)** : `make budget-a11y` — axe-core sur l'accueil, une page de pôle et une
+- **a11y (dev)** : `make budget-a11y`, axe-core sur l'accueil, une page de pôle et une
   page d'article ; une violation d'impact `critical` ou `serious` fait échouer la PR.
   Placé sur `dev` **parce qu'il est rapide** (~2 min) et qu'une régression
   d'accessibilité vient presque toujours d'un changement de balisage : elle se corrige
   cent fois moins cher le jour où elle est écrite. Ce contrôle ne vaut **pas** un audit
-  RGAA — il couvre la part mécanisable de WCAG AA, voir
+  RGAA : il couvre la part mécanisable de WCAG AA, voir
   [accessibility](./accessibility.md).
 - **budgets (main)** : `make budgets`, soit axe **et** Lighthouse (plancher bloquant : 80 en
   performance depuis le 2026-08-24, 95 sur les trois autres catégories ; cible 95
@@ -42,24 +42,24 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
   Placé sur `main` **parce qu'il est lent** : trois passes par page, et la variance de
   Lighthouse impose la répétition. Le payer à chaque PR vers `dev` taxerait tout le monde
   pour une métrique qui bouge rarement d'un commit à l'autre ; le placer sur la PR de
-  mise en production le met là où la question se pose — *est-ce que ce qu'on publie tient
+  mise en production le met là où la question se pose : *est-ce que ce qu'on publie tient
   les chiffres qu'on vend ?* Un `workflow_dispatch` permet de le lancer à la demande
   depuis `dev` sans attendre la PR de production. Seuils et cibles :
   `scripts/budgets/pages.mjs`, source unique. Un score entre le plancher et la cible ne
   fait pas échouer le contrôle, il est listé nommément dans le rapport.
   Détail : [testing](./testing.md).
-- **nginx (dev)** : `make nginx-check` — monte `docker/nginx.conf` là où le
+- **nginx (dev)** : `make nginx-check`, monte `docker/nginx.conf` là où le
   `Dockerfile` le copie et lance **`nginx -t`** dans l'image `nginx:1.29-alpine`. Placé
   sur `dev` **parce qu'il est rapide** : aucun build applicatif, un pull d'image et un
   test de syntaxe, ~10 s. Ce fichier décidait jusqu'ici du comportement de production
-  sans qu'aucun contrôle ne le lise — une directive mal orthographiée passait toute la CI
+  sans qu'aucun contrôle ne le lise : une directive mal orthographiée passait toute la CI
   au vert et n'éclatait qu'au premier `docker compose up`. Un défaut qui ne se voit qu'en
   production coûte trop cher pour attendre la PR de mise en production. Détail :
   [docker](./docker.md).
-- **docker (dev)** : `make docker-smoke` — **construit l'image**, rejoue `nginx -t`
+- **docker (dev)** : `make docker-smoke`, **construit l'image**, rejoue `nginx -t`
   dedans, la démarre et vérifie les promesses de la configuration : `GET /` → 200, URL
   absente → 404, `Content-Encoding: gzip` sur le HTML, `Vary: Accept-Encoding`. Il ajoute
-  la seule chose que `nginx -t` ne sait pas dire : que les directives **agissent** — un
+  la seule chose que `nginx -t` ne sait pas dire : que les directives **agissent**. Un
   `gzip_types` mal placé reste syntaxiquement valide, un `Content-Encoding` absent ne se
   discute pas. Placé sur `dev` **après mesure** : estimé à quatre minutes, il en prend
   **cinquante secondes**, moins que `ci-dev-a11y`. Le critère du dépôt est la durée ; à ce
@@ -78,8 +78,8 @@ Le hook `.claude/hooks/check-ci-before-publish.sh` (PreToolUse) vérifie l'état
 | État de la pipeline sur le commit | Décision |
 |---|---|
 | tout vert | la commande passe |
-| rouge (`failure`, `timed_out`, `cancelled`) | **refus** — on corrige le **code** |
-| en cours (`queued`, `in_progress`, `running`) | **refus** — attendre (`gh pr checks --watch`, `glab ci status`) |
+| rouge (`failure`, `timed_out`, `cancelled`) | **refus** : on corrige le **code** |
+| en cours (`queued`, `in_progress`, `running`) | **refus** : attendre (`gh pr checks --watch`, `glab ci status`) |
 | aucun run pour ce commit, CLI absente, réseau KO | **confirmation humaine** |
 
 Le push d'une branche `feature/*` ou `hotfix/*` passe toujours : c'est lui qui
@@ -93,12 +93,12 @@ depuis une commande. Sur les fichiers de workflow, `continue-on-error: true`,
 `if: false` et `when: never` demandent confirmation.
 
 `REQUIRE_GREEN_CI=0` dans l'environnement de la session (Jérôme MARICHEZ uniquement)
-désactive la seule interrogation réseau — jamais les anti-contournements.
+désactive la seule interrogation réseau, jamais les anti-contournements.
 
 ## Règles
 
 - Un check rouge **bloque la fusion** (branches protégées) **et la publication**.
 - Interdiction de modifier/affaiblir les workflows pour faire passer la CI
-  (voir `CLAUDE.md`, règle d'intégrité) — le hook ci-dessus l'applique.
+  (voir `CLAUDE.md`, règle d'intégrité) : le hook ci-dessus l'applique.
 
 <!-- TODO : ajouter le déploiement (registry Docker, environnements) quand il existera. -->

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -8,7 +8,7 @@ TypeScript dans `src/contenu/`, et sa forme est tenue par des interfaces de
 > externes** (formulaire, body d'API, webhook, variables d'environnement). Un fichier de
 > contenu compilé avec le site n'en est pas une : le compilateur refuse déjà un champ
 > manquant ou mal typé, et un schéma exécuté au build ne ferait que revérifier ce que
-> TypeScript a garanti. La seule vraie frontière du blog est le `slug` d'URL — il est
+> TypeScript a garanti. La seule vraie frontière du blog est le `slug` d'URL : il est
 > confronté à la liste close des articles par `generateStaticParams`, donc aucune URL
 > hors de cette liste n'est servie. Il en va de même pour les réalisations.
 
@@ -20,21 +20,21 @@ TypeScript dans `src/contenu/`, et sa forme est tenue par des interfaces de
 | **`IJointure`** | `src/interfaces/IJointure.ts` | Une **arête** : ce qu'un pôle remet au suivant, et ce qui se passe si le client l'a déjà | `amont` et `aval` référencent un `PoleId` |
 | `IEditorialPage` | `src/interfaces/IEditorialPage.ts` | Une page rédigée (accueil, page de pôle) | contient des `IEditorialSection` |
 | `IEditorialSection` | `src/interfaces/IEditorialSection.ts` | Une section de page | contient des `IEditorialBlock` ; `pole` référence un `PoleId` |
-| `IEditorialBlock` | `src/interfaces/IEditorialBlock.ts` | Un point d'expertise | — |
+| `IEditorialBlock` | `src/interfaces/IEditorialBlock.ts` | Un point d'expertise | *aucune* |
 | `IProof` | `src/interfaces/IProof.ts` | Une preuve chiffrée | `fiche` référence une `IRealisationChiffree` |
 | **`IRealisation`** | `src/interfaces/IRealisation.ts` | **Une réalisation** : un travail mené, son cadre, sa décision | contient un `IRealisationCadre` et des `IRealisationEtape` ; `poles` référence des `PoleId` |
 | `IRealisationChiffree` | `src/interfaces/IRealisationChiffree.ts` | Une `IRealisation` dont le `chiffre` est **obligatoire** | étend `IRealisation` |
-| `IRealisationCadre` | `src/interfaces/IRealisationCadre.ts` | Le cadre : statut, organisation, poste, période, équipe | — |
-| `IRealisationChiffre` | `src/interfaces/IRealisationChiffre.ts` | Un résultat chiffré, et ce qu'il ne dit pas | — |
-| `IRealisationEtape` | `src/interfaces/IRealisationEtape.ts` | Une étape du travail mené | — |
+| `IRealisationCadre` | `src/interfaces/IRealisationCadre.ts` | Le cadre : statut, organisation, poste, période, équipe | *aucune* |
+| `IRealisationChiffre` | `src/interfaces/IRealisationChiffre.ts` | Un résultat chiffré, et ce qu'il ne dit pas | *aucune* |
+| `IRealisationEtape` | `src/interfaces/IRealisationEtape.ts` | Une étape du travail mené | *aucune* |
 | `IRealisationGroupe` | `src/interfaces/IRealisationGroupe.ts` | Vue dérivée : un cadre et ses fiches | calculée par `find-realisation`, jamais déclarée |
-| `IRealisationsIndex` | `src/interfaces/IRealisationsIndex.ts` | L'en-tête éditoriale de `/realisations` | — |
+| `IRealisationsIndex` | `src/interfaces/IRealisationsIndex.ts` | L'en-tête éditoriale de `/realisations` | *aucune* |
 | `ICertification` | `src/interfaces/ICertification.ts` | Une certification obtenue | `ICertificationLogo` |
-| `IBoundary` | `src/interfaces/IBoundary.ts` | Une limite assumée | — |
+| `IBoundary` | `src/interfaces/IBoundary.ts` | Une limite assumée | *aucune* |
 | **`IArticle`** | `src/interfaces/IArticle.ts` | **Un article du blog** | contient des `IArticleSection`, porte une `IArticleSource` |
-| `IArticleSection` | `src/interfaces/IArticleSection.ts` | Une section d'article : un titre, des paragraphes, éventuellement une liste | — |
-| `IArticleSource` | `src/interfaces/IArticleSource.ts` | La publication d'origine d'un article | — |
-| `IBlogIndex` | `src/interfaces/IBlogIndex.ts` | L'en-tête éditoriale de `/blog` | — |
+| `IArticleSection` | `src/interfaces/IArticleSection.ts` | Une section d'article : un titre, des paragraphes, éventuellement une liste | *aucune* |
+| `IArticleSource` | `src/interfaces/IArticleSource.ts` | La publication d'origine d'un article | *aucune* |
+| `IBlogIndex` | `src/interfaces/IBlogIndex.ts` | L'en-tête éditoriale de `/blog` | *aucune* |
 | `IBreadcrumbItem` | `src/interfaces/IBreadcrumbItem.ts` | Un niveau de fil d'Ariane | lu par le rendu **et** par le JSON-LD |
 
 ## Le bloc éditorial (`IEditorialBlock`)
@@ -56,7 +56,7 @@ absence est un **signal de relecture**, pas un état souhaitable.
 
 `texte` l'est pour la raison inverse. Quand un bloc porte déjà un titre, une preuve
 chiffrée et une décision, le paragraphe redit en prose ce que les trois autres
-établissent — et c'est le seul des quatre qui n'apporte rien à un dirigeant pressé
+établissent, et c'est le seul des quatre qui n'apporte rien à un dirigeant pressé
 (issue #45). Dans ce cas précis, il s'omet.
 
 ### Contraintes d'intégrité
@@ -102,7 +102,7 @@ contenu : une page de pôle est vraie ou fausse, un article est vrai **à une da
 | `paragraphes` | `string[]` | oui | Texte fini, un `<p>` par entrée |
 | `liste` | `string[]` | non | Points listés, rendus en `<ul>` **après** les paragraphes |
 
-Le modèle est resté pauvre pendant quatre articles — un titre, des paragraphes — et son
+Le modèle est resté pauvre pendant quatre articles (un titre, des paragraphes) et son
 commentaire annonçait déjà la suite : « le jour où un article demande davantage, c'est le
 modèle qu'on élargit, pas le rendu qu'on contourne ». **Ce jour est l'issue #121** : deux
 articles repris de posts portent une énumération dont la valeur tient à la forme, et l'un
@@ -122,13 +122,13 @@ L'élargissement s'arrête à **un champ**, et trois limites le tiennent :
   sections.
 
 Côté rendu, c'est la **seule liste de prose du site** : partout ailleurs un `<ul>` porte
-une navigation ou des cartes, et sa puce est retirée. Ici elle reste — `list-style: none`
+une navigation ou des cartes, et sa puce est retirée. Ici elle reste : `list-style: none`
 fait perdre à Safari/VoiceOver les sémantiques de liste, et c'est précisément ici que
 l'annonce « liste de *n* éléments » vaut quelque chose.
 
 ### Contraintes d'intégrité
 
-Aucune n'est vérifiée à l'exécution — elles le sont par le compilateur, par la
+Aucune n'est vérifiée à l'exécution. Elles le sont par le compilateur, par la
 construction du site, ou elles restent à la charge de l'auteur :
 
 - **`slug` unique et stable.** Deux articles de même slug produiraient deux fois la même
@@ -159,14 +159,14 @@ construction du site, ou elles restent à la charge de l'auteur :
 - **Un article repris ailleurs porte le texte, il ne le réécrit pas** (issue #121). Le
   titre, le plan et les formulations de l'auteur passent tels quels ; seules deux choses
   les modifient : une **correction de véracité** (une affirmation plus large que ce qui est
-  établi se réécrit à la baisse) et la **mise à la forme** d'un article — orthographe,
-  syntaxe, chapô, sections titrées. La ligne éditoriale du site — vendre une décision,
-  finir sur ce que le lecteur peut trancher — s'applique à un article **écrit pour le
+  établi se réécrit à la baisse) et la **mise à la forme** d'un article (orthographe,
+  syntaxe, chapô, sections titrées). La ligne éditoriale du site (vendre une décision,
+  finir sur ce que le lecteur peut trancher) s'applique à un article **écrit pour le
   site** ; elle n'autorise pas à refaire l'angle d'un texte repris.
 - **`figure` est obligatoire, délibérément.** La laisser facultative aurait produit une liste
   où certains articles ont une figure et d'autres pas, c'est-à-dire un rythme cassé sans
-  qu'aucune information ne le justifie. Deux articles peuvent partager une figure — rien ne
-  l'interdit — mais les articles publiés en ont chacun une, sans quoi elle cesserait de
+  qu'aucune information ne le justifie. Deux articles peuvent partager une figure (rien ne
+  l'interdit), mais les articles publiés en ont chacun une, sans quoi elle cesserait de
   distinguer.
 
 ### Règles portées par le service
@@ -193,7 +193,7 @@ un composant :
   d'article ».
 - **Pas de rattachement à un pôle, pas de tags, pas de catégories.** À cinq articles,
   une taxonomie serait encore un classement sans classe. Le jour où elle s'impose, le
-  rattachement dérivera de `PoleId` et de l'ordre porté par `POLES_NAV` — jamais d'une
+  rattachement dérivera de `PoleId` et de l'ordre porté par `POLES_NAV`, jamais d'une
   liste de pôles recopiée dans le blog. L'ordre est **la position dans `POLES_NAV`**, et
   nulle part ailleurs : une seconde liste d'ordre finirait par contredire la première.
 - **Pas de statut `brouillon`.** Un article non publié n'est pas dans `articles.ts`.
@@ -201,7 +201,7 @@ un composant :
 ## La réalisation (`IRealisation`)
 
 C'est l'entité la plus exposée du site : le format « portfolio » dérive de lui-même vers
-« mon client X ». Le modèle tient cette frontière par le **type**, pas par la relecture —
+« mon client X ». Le modèle tient cette frontière par le **type**, pas par la relecture :
 chaque fiche porte le **statut** sous lequel elle a été menée, et ce statut n'est pas
 uniforme : deux postes salariés (Acetelecom / MailingVox, Verhoeven Joaillier) et une
 mission en indépendant (Truffle Capital, 2017-2019).
@@ -223,31 +223,31 @@ mission en indépendant (Truffle Capital, 2017-2019).
 ### Ce que le type interdit, et pourquoi
 
 - **`cadre` n'a aucun champ optionnel.** Une fiche ne peut pas paraître sans dire d'où
-  elle vient — et une fiche sans provenance se lit comme une prestation vendue. C'est le
+  elle vient, et une fiche sans provenance se lit comme une prestation vendue. C'est le
   compilateur qui ferme cette porte, parce que c'est le seul garde-fou qui ne s'oublie pas
   en relecture. Le champ `equipe` existe pour la même raison : il empêche « j'ai managé N
   développeurs », en obligeant à écrire ce qui a réellement été encadré.
 - **`statut` est obligatoire au même titre, et c'est lui qui manquait.** Tant que le cadre
   ne portait que l'organisation, le poste, la période et l'équipe, l'espace pouvait
-  annoncer « trois postes salariés » sans que rien ne le contredise — alors que Truffle
+  annoncer « trois postes salariés » sans que rien ne le contredise, alors que Truffle
   Capital était une mission menée en auto-entrepreneur (issue #107). Un champ facultatif
   aurait laissé revenir la même ambiguïté fiche par fiche.
 - **Le chiffre n'a qu'une porte d'entrée.** `IRealisationChiffre` est une entité à part,
-  avec une `portee` obligatoire — ce que le chiffre **ne** dit **pas**. Un chiffre publié
+  avec une `portee` obligatoire : ce que le chiffre **ne** dit **pas**. Un chiffre publié
   sans sa portée se fait élargir tout seul par celui qui le lit : « +50 % de panier moyen »
   devient « +50 % de chiffre d'affaires ». Concentrer le nombre dans une entité dédiée le
   rend aussi visible en revue : une quatrième fiche chiffrée ne peut pas apparaître au
   détour d'un paragraphe.
 - **`IRealisationChiffree` porte les deux gabarits dans le type.** `IRealisation` laisse
-  `chiffre` optionnel — c'est le cas général ; l'interface dérivée le rend obligatoire.
+  `chiffre` optionnel : c'est le cas général ; l'interface dérivée le rend obligatoire.
   `IProof.fiche` n'accepte qu'une `IRealisationChiffree`, donc le mur de preuves de
   l'accueil **lit** le chiffre sur la fiche au lieu de le recopier. Le nombre n'est écrit
   qu'une fois dans le dépôt : l'accueil et la fiche ne peuvent pas diverger.
 - **`resultat` est obligatoire même quand il n'y a rien à annoncer.** Deux fiches n'ont
   aucun résultat mesuré et l'écrivent. Rendre le champ optionnel laisserait une fiche muette
   sur son issue, ce qui se lit comme un résultat tu, pas comme un résultat absent.
-- **`poles` n'est pas contraint.** Le modèle de l'offre — ingénierie web → data → (IA
-  et/ou SEA & UX) — décrit ce qui se vend aujourd'hui, pas un historique. Un type qui
+- **`poles` n'est pas contraint.** Le modèle de l'offre, ingénierie web → data → (IA
+  et/ou SEA & UX), décrit ce qui se vend aujourd'hui, pas un historique. Un type qui
   exigerait `data` partout forcerait à réétiqueter des travaux de 2017 pour satisfaire le
   compilateur : ce serait le type qui écrirait le contenu.
 
@@ -259,7 +259,7 @@ Elles vivent dans `src/services/find-realisation.ts` :
 |-------|--------------|
 | `listRealisations()` | Rend la liste **dans l'ordre déclaré**. Aucun tri : une réalisation n'est pas datée, il n'existe pas de clé de tri qui ne soit pas inventée |
 | `groupRealisationsByCadre()` | Groupe par organisation, dans l'ordre de `CADRES` (du poste le plus récent au plus ancien). Un cadre sans fiche ne produit pas de groupe vide |
-| `findRealisation(slug)` | Rend la fiche et jusqu'à `MAX_REALISATIONS_LIEES` (2) autres, choisies sur les **pôles partagés** — la liste groupe déjà par organisation, proposer trois fois la même organisation en bas de page n'apprendrait rien. **Lève** sur un slug inconnu |
+| `findRealisation(slug)` | Rend la fiche et jusqu'à `MAX_REALISATIONS_LIEES` (2) autres, choisies sur les **pôles partagés** : la liste groupe déjà par organisation, proposer trois fois la même organisation en bas de page n'apprendrait rien. **Lève** sur un slug inconnu |
 | `listPoles(ids)` (`find-pole`) | Ordonne les pôles selon `POLES_NAV`, jamais selon l'ordre déclaré par la fiche |
 
 ## Où vivent les données
@@ -286,7 +286,7 @@ src/contenu/realisations/
 
 `articles.ts` et `realisations.ts` alimentent **tout** : la liste, les pages générées au
 build (`generateStaticParams`), le sitemap (`src/seo/sitemap-entries`) et les données
-structurées. Retirer une entrée de ces tableaux la fait disparaître partout — il n'y a pas
+structurées. Retirer une entrée de ces tableaux la fait disparaître partout : il n'y a pas
 de second endroit à mettre à jour.
 
 ## Règles générales
@@ -294,7 +294,7 @@ de second endroit à mettre à jour.
 - **Pas de binaire en base** : sans objet, il n'y a pas de base. Les rares visuels (logos
   de certification) sont des **références** vers `public/`, jamais des données.
 - **Migrations** : sans objet. Un changement de forme d'entité est une modification de
-  type, donc une erreur de compilation tant que le contenu ne l'a pas suivie — c'est la
+  type, donc une erreur de compilation tant que le contenu ne l'a pas suivie : c'est la
   contrepartie recherchée d'un contenu typé plutôt que stocké.
 - **Seed de démonstration** : sans objet. Les jeux de données de test vivent dans
   `tests/fixtures/` (`article.fixture.json` pour le blog).

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,11 +1,11 @@
 # Design & UI
 
 Direction retenue : **« L'Établi »**. Le site est un plan de travail vu à travers des
-panneaux de verre — on voit littéralement au travers parce qu'il n'y a rien à cacher,
+panneaux de verre : on voit littéralement au travers parce qu'il n'y a rien à cacher,
 ni chaîne de prestataires ni couche commerciale. Les quatre pôles ne sont pas quatre
 offres côte à côte au catalogue, et ce n'est pas non plus une file de quatre maillons :
-ce sont des plaques teintées chacune par sa propre teinte, dont les deux dernières —
-l'IA et le SEA & UX — sont écartées **côte à côte**, à égalité. Un seul filet vertical
+ce sont des plaques teintées chacune par sa propre teinte, dont les deux dernières (l'IA
+et le SEA & UX) sont écartées **côte à côte**, à égalité. Un seul filet vertical
 les traverse toutes : l'interlocuteur unique.
 
 Le verre ne réfracte **jamais du texte**, seulement le fond d'atelier (dégradé + trame
@@ -21,7 +21,7 @@ exactement l'arbitrage que le site vend, appliqué à lui-même.
   jamais un prérequis de lecture. La scène des quatre dalles, elle, est du SVG : elle
   s'affiche partout, au même coût sur un téléphone et sur un poste de travail.
 - **Thème** : clair et sombre, via `prefers-color-scheme`. Les deux palettes sont
-  complètes et vérifiées en contraste — aucune couleur n'est définie dans un seul thème.
+  complètes et vérifiées en contraste : aucune couleur n'est définie dans un seul thème.
 
 ## Bibliothèque UI
 
@@ -32,7 +32,7 @@ système entier coûterait plus en poids et en contraintes qu'il ne ferait gagne
 |-------|-------|
 | Composants maison | `src/components/`, un dossier par composant |
 
-**Aucune dépendance d'effet visuel.** Le verre est du CSS — voir « Le verre » plus bas
+**Aucune dépendance d'effet visuel.** Le verre est du CSS, voir « Le verre » plus bas
 pour les deux bibliothèques essayées et écartées, et pourquoi.
 
 ## Stratégie de style
@@ -54,9 +54,9 @@ site, et aucune n'est autorisée.
 **Le flou des panneaux n'a plus de seuil ; leur réfraction en a un.** Les deux ne se
 confondent pas : le flou est le verre lui-même et il est servi partout, la réfraction est
 un enrichissement desktop qui coûtait un point de budget sur mobile pour un écart de
-2/255 — voir « La réfraction » plus bas.
+2/255, voir « La réfraction » plus bas.
 
-**Le flou des panneaux, donc, n'a plus de seuil.** Il en avait un — 1024px — pour deux raisons
+**Le flou des panneaux, donc, n'a plus de seuil.** Il en avait un (1024px) pour deux raisons
 qui appartenaient toutes deux à liquidGL : Safari devenait instable dès qu'une lentille
 dépassait la moitié du viewport, et le flou promettait une couche GPU pour un mouvement
 qui n'arrivait jamais sur un petit écran. La bibliothèque partie, il ne reste qu'un
@@ -68,7 +68,7 @@ Les **bandes collantes** gardent le seuil, pour une raison qui n'a rien à voir 
 liquidGL : une bande `sticky` pleine largeur est reflouée à **chaque image de
 défilement**, puisque ce qui passe dessous change en permanence. C'est le cas d'école du
 jank au défilement, sur les appareils qui en ont le moins les moyens. Sous 1024px les
-deux bandes sont donc **opaques** — jamais translucides sans flou, ce qui laisserait
+deux bandes sont donc **opaques**, jamais translucides sans flou, ce qui laisserait
 passer un fantôme de texte.
 
 ## Jetons
@@ -76,23 +76,23 @@ passer un fantôme de texte.
 Valeurs réelles dans [`globals.css`](../src/app/globals.css). Les ratios de contraste
 ci-dessous sont ceux des couples texte/fond effectivement utilisés.
 
-### Couleurs — thème clair
+### Couleurs : thème clair
 
 | Jeton | Valeur | Usage | Contraste sur `--fond` |
 |-------|--------|-------|------------------------|
-| `--fond` | `#F2EFE8` | fond de page, papier chaud | — |
-| `--fond-creux` | `#E7E2D7` | bandes de section en retrait | — |
+| `--fond` | `#F2EFE8` | fond de page, papier chaud | *sans objet* |
+| `--fond-creux` | `#E7E2D7` | bandes de section en retrait | *sans objet* |
 | `--encre` | `#14171A` | texte courant et titres | 15.67:1 |
 | `--encre-douce` | `#4A5157` | texte secondaire, chapôs | 7.02:1 |
 | `--cuivre` | `#8F4520` | teinte de marque, et teinte du pôle « ingénierie web » | 6.02:1 |
 | `--cuivre-vif` | `#B4623A` | **non-texte uniquement** : filets, arêtes | 3.85:1 |
-| `--signal` | `#1F5F52` | **la décision, et rien d'autre** — voir plus bas | 6.49:1 |
+| `--signal` | `#1F5F52` | **la décision, et rien d'autre**, voir plus bas | 6.49:1 |
 
-### Couleurs — thème sombre
+### Couleurs : thème sombre
 
 | Jeton | Valeur | Contraste sur `--fond` |
 |-------|--------|------------------------|
-| `--fond` | `#0E1114` | — |
+| `--fond` | `#0E1114` | *sans objet* |
 | `--encre` | `#ECE7DE` (jamais `#FFF`) | 15.38:1 |
 | `--encre-douce` | `#9BA3AA` | 7.41:1 |
 | `--cuivre` | `#E08B4C` | 7.18:1 |
@@ -106,52 +106,52 @@ tient en trois lignes, dans [`poles.css`](../src/app/poles.css) :
 
 1. une page ou une section de pôle pose `data-pole="<id>"` ;
 2. un bloc CSS mappe `--accent` et `--accent-vif` sur la teinte de ce pôle ;
-3. **aucun composant ne connaît la couleur d'un pôle** — les dix-huit modules CSS du
+3. **aucun composant ne connaît la couleur d'un pôle** : les dix-huit modules CSS du
    site ne consomment que `--accent` et `--accent-vif`.
 
-Hors de tout `data-pole` — accueil, blog, en-tête, pied de page — `--accent` vaut le
+Hors de tout `data-pole` (accueil, blog, en-tête, pied de page), `--accent` vaut le
 cuivre : la teinte de marque, qui est aussi celle du socle.
 
 Trois endroits posent `data-pole` : la page de pôle
 ([`PolePageView`](../src/views/PolePageView/index.tsx)), chaque maillon du
 schéma de la chaîne ([`ChainDiagram`](../src/components/ChainDiagram/index.tsx)),
-et chaque entrée du menu ([`SiteHeader`](../src/components/SiteHeader/index.tsx)) —
+et chaque entrée du menu ([`SiteHeader`](../src/components/SiteHeader/index.tsx)) :
 l'en-tête devient ainsi la légende de la palette.
 
 #### Le choix des teintes
 
 Les quatre teintes sont posées en **OKLCH**, sur une seule clarté et une seule chroma par
 variante : **seule la teinte change**. C'est ce qui interdit de lire une progression là où
-il n'y en a pas — en particulier entre l'IA et le SEA & UX, qui sont deux branches
+il n'y en a pas, en particulier entre l'IA et le SEA & UX, qui sont deux branches
 **parallèles** de la donnée et non deux étapes successives (`CLAUDE.md`). Deux couleurs
 d'éclat différent auraient affirmé dans le pixel un ordre que le modèle nie.
 
 | Pôle | Place | Teinte OKLCH | Lecture |
 |------|-------|--------------|---------|
-| Ingénierie web | socle, temps 1 | h ≈ 45 — cuivre | inchangée : c'est la couleur de la maison |
-| Data | passage, temps 2 | h = 215 — bleu d'encre | le tronc refroidit en passant du construire au mesurer |
-| IA | suite, temps 3 | h = 300 — violet | à **+85°** du bleu de la donnée |
-| SEA & UX | suite, temps 3 | h = 130 — vert | à **−85°** du bleu de la donnée |
+| Ingénierie web | socle, temps 1 | h ≈ 45, cuivre | inchangée : c'est la couleur de la maison |
+| Data | passage, temps 2 | h = 215, bleu d'encre | le tronc refroidit en passant du construire au mesurer |
+| IA | suite, temps 3 | h = 300, violet | à **+85°** du bleu de la donnée |
+| SEA & UX | suite, temps 3 | h = 130, vert | à **−85°** du bleu de la donnée |
 
 Les deux suites sont **équidistantes** de la teinte de leur parent, à clarté et chroma
 strictement égales : la branche ne progresse pas, elle se dédouble.
 
-#### Contraste — les 16 valeurs, mesurées
+#### Contraste : les 16 valeurs, mesurées
 
 Luminance relative WCAG 2.x, calculée sur les valeurs sRGB effectives. **Aucune n'est
 arrondie ni estimée.**
 
 | Pôle | `--accent` clair | `--accent-vif` clair | `--accent` sombre | `--accent-vif` sombre |
 |------|------------------|----------------------|-------------------|-----------------------|
-| Ingénierie web | `#8F4520` — **6.02:1** | `#B4623A` — **3.85:1** | `#E08B4C` — **7.18:1** | `#F0A468` — **9.21:1** |
-| Data | `#00697B` — **5.53:1** | `#008AA1` — **3.55:1** | `#01B6D4` — **7.79:1** | `#48CBE7` — **9.89:1** |
-| IA | `#674D91` — **6.00:1** | `#8669B7` — **3.88:1** | `#AF8FE8` — **7.14:1** | `#C3A6F8` — **9.14:1** |
-| SEA & UX | `#48691D` — **5.52:1** | `#638937` — **3.54:1** | `#87B357` — **7.77:1** | `#9FC774` — **9.83:1** |
+| Ingénierie web | `#8F4520`, **6.02:1** | `#B4623A`, **3.85:1** | `#E08B4C`, **7.18:1** | `#F0A468`, **9.21:1** |
+| Data | `#00697B`, **5.53:1** | `#008AA1`, **3.55:1** | `#01B6D4`, **7.79:1** | `#48CBE7`, **9.89:1** |
+| IA | `#674D91`, **6.00:1** | `#8669B7`, **3.88:1** | `#AF8FE8`, **7.14:1** | `#C3A6F8`, **9.14:1** |
+| SEA & UX | `#48691D`, **5.52:1** | `#638937`, **3.54:1** | `#87B357`, **7.77:1** | `#9FC774`, **9.83:1** |
 
 - **`--accent` porte du texte** : seuil 4.5:1. Les huit valeurs le passent, la plus basse
   à 5.52:1 (SEA & UX en thème clair).
 - **`--accent-vif` ne porte JAMAIS de texte** : seuil non-texte 3:1. Les quatre valeurs
-  claires sont entre 3.54:1 et 3.88:1 — au-dessus de 3:1, **sous** 4.5:1. C'est la même
+  claires sont entre 3.54:1 et 3.88:1, au-dessus de 3:1, **sous** 4.5:1. C'est la même
   règle que celle qui s'appliquait déjà au cuivre vif, étendue aux quatre pôles : filets,
   arêtes, liserés, jamais un mot.
 - En thème sombre, les seize valeurs dépassent 7:1 : aucune contrainte n'y est tendue.
@@ -160,23 +160,23 @@ arrondie ni estimée.**
 
 Le bleu de la donnée est la seule teinte dont la **chroma est bridée par le gamut sRGB**
 en thème clair : 0.084 au lieu des 0.110 des trois autres. Le cyan profond n'existe pas
-plus saturé à cette clarté. La conséquence est visible — la donnée paraît légèrement
-moins colorée que ses voisines sur fond clair — et elle est assumée : baisser les trois
+plus saturé à cette clarté. La conséquence est visible (la donnée paraît légèrement
+moins colorée que ses voisines sur fond clair) et elle est assumée : baisser les trois
 autres à 0.084 aurait éteint toute la palette pour aligner une seule teinte.
 
 Le **daltonisme** est la limite réelle de cette issue, et elle mérite d'être dite en
 clair. Quatre teintes à clarté et chroma égales ne peuvent pas rester toutes
 distinguables entre elles sous une vision dichromate : c'est une propriété de l'espace
 des couleurs, pas un défaut d'implémentation. Le choix a donc porté sur la paire qui
-compte le plus — les deux sœurs :
+compte le plus, les deux sœurs :
 
 | Paire | Protanopie | Deutéranopie | Tritanopie |
 |-------|-----------|--------------|------------|
 | IA / SEA & UX (retenue, h 300 / 130) | ΔE 0.199 | ΔE 0.180 | ΔE 0.024 |
 | *cyan / magenta voisins (écartée, h 210 / 320)* | *ΔE 0.061* | *ΔE 0.003* | *ΔE 0.115* |
 
-ΔE en OKLab, simulation Viénot 1999. La paire voisine — celle qui aurait le mieux dit
-« même famille chromatique » — rend les deux suites **strictement identiques** pour une
+ΔE en OKLab, simulation Viénot 1999. La paire voisine (celle qui aurait le mieux dit
+« même famille chromatique ») rend les deux suites **strictement identiques** pour une
 deutéranopie, qui touche environ 5 % des hommes. La paire retenue les sépare franchement
 sur les deux formes courantes de daltonisme, et faiblement sur la tritanopie, qui touche
 moins de 0.01 % de la population. Le prix payé est un écart de teinte plus large que
@@ -191,7 +191,7 @@ chaque pôle porte aussi son nom, son libellé de place et son temps.
 ### `--signal` : la décision, et rien d'autre
 
 `--signal` n'est pas une couleur d'ambiance. Il marque **la ligne « vous tranchez »**,
-partout où un bloc éditorial en porte une (`decision:` dans les contenus — une trentaine
+partout où un bloc éditorial en porte une (`decision:` dans les contenus, une trentaine
 d'occurrences), et le **témoin de mise en pause** du `MotionToggle`. Trois emplois, une
 seule idée : *ici, une décision*.
 
@@ -220,7 +220,7 @@ d'un panneau, ce texte ressortirait en traînée colorée sous l'en-tête.
 | Jeton | Valeur | Où |
 |-------|--------|-----|
 | `--verre-flou` | `22px` | les panneaux, à toutes les largeurs. En dessous de 22px, le verre se lit comme un calque translucide posé sur la trame, pas comme une épaisseur |
-| `--verre-saturation` | `1.7` | les panneaux. C'est la « vibrancy » : ce qui passe derrière ressort plus coloré qu'il n'entre — le réglage qui distingue un verre d'Apple d'un simple dépoli |
+| `--verre-saturation` | `1.7` | les panneaux. C'est la « vibrancy » : ce qui passe derrière ressort plus coloré qu'il n'entre, le réglage qui distingue un verre d'Apple d'un simple dépoli |
 | `--verre-flou-bande` | `14px` | les deux bandes collantes, au-delà de 1024px |
 | `--verre-saturation-bande` | `1.1` | les bandes : ce qui passe dessous est du texte, pas un décor |
 | `--verre-teinte-part` | `8%` (clair) / `13%` (sombre) | part d'`--accent` lavée dans le **haut** du panneau, éteinte avant la moitié. Le verre prend la couleur du pôle qu'il porte |
@@ -232,7 +232,7 @@ d'un panneau, ce texte ressortirait en traînée colorée sous l'en-tête.
 | `--verre-voile-bande` | `88%` | en-tête du site |
 | `--verre-voile-barre` | `82%` | barre de pôle |
 
-L'**échelle d'élévation** compte trois crans, dans l'ordre, et pas un de plus — un cran
+L'**échelle d'élévation** compte trois crans, dans l'ordre, et pas un de plus. Un cran
 sans emploi serait un jeton mort, exactement le défaut corrigé ici :
 
 | Jeton | Sens | Où |
@@ -259,7 +259,7 @@ emmène ensemble au lieu d'en laisser six derrière.
 
 ### Typographie
 
-Deux familles chargées par `next/font/google` — donc auto-hébergées au build : aucune
+Deux familles chargées par `next/font/google`, donc auto-hébergées au build : aucune
 requête vers `fonts.googleapis.com`, rien à déclarer côté RGPD. La troisième est servie
 par la pile système, pour zéro octet. C'est un budget autant qu'un parti pris : chaque
 fonte préchargée est un fichier que le navigateur va chercher avant de peindre le texte.
@@ -274,12 +274,12 @@ fonte préchargée est un fichier que le navigateur va chercher avant de peindre
 `--t-note` (15px) et `--t-chiffre` (40→64px) pour le mur de preuves. Mesures : 64ch sur
 le corps, 30ch sur les `h2`, 18ch sur le `h1`, 46ch dans un panneau de verre.
 
-`--t-note` n'est pas un cran de confort : sept modules écrivaient `0.9375rem` en dur —
+`--t-note` n'est pas un cran de confort : sept modules écrivaient `0.9375rem` en dur :
 menus, repères de charnière, notes de bas de section. Un demi-cran manquait à l'échelle,
 et chacun le réinventait chez lui.
 
 L'**interlettrage** est un jeton, jamais une valeur locale. Une fonte de titre se
-resserre à mesure qu'elle grandit — à 68 px, l'approche dessinée pour du labeur laisse
+resserre à mesure qu'elle grandit : à 68 px, l'approche dessinée pour du labeur laisse
 des trous entre les lettres ; les étiquettes font l'inverse, capitales de 13 px qui ont
 besoin d'air.
 
@@ -304,7 +304,7 @@ Trois jetons tiennent l'empilement collant, et un seul endroit les déclare :
 
 ### Le fond d'atelier
 
-`.fond-atelier` est un calque peint, séparé du contenu — c'est ce que le verre floute, et
+`.fond-atelier` est un calque peint, séparé du contenu : c'est ce que le verre floute, et
 il fait plus de 9 000 px de haut sur l'accueil. **Tout ce qu'on y pose doit être une
 tuile.** Un `repeating-linear-gradient` sans `background-size` est généré une fois aux
 dimensions de son élément, soit ici plus de 9 000 px de haut.
@@ -321,7 +321,7 @@ défilerait pas derrière les panneaux, et le verre n'aurait rien à montrer qui
 Le grain est volontairement **une tuile de plus, et pas un filtre** : `filter: invert()`
 sur ce calque pour l'adapter au thème sombre forcerait une couche de compositing de la
 hauteur du document. Sous 4 % d'alpha, aucun couple texte/fond documenté ci-dessus ne
-descend sous son seuil AA — et l'audit de contraste n'est de toute façon pas concerné,
+descend sous son seuil AA, et l'audit de contraste n'est de toute façon pas concerné,
 le calque étant un frère du contenu, pas son ancêtre.
 
 ## Mouvement
@@ -332,10 +332,10 @@ personnalisé.
 
 | Geste | Où | Détail |
 |-------|-----|--------|
-| **Poser** | toute section qui entre dans l'écran | `opacity: 0` → `1` et `translateY(24px)` → `none`, `--duree-poser`. Porté par [`Reveal`](../src/components/Reveal/index.tsx), qui s'appuie sur `useInViewport` — voir « La révélation » ci-dessous |
+| **Poser** | toute section qui entre dans l'écran | `opacity: 0` → `1` et `translateY(24px)` → `none`, `--duree-poser`. Porté par [`Reveal`](../src/components/Reveal/index.tsx), qui s'appuie sur `useInViewport`, voir « La révélation » ci-dessous |
 | **Tracer** | les deux charnières | filet cuivre 2px, `scaleY(0)` → `scaleY(1)`, `--duree-tracer`. Seul mouvement porteur de sens : la chaîne se trace. Déclenché à l'entrée de la charnière dans l'écran, et non au chargement de la page |
-| **Traverser** | le fil IA | filets cuivre **horizontaux**, `scaleX(0)` → `scaleX(1)`, même durée, même déclenchement. Perpendiculaires à ceux des charnières : la chaîne descend, le fil la coupe — la géométrie dit « ceci n'est pas une quatrième offre » |
-| **Dériver** | la scène des quatre dalles | deux fréquences lentes qui ne se referment jamais ensemble, en `transform` seul — assez pour faire lire du volume, jamais assez pour appeler le regard. Le filet de tenue en est **exclu** : ce qui tient ne dérive pas |
+| **Traverser** | le fil IA | filets cuivre **horizontaux**, `scaleX(0)` → `scaleX(1)`, même durée, même déclenchement. Perpendiculaires à ceux des charnières : la chaîne descend, le fil la coupe. La géométrie dit « ceci n'est pas une quatrième offre » |
+| **Dériver** | la scène des quatre dalles | deux fréquences lentes qui ne se referment jamais ensemble, en `transform` seul : assez pour faire lire du volume, jamais assez pour appeler le regard. Le filet de tenue en est **exclu** : ce qui tient ne dérive pas |
 | **Micro-états** | liens et boutons | épaisseur de soulignement, ombre qui monte au survol, `--duree-micro`. Aucun déplacement de mise en page, et aucun déplacement tout court : voir « Le survol d'un bouton d'action » ci-dessous |
 
 **Dès qu'un mouvement dure, se répète ou porte du sens, seuls `transform` et `opacity`
@@ -378,7 +378,7 @@ Le focus clavier reste celui de `:focus-visible` dans `globals.css`, un contour 
 en `--accent` à 3 px d'écart.
 
 Sous `prefers-reduced-motion: reduce` : les animations CSS sont coupées et la scène est
-rendue **figée** — les dalles gardent leur pose. **Le verre, lui, n'est pas concerné** :
+rendue **figée** : les dalles gardent leur pose. **Le verre, lui, n'est pas concerné** :
 il ne bouge pas. Un `backdrop-filter` est une propriété de peinture, pas une animation ;
 le couper sous mouvement réduit retirerait une qualité visuelle sans rien apporter à
 personne. C'est la boucle de rendu permanente de liquidGL qui était une animation, pas le
@@ -387,9 +387,9 @@ verre.
 Le bouton `MotionToggle` offre le même arrêt depuis la page, comme l'exige WCAG 2.2.2 :
 une préférence système n'est pas un mécanisme de mise en pause, elle ne se change pas
 depuis le site. Il est rendu par le **pied de page**, donc par la mise en page racine,
-donc sur **toute page** — accueil, les quatre pôles, le blog. Il n'existait auparavant que
+donc sur **toute page** : accueil, les quatre pôles, le blog. Il n'existait auparavant que
 dans `HomeHero` : une page de pôle révélait ses sections au défilement sans offrir nulle
-part le moyen d'arrêter ça. L'accueil en porte donc deux, et c'est voulu — les deux lisent
+part le moyen d'arrêter ça. L'accueil en porte donc deux, et c'est voulu : les deux lisent
 le même magasin, mais celui du seuil est au pied de la scène, là où le mouvement se voit.
 
 Tout ce qui est encore en attente se pose alors **sans transition** : figer l'animation et
@@ -402,14 +402,14 @@ Une révélation au défilement se paie normalement de deux défauts, et [`Revea
 n'en accepte aucun :
 
 - **Rien n'est masqué au rendu serveur.** L'état caché n'est armé qu'après montage. Sans
-  JavaScript — ou si l'hydratation échoue — la page reste entièrement lisible. Une
+  JavaScript (ou si l'hydratation échoue), la page reste entièrement lisible. Une
   révélation qui laisse du contenu à `opacity: 0` n'est pas un effet, c'est une panne, et
   elle est invisible à celui qui l'écrit.
 - **Ce qui est déjà à l'écran n'est jamais caché puis remontré.** Au montage, seul ce qui
   est *sous la ligne de flottaison* est armé. C'est le clignotement typique des
   révélations au défilement, et il frappe d'abord le premier écran.
 
-L'état posé ne déclare **aucun** `transform` — pas même l'identité. Un
+L'état posé ne déclare **aucun** `transform`, pas même l'identité. Un
 `translate3d(0, 0, 0)` résiduel créerait sur chaque section un contexte d'empilement et
 une couche de compositing **permanents**, pour une animation qui ne dure que le temps de
 l'arrivée : sur l'accueil, une douzaine de couches promises au GPU jusqu'à la fin de la
@@ -425,13 +425,13 @@ règle paie deux fois :
 - une section **ancrable** ne bouge pas. Un `transform` sur l'élément que vise une ancre
   décale la cible du `scrollIntoView` de la hauteur de la révélation : la section se pose
   ensuite 24 px plus haut, et arrive sous l'en-tête. Les cinq sections ancrables de
-  l'accueil gardent donc leur `<section>` — identifiant et `scroll-margin-top` — et la
+  l'accueil gardent donc leur `<section>` (identifiant et `scroll-margin-top`) et la
   révélation passe à l'intérieur.
 
 Les charnières et le fil font exception : ce sont les seules révélations qui *sont* leur
 section, parce que le filet qui se trace est un `::before` de la section. Aucun lien ne
 pointe vers leur identifiant, et un lien profond arrivant de l'extérieur est exact de
-toute façon — le navigateur défile avant que React ne monte, donc la cible est déjà à
+toute façon : le navigateur défile avant que React ne monte, donc la cible est déjà à
 l'écran et la révélation ne s'arme pas.
 
 ## Les bandes collantes
@@ -443,9 +443,9 @@ des pôles on lisait, et l'action de contact était restée en bas.
 
 | Contrainte | Parade |
 |------------|--------|
-| Une bande `sticky` est **reflouée à chaque image** de défilement : ce qui passe dessous change en permanence | Flou **au-delà de 1024px seulement** — même recette pour les deux. C'est la seule surface du site où le seuil de largeur a encore un sens, et il n'a rien à voir avec l'ancien seuil de liquidGL |
+| Une bande `sticky` est **reflouée à chaque image** de défilement : ce qui passe dessous change en permanence | Flou **au-delà de 1024px seulement**, même recette pour les deux. C'est la seule surface du site où le seuil de largeur a encore un sens, et il n'a rien à voir avec l'ancien seuil de liquidGL |
 | Sans flou, la translucidité laisse passer un **fantôme de texte** | En dessous de 1024px, la bande est **opaque**. La transparence du site est celle du verre, et le verre floute ; là où le flou n'est pas payé, la bande est pleine |
-| Ce qui passe dessous est du **texte**, pas un décor | Jetons de bande, jamais de panneau : `--verre-flou-bande` (14px) et `--verre-saturation-bande` (1.1). Au réglage d'un panneau — 22px et 1.7 — le texte ressortirait en traînée colorée |
+| Ce qui passe dessous est du **texte**, pas un décor | Jetons de bande, jamais de panneau : `--verre-flou-bande` (14px) et `--verre-saturation-bande` (1.1). Au réglage d'un panneau (22px et 1.7), le texte ressortirait en traînée colorée |
 | L'en-tête est bien plus haut sous 720px (il passe en colonne) | La barre de pôle y reste **dans le flux**. Deux bandes collantes sur un téléphone prendraient la place de ce qu'elles annoncent |
 | Une ancre ne doit pas se poser sous les bandes | `--decalage-ancre`, redéfini localement sur la page de pôle |
 
@@ -462,8 +462,8 @@ Rien à amorcer, rien à charger, rien à démonter, aucun seuil de largeur. Il 
 premier octet de HTML servi, identique avec et sans JavaScript.
 
 **Le contenu est DANS le verre.** `GlassSurface` est le conteneur de son contenu et se
-dimensionne dessus. Le contrat précédent était l'inverse — une div vide posée *derrière*
-le texte — et ce n'était pas un choix de design : liquidGL mutait l'élément dont il
+dimensionne dessus. Le contrat précédent était l'inverse (une div vide posée *derrière*
+le texte), et ce n'était pas un choix de design : liquidGL mutait l'élément dont il
 faisait une lentille (`opacity: 0`, puis `pointer-events: none` jamais restauré) et
 effaçait son `background` en styles en ligne. Le calque vide était une parade ; la
 bibliothèque partie, la parade n'a plus d'objet.
@@ -483,7 +483,7 @@ trois `z-index` qui l'accompagnaient ont disparu avec la bibliothèque qui les e
 | lavis d'`--accent`, éteint avant la moitié | le verre prend la couleur du pôle qu'il porte. Une teinte uniforme se lirait comme un fond coloré ; une teinte qui décroît se lit comme de la lumière prise par la tranche haute |
 | arête spéculaire (`::before` masqué en anneau) | vive en haut, éteinte au milieu, rebond faible en bas. Elle suit le `border-radius`, ce qu'un `box-shadow: inset` ne sait pas faire |
 | `--verre-ombre`, basse et très étalée | le panneau flotte de peu. Un rayon court et sombre en ferait une carte |
-| réfraction SVG (`--verre-refraction`), ≥ 1024px, Blink seul | l'épaisseur prend une **forme** : au ras de l'arête, le verre va chercher son image un peu plus loin vers le dedans. Mesurée à 2/255 sur ce fond — voir « La réfraction » |
+| réfraction SVG (`--verre-refraction`), ≥ 1024px, Blink seul | l'épaisseur prend une **forme** : au ras de l'arête, le verre va chercher son image un peu plus loin vers le dedans. Mesurée à 2/255 sur ce fond, voir « La réfraction » |
 | repli `@supports` | là où `backdrop-filter` manque, le voile opaque `--verre-voile` reprend la garantie de contraste du texte |
 
 Le plafond de panneaux par page (`glass-policy.ts` : **1 sur l'accueil**, 3 sur une page
@@ -492,7 +492,7 @@ monter ; au-delà de trois, l'effet cesse simplement d'être un signal et devien
 
 L'accueil est passé de 3 à 1 avec l'issue #103, et ce n'est pas un réglage : le plafond
 suit le nombre de sections **éditoriales réellement présentes**, et l'accueil devenu
-vitrine n'en porte plus qu'une — les deux objections. Ses trois sections de pôle sont
+vitrine n'en porte plus qu'une : les deux objections. Ses trois sections de pôle sont
 descendues sur `/services/<pole>/`, où c'est `MAX_GLASS_PAGE_POLE` qui les vitre. La
 page n'est pas pour autant sans verre : le seuil, les plaques du schéma de la chaîne et
 le bloc de contact portent les mêmes jetons de surface, posés par leurs propres modules.
@@ -501,12 +501,12 @@ le bloc de contact portent les mêmes jetons de surface, posés par leurs propre
 
 **liquidGL** (WebGL) a été retirée. **`liquid-glass-react`** (rdev, MIT, 33 ko gzip) a été
 installée, mesurée et retirée le même jour. Elle ne peut pas rendre un panneau éditorial
-pleine largeur, et le défaut est structurel, pas esthétique — mesuré sur un panneau réel
+pleine largeur, et le défaut est structurel, pas esthétique, mesuré sur un panneau réel
 de 1164 × 282 px :
 
 | Ce que la bibliothèque impose | Conséquence ici |
 |-------------------------------|-----------------|
-| `position: relative` par défaut, avec 3 calques de recouvrement **restés dans le flux** | un conteneur de **880 px** pour un panneau de 282 : trois blocs vides empilés sous lui. Le contournement est `position: absolute`, mais un panneau absolu ne peut plus être dimensionné par son contenu — et c'est exactement ce qu'on venait de regagner |
+| `position: relative` par défaut, avec 3 calques de recouvrement **restés dans le flux** | un conteneur de **880 px** pour un panneau de 282 : trois blocs vides empilés sous lui. Le contournement est `position: absolute`, mais un panneau absolu ne peut plus être dimensionné par son contenu, et c'est exactement ce qu'on venait de regagner |
 | `display: inline-flex` en style **en ligne** | le panneau se rétracte sur son contenu au lieu de tenir la largeur de la page. Un style en ligne ne se corrige que par `!important` |
 | `padding: 24px 32px`, `box-shadow: rgba(0,0,0,.25) 0 12px 40px` en ligne | l'échelle d'espacement et les jetons d'élévation du site sont court-circuités, au profit d'un noir codé en dur étranger à la palette |
 | `font: 500 20px/1 system-ui` et `text-shadow: rgba(0,0,0,.4) 0 2px 12px` en ligne, hérités | `line-height: 20px` **calculé sur les `h2`** du panneau, et un halo noir sur chaque texte. Sur le papier chaud du site, cela se lit comme du texte sale |
@@ -521,16 +521,16 @@ navigateur ne se défend pas **sous cette forme**. La technique, elle, se défen
 
 ### La réfraction : ce qu'elle coûte, ce qu'elle rend
 
-**`feImage` + `feDisplacementMap`, deux primitives, zéro dépendance** — la même technique
+**`feImage` + `feDisplacementMap`, deux primitives, zéro dépendance** : la même technique
 que `liquid-glass-react`, en ~30 lignes de SVG rendues au serveur
 ([`GlassRefraction`](../src/components/GlassRefraction/index.tsx)). Le filtre est
 déclaré une fois par la mise en page racine ; les panneaux le consomment par le jeton
 `--verre-refraction`, jamais en écrivant `url(#…)` dans un module.
 
 **Les artefacts en losange du premier essai ont disparu par construction, pas par
-réglage.** La carte de déplacement pose un **plateau neutre au centre** — l'effet ne vit
+réglage.** La carte de déplacement pose un **plateau neutre au centre** (l'effet ne vit
 que sur ~10 % de chaque bord, le seul endroit où un vrai verre courbe ce qu'il y a
-derrière — et **échantillonne toujours vers l'intérieur** aux quatre bords. Aucun pixel ne
+derrière) et **échantillonne toujours vers l'intérieur** aux quatre bords. Aucun pixel ne
 va donc chercher hors de la région du filtre, ce qui rend la frange impossible plutôt
 qu'improbable. Vérifié sur damier haute fréquence jusqu'à six fois l'amplitude retenue.
 
@@ -553,7 +553,7 @@ crée pas du contraste qui n'existe pas.**
 Un piège mérite d'être noté, parce qu'il aurait fait livrer l'inverse de ce qu'on croyait :
 la variante qui « faisait le plus d'effet » (7/255) donnait **exactement les mêmes chiffres
 avec un filtre identité**, qui ne fait rien. Ces sept niveaux n'étaient pas de la
-réfraction mais le `blur(22px)` qui se dégradait faute de matière près des bords — la
+réfraction mais le `blur(22px)` qui se dégradait faute de matière près des bords : la
 version « visible » **abîmait** le verre. D'où la région élargie à 40 % de la boîte : il
 faut au moins trois écarts-types de flou de matière autour du panneau.
 
@@ -566,8 +566,8 @@ l'arbitrage ci-dessous ne change pas) :
 | Accueil | Perf |
 |---|---|
 | sans réfraction | 96 |
-| réfraction sur toutes les largeurs | **95** — tout le reste de marge |
-| réfraction ≥ 1024px (livré) | **96** — la marge est rendue |
+| réfraction sur toutes les largeurs | **95**, tout le reste de marge |
+| réfraction ≥ 1024px (livré) | **96**, la marge est rendue |
 
 Le seuil rend le point, et il faut dire pourquoi sans se payer de mots : **le budget est
 mesuré en mobile bridé, donc il ne mesure plus la réfraction du tout.** Le coût d'un point
@@ -577,15 +577,15 @@ les 2/255 du desktop.
 
 Un point de budget pour un effet à 2/255, c'est trop cher, et **un budget pile sur le
 seuil échoue en CI au tirage au sort**. La réfraction est donc **desktop seulement
-(≥ 1024px)** : c'est déjà la règle posée en tête de ce document — le verre réfractant est
+(≥ 1024px)** : c'est déjà la règle posée en tête de ce document. Le verre réfractant est
 un enrichissement, jamais un prérequis de lecture. Sur un téléphone le panneau fait ~350px,
 la rampe de 10 % n'y couvre plus que 35px, et il y a encore moins à voir qu'en desktop.
 **Le seuil ne concerne que la réfraction** : le flou, lui, n'a plus de seuil et reste sur
-tous les téléphones — c'est le gain du lot précédent, il n'est pas repris.
+tous les téléphones : c'est le gain du lot précédent, il n'est pas repris.
 
 #### Le test de moteur, et pourquoi il existe
 
-La réfraction est servie **à Blink seulement**, derrière un test de moteur explicite —
+La réfraction est servie **à Blink seulement**, derrière un test de moteur explicite,
 **la seule entorse de ce genre dans le projet**, et elle est assumée :
 
 ```css
@@ -595,27 +595,27 @@ La réfraction est servie **à Blink seulement**, derrière un test de moteur ex
 ```
 
 `@supports` ne teste que la **grammaire**, jamais l'implémentation. WebKit et Gecko peuvent
-accepter `backdrop-filter: url(…)` puis ne rien en faire — et une déclaration acceptée
+accepter `backdrop-filter: url(…)` puis ne rien en faire, et une déclaration acceptée
 **remplace** celle du dessus : ils perdraient leur flou, c'est-à-dire tout leur verre.
 
 On ne peut pas s'en remettre à l'ordre des déclarations, et c'est un **défaut mesuré sur le
-CSS livré** : Lightning CSS **synthétise le préfixe** — il écrit
-`-webkit-backdrop-filter: url(…)` à l'intérieur du bloc — **et élargit la condition** en
+CSS livré** : Lightning CSS **synthétise le préfixe** (il écrit
+`-webkit-backdrop-filter: url(…)` à l'intérieur du bloc) **et élargit la condition** en
 `(-webkit-backdrop-filter: url(…)) or (backdrop-filter: url(…))`. Écrire le préfixe avant,
 après ou pas du tout n'y change rien, et sur Safari 18+ les deux formes sont des alias.
 C'est la **même famille que le bug de production déjà corrigé** (le minifieur ne gardant
-que la dernière des deux formes), par une autre porte — et il ne se voit pas en `next dev`,
+que la dernière des deux formes), par une autre porte, et il ne se voit pas en `next dev`,
 où rien n'est minifié.
 
 Les deux sondes sont choisies pour être **vérifiables des deux côtés**, pas pour leur
 exotisme. `-webkit-backdrop-filter` écarte WebKit : Blink y répond `false` (mesuré), et
-Safari y répond **forcément** `true` — c'est la propriété même par laquelle le site lui
+Safari y répond **forcément** `true` : c'est la propriété même par laquelle le site lui
 livre son flou aujourd'hui ; s'il y répondait `false`, il n'aurait déjà aucun verre.
 L'exclusion de Safari n'est donc pas une supposition sur un moteur, elle est **forcée par
 une propriété dont le site dépend déjà**. `-moz-appearance` écarte Gecko, `false` dans
 Blink (mesuré).
 
-**Le rendu de Safari et de Firefox reste raisonné et non observé** — l'automation Safari
+**Le rendu de Safari et de Firefox reste raisonné et non observé** : l'automation Safari
 est désactivée sur le poste et Firefox n'y est pas installé. C'est précisément pourquoi le
 gate est construit ainsi : l'incertitude porte sur ce que ces moteurs *feraient* d'un
 `url()`, et le gate fait en sorte qu'ils n'y soient jamais confrontés. Ils gardent
@@ -629,7 +629,7 @@ moteurs, ou qu'un `@supports` sache tester le rendu et non la seule syntaxe.
 
 `prefers-reduced-motion` et le `MotionToggle` coupent la réfraction et gardent le flou :
 elle ne bouge pas d'elle-même, mais le compositeur la recalcule à chaque image où le fond
-défile derrière le panneau. Les deux gardes sont indépendantes — requête média sans
+défile derrière le panneau. Les deux gardes sont indépendantes : requête média sans
 JavaScript d'un côté, attribut publié sur `<html>` par
 [`MotionState`](../src/components/MotionState/index.tsx) de l'autre (WCAG 2.2.2).
 
@@ -641,11 +641,11 @@ modèle de l'offre rendu en volume. Aucun texte, aucun logo, aucune particule.
 La topologie est celle du `CLAUDE.md`, pas une composition libre :
 
 ```
-  ┌───────────────┐      ingénierie web — temps 1, dans l'axe
+  ┌───────────────┐      ingénierie web : temps 1, dans l'axe
   └───────────────┘
-  ┌───────────────┐      data — temps 2, dans l'axe, décalée
+  ┌───────────────┐      data : temps 2, dans l'axe, décalée
   └───────────────┘
-┌─────────┐ ┌─────────┐  IA  et  SEA & UX — temps 3, écartées côte à côte
+┌─────────┐ ┌─────────┐  IA  et  SEA & UX : temps 3, écartées côte à côte
 └─────────┘ └─────────┘
         (un filet vertical descend derrière les quatre)
 ```
@@ -654,7 +654,7 @@ La topologie est celle du `CLAUDE.md`, pas une composition libre :
 une quatrième puis une cinquième étape. Même largeur, même hauteur, même dégradé, même
 classe CSS, même durée d'animation ; seul un décalage vertical de 12 unités casse la
 symétrie mécanique, et un décalage n'a ni premier ni second. Toute retouche de la scène
-doit préserver cette égalité — c'est l'argument que le site vend.
+doit préserver cette égalité : c'est l'argument que le site vend.
 
 Le **filet de tenue** est l'interlocuteur unique. Il est le seul élément **non animé** de
 la scène, et le seul à ne porter aucun `data-pole` : il prend le cuivre de la racine, qui
@@ -664,7 +664,7 @@ et ressort dans l'écart qui sépare les deux sœurs, là où on le lit le mieux
 Elle a d'abord été une scène WebGL (`three` + `@react-three/fiber`, ~235 ko gzip). Elle
 est aujourd'hui **un SVG d'environ 1,7 ko rendu au serveur**, et le compromis n'en est pas
 un : le site vend une performance tenue, il ne pouvait pas payer un moteur 3D pour un
-décor. Ce qui est perdu — la réfraction physique, la rotation pilotée par le défilement —
+décor. Ce qui est perdu (la réfraction physique, la rotation pilotée par le défilement)
 n'était lisible par personne. Ce qui est gagné se mesure au premier chargement, et la
 scène s'affiche désormais **aussi sous 1024px**, là où le WebGL n'était jamais monté.
 
@@ -694,40 +694,40 @@ L'accueil déroulait sa chaîne dans le fil du texte : on y entrait en lisant, o
 menu. Un visiteur qui scanne ne trouvait aucune porte. Deux composants la lui donnent, et
 leur **disposition porte le modèle** plutôt que de le décrire.
 
-### `PoleEntries` — les quatre pôles
+### `PoleEntries` : les quatre pôles
 
 Quatre plaques alignées à égalité diraient un catalogue, ce que le site refuse d'être. La
-grille rend donc la chaîne réelle : **Ingénierie web** puis **Data** en pleine largeur —
-le socle, puis le passage obligé — et **IA** et **SEA & UX** partageant une rangée,
+grille rend donc la chaîne réelle : **Ingénierie web** puis **Data** en pleine largeur
+(le socle, puis le passage obligé) et **IA** et **SEA & UX** partageant une rangée,
 côte à côte. Les deux suites partagent une ligne parce qu'elles partagent un temps ;
 les empiler aurait réintroduit l'ordre que le modèle nie.
 
 Chaque plaque porte `data-pole` : sa marque et son filet prennent `--accent` sans qu'aucune
 règle du composant ne nomme une couleur.
 
-### `PoleGlyph` — des marques produites, jamais trouvées
+### `PoleGlyph` : des marques produites, jamais trouvées
 
-Le site n'a **aucune photographie utilisable** — ni portrait, ni capture de projet
+Le site n'a **aucune photographie utilisable** : ni portrait, ni capture de projet
 autorisée, ni logo client. Tout visuel est donc construit, en SVG rendu au serveur :
 quatre marques pèsent moins de 700 octets dans le document, là où la moindre image
 matricielle ferait tomber un budget qui ne tient qu'à un point.
 
-**Aucune de ces marques ne simule une donnée.** Un pictogramme qui mimerait un graphique —
-courbe qui monte, barres qui progressent — afficherait un chiffre inventé, ce que les
+**Aucune de ces marques ne simule une donnée.** Un pictogramme qui mimerait un graphique
+(courbe qui monte, barres qui progressent) afficherait un chiffre inventé, ce que les
 règles de véracité interdisent. Ce sont des **figures de structure**, pas des
 visualisations.
 
 L'IA n'est pas dessinée par le nœud à trois entrées, c'est-à-dire le neurone : c'est le
 cliché attendu, et il dirait quelque chose de faux, puisque ce pôle promet que « la
 réponse n'est pas toujours un modèle ». Sa marque est un embranchement dont une branche
-est retenue et l'autre écartée — la promesse, littéralement. Les deux sœurs partagent la
+est retenue et l'autre écartée : la promesse, littéralement. Les deux sœurs partagent la
 même grammaire de trait, même poids et même nombre de tracés : deux figures de décision de
 rang égal.
 
-### `SpaceEntries` — les deux espaces éditoriaux
+### `SpaceEntries` : les deux espaces éditoriaux
 
 Registre volontairement **plus sobre** que celui des pôles : un filet à gauche plutôt
-qu'une plaque encadrée. Un espace ne se vend pas, il déplie — et la hiérarchie visuelle
+qu'une plaque encadrée. Un espace ne se vend pas, il déplie, et la hiérarchie visuelle
 doit le dire sans qu'un mot ait à l'expliquer.
 
 Le volume annoncé est **dérivé des listes sources**, jamais écrit à la main : l'accueil ne
@@ -739,7 +739,7 @@ que pour les chiffres de `preuves.ts`.
 Le blog était entièrement textuel : sur `/blog/` comme sur une fiche, rien ne distinguait
 un article d'un autre à l'œil. Chaque article porte désormais une **figure**
 ([`ArticleFigure`](../src/components/ArticleFigure/index.tsx)), et elle obéit à la
-même doctrine que les marques de pôle — c'est ce qui fait que le blog appartient au même
+même doctrine que les marques de pôle : c'est ce qui fait que le blog appartient au même
 site que l'accueil.
 
 ### Construite, jamais matricielle
@@ -747,58 +747,58 @@ site que l'accueil.
 Le site n'a **aucune image matricielle** : quatre SVG en tout, `next/image` écarté
 délibérément. Une illustration d'article n'allait pas en introduire la première. Les figures
 sont du **SVG rendu au serveur**, elles pèsent quelques centaines d'octets dans le
-document, et le budget Lighthouse — qui ne tient qu'à un point — n'en sait rien.
+document, et le budget Lighthouse (qui ne tient qu'à un point) n'en sait rien.
 
 Elles n'ont **aucun fichier**, ce qui a une conséquence en dehors du design : le JSON-LD
-d'un article ne déclare toujours pas de champ `image`. La raison a changé — le site sert
-désormais une illustration — mais il n'existe aucune ressource qu'un moteur puisse aller
+d'un article ne déclare toujours pas de champ `image`. La raison a changé (le site sert
+désormais une illustration), mais il n'existe aucune ressource qu'un moteur puisse aller
 chercher, et déclarer une URL qui rendrait 404 serait un mensonge de plus.
 
 ### Rien qui simule une donnée
 
 C'est la règle des marques de pôle, appliquée mot pour mot. Le site vend la mesure : un
-pictogramme qui mimerait un graphique — une courbe qui monte, des barres qui progressent —
+pictogramme qui mimerait un graphique (une courbe qui monte, des barres qui progressent)
 afficherait un chiffre inventé, ce que les règles de véracité du `CLAUDE.md` interdisent.
 Ce sont des **figures de structure**, pas des visualisations.
 
 Le cas le plus tendu est celui de « Mesurer avant d'arbitrer », dont la figure est une
 balance : son **fléau est strictement horizontal**, et ce n'est pas un détail de dessin. Une
 balance qui penche affiche un verdict, c'est-à-dire un chiffre. Ce qui est dessiné, c'est
-qu'un arbitrage repose sur une collecte — jamais lequel des deux plateaux l'emporte.
+qu'un arbitrage repose sur une collecte, jamais lequel des deux plateaux l'emporte.
 
 ### La grammaire, reprise trait pour trait
 
 | Signe | Sens | Où on l'a déjà vu |
 |-------|------|-------------------|
 | trait plein | ce qui est retenu | les quatre marques de pôle |
-| trait tireté, opacité 0.65 | ce qui est écarté | `PoleGlyph` — l'IA et le SEA & UX |
-| croix | une voie fermée | `PoleGlyph` — la branche écartée de l'IA |
+| trait tireté, opacité 0.65 | ce qui est écarté | `PoleGlyph`, l'IA et le SEA & UX |
+| croix | une voie fermée | `PoleGlyph`, la branche écartée de l'IA |
 | point plein | un aboutissement | les quatre marques de pôle |
 | trait épais (2.4) | une assise | le socle de l'ingénierie web |
 
 Une seule chose diffère, et elle corrige une lecture : **la croix n'est pas tiretée**. Ses
 branches mesurent 5,1 unités, soit à peine deux tirets ; tiretées, elles ne rendent que leur
-amorce et la croix se lit comme une **coche** — l'exact contraire de ce qu'elle dit. Mesuré
+amorce et la croix se lit comme une **coche**, l'exact contraire de ce qu'elle dit. Mesuré
 au rendu, pas supposé.
 
 | Article | Figure | Ce qu'elle dessine |
 |---------|--------|--------------------|
 | Pourquoi ce site est un export statique | `borne` | Trois plaques écrites, un aboutissement, une ligne que rien ne franchit ; au-delà, tireté, le serveur applicatif qui n'existe plus |
-| Le test avant le code, même avec un agent | `anteriorite` | Deux temps sur un axe — le point posé d'abord, la boîte ouverte ensuite ; dessous, tiretée et fermée d'une croix, la voie inverse |
+| Le test avant le code, même avec un agent | `anteriorite` | Deux temps sur un axe : le point posé d'abord, la boîte ouverte ensuite ; dessous, tiretée et fermée d'une croix, la voie inverse |
 | Mesurer avant d'arbitrer | `appui` | Un fléau à l'horizontale et deux plateaux identiques, la décision au sommet du mât, portés par une assise et sa trame de mesure |
 | Un générateur de projets, public et personnel | `gabarit` | Une forme à trois compartiments, ouverte du côté de la sortie, et ce qui en sort : un cadre fermé, complet, jusqu'à son aboutissement |
-| Le premier risque n'est pas le code, c'est l'endroit | `liaison` | Des ensembles séparés, un lieu commun plus grand qu'eux, deux liens qui portent — et un troisième, tireté, qui n'aboutit à rien |
+| Le premier risque n'est pas le code, c'est l'endroit | `liaison` | Des ensembles séparés, un lieu commun plus grand qu'eux, deux liens qui portent, et un troisième, tireté, qui n'aboutit à rien |
 
 Deux ajouts de l'issue #109 étendent la grammaire sans la contredire, et il vaut mieux
 l'écrire ici que le redécouvrir :
 
 - **Le trait tireté couvre une nuance de plus.** Sur `liaison`, « écarté » devient
-  « annoncé, jamais emprunté » — la dépendance déclarée que rien n'importe. C'est le même
+  « annoncé, jamais emprunté » : la dépendance déclarée que rien n'importe. C'est le même
   sens au fond, un chemin qui n'a pas lieu ; le signe n'a donc pas eu à être dédoublé.
 - **La longueur d'un tracé tireté est une contrainte, pas un hasard.** C'est le constat déjà
   fait sur la croix de `anteriorite` : à 2,6 unités de tiret, un segment court ne rend que
   son amorce. Là où la croix a été traitée en **retirant** le tiretage, le lien de `liaison`
-  l'est en **allongeant** le tracé — quinze unités, soit trois tirets pleins.
+  l'est en **allongeant** le tracé : quinze unités, soit trois tirets pleins.
 
 Ce que ces deux figures se sont **interdit** relève de la même règle que le fléau horizontal
 de `appui` : ne rien dessiner qui se compte. Pas de pile de formes produites sur `gabarit`,
@@ -809,7 +809,7 @@ nommer.
 ### Deux registres, un seul jeton
 
 `--taille-figure-article` vaut **3rem** partout, et la fiche d'article le redéfinit chez elle
-à `clamp(6.5rem, 22vw, 9rem)` — le même geste que `--decalage-ancre` sur les pages de pôle.
+à `clamp(6.5rem, 22vw, 9rem)`, le même geste que `--decalage-ancre` sur les pages de pôle.
 La hauteur n'a **pas** de jeton : elle suit le `viewBox` (48 × 32), et deux valeurs à tenir
 d'accord divergent à la première retouche.
 
@@ -821,7 +821,7 @@ elle distingue les articles à l'œil sans ajouter une seule ligne au rythme de 
 
 Le registre est aussi ce qui distingue la figure d'une marque de pôle : une marque est
 carrée (32 × 32), une figure d'article est **couchée** (48 × 32). Une page de pôle vend, un
-article raconte — et une figure large se pose au-dessus d'un texte sans prétendre à l'insigne.
+article raconte, et une figure large se pose au-dessus d'un texte sans prétendre à l'insigne.
 
 ### Décor, jamais information
 
@@ -831,7 +831,7 @@ toutes lettres, juste à côté (WCAG 1.1.1 et 1.4.1). C'est aussi ce qui autori
 
 Aucune couleur n'est nommée dans le module : le tracé est en `currentColor` et le module pose
 `color: var(--accent)`. Le blog n'est sous aucun `data-pole`, donc `--accent` y vaut le cuivre
-de la racine — la teinte de la maison, exactement ce que doit prendre un contenu qui
+de la racine : la teinte de la maison, exactement ce que doit prendre un contenu qui
 n'appartient à aucun pôle. Les deux thèmes suivent sans qu'une ligne y soit consacrée.
 
 ## La note de publication d'origine
@@ -840,9 +840,9 @@ Un article peut reprendre un texte d'abord paru sur un réseau
 ([`ArticleSource`](../src/components/ArticleSource/index.tsx)). Le champ est
 **optionnel** et le restera. Un seul article publié porte une source à ce jour ; les autres
 ont été écrits pour ce site, **ou bien reprennent un post dont l'adresse n'a pas été
-fournie** — c'est le cas de « Un générateur de projets, public et personnel », et il se
+fournie** : c'est le cas de « Un générateur de projets, public et personnel », et il se
 publie donc sans source. **Une URL absente ne se devine pas** : c'est déjà la règle des
-justificatifs de certification. Sans source, rien n'est rendu — ni ligne vide, ni filet
+justificatifs de certification. Sans source, rien n'est rendu : ni ligne vide, ni filet
 orphelin.
 
 Le lien sort du site, et **son caractère externe ne repose pas sur la couleur** (WCAG 1.4.1).
@@ -857,7 +857,7 @@ Trois porteurs, dont chacun survit à la disparition des deux autres :
 La flèche est dessinée plutôt qu'écrite en caractère (« ↗ ») : le glyphe manque à plusieurs
 polices système et s'y remplace par un rectangle, et son dessin varie assez d'une fonte à
 l'autre pour ne plus faire série avec les figures du site. Elle redéclare `display:
-inline-block` — c'est le **seul `svg` du site à vivre dans une ligne de texte**, et le
+inline-block` : c'est le **seul `svg` du site à vivre dans une ligne de texte**, et le
 `display: block` global de `globals.css` la poussait seule à la ligne.
 
 `rel="noopener noreferrer"`, comme le lien de justificatif d'une certification : un lien
@@ -865,18 +865,18 @@ sortant est traité pareil partout, ou il finit par ne l'être nulle part.
 
 ## Le lavis de pôle
 
-Le fond était un lavis radial unique, une trame de 32 px et un grain. Correct, sobre —
+Le fond était un lavis radial unique, une trame de 32 px et un grain. Correct, sobre,
 et **sans matière**. C'est ce qui explique l'échec des trois tentatives de verre
 réfractant : un verre ne montre rien par lui-même, il montre **ce qu'il déforme**. Sur un
 lavis uniforme, la réfraction a été mesurée à **2 niveaux sur 255**, c'est-à-dire rien.
 
 La première réponse fut une **maille** : quatre lavis larges, un par pôle, posés en
-descendant dans `.fond-atelier` — ingénierie en haut à gauche, donnée à droite, les deux
+descendant dans `.fond-atelier` : ingénierie en haut à gauche, donnée à droite, les deux
 suites plus bas. Elle a été **remplacée** (issue #104), pour deux défauts qui n'étaient
 pas des réglages :
 
 1. **Ses coordonnées étaient fixes et le document ne les connaissait pas.** Sur
-   `/services/ia/`, le haut de page recevait le lavis d'ingénierie — non parce qu'on y
+   `/services/ia/`, le haut de page recevait le lavis d'ingénierie, non parce qu'on y
    parlait d'ingénierie, mais parce que c'est le haut du document. Le fond racontait la
    chaîne à un lecteur qui, lui, lisait une page.
 2. **Étalés sur plus de 9 000 px, les quatre lavis n'atteignaient nulle part leur propre
@@ -891,8 +891,8 @@ hauteur ; les quatre portes de l'accueil sont quatre taches de couleur côte à 
 
 ### Le mécanisme
 
-`poles.css` mappe `--accent` sous `data-pole`. `lavis.css` en dérive quatre jetons —
-`--lavis-fond`, `--lavis-tache`, et leurs équivalents d'échelle bloc — **déclarés sur
+`poles.css` mappe `--accent` sous `data-pole`. `lavis.css` en dérive quatre jetons
+(`--lavis-fond`, `--lavis-tache`, et leurs équivalents d'échelle bloc) **déclarés sur
 `[data-pole]` lui-même**, jamais seulement sur `:root` : une propriété personnalisée est
 substituée au *computed-value time*, sur l'élément qui la déclare. Déclarés à la racine,
 ils figeraient le cuivre et descendraient tels quels dans les quatre pages de pôle. C'est
@@ -910,18 +910,18 @@ ne connaissent que les jetons :
 ### Deux couches, et pourquoi pas trois
 
 Le lavis est un **fond plat translucide** plus une **tache dégradée** par-dessus. Le fond
-plat garantit que le bloc du pôle est teinté *partout* — c'est lui qui fait qu'on lit une
+plat garantit que le bloc du pôle est teinté *partout* : c'est lui qui fait qu'on lit une
 couleur et non une éclaircie, et c'est exactement ce qui manquait à la maille. La tache
 fait le dégradé et empêche l'aplat.
 
 Deux couches et pas plus, parce que **les alphas se composent** : là où deux taches se
 recouvrent, la densité vaut `1-(1-a)(1-b)` et non `a`. Un troisième calque rendrait le
 pire cas dépendant de la géométrie, donc de la hauteur du bloc, donc invérifiable. Ici il
-est fixe et calculable — et c'est ce nombre-là qui est mesuré.
+est fixe et calculable, et c'est ce nombre-là qui est mesuré.
 
 La **répartition** entre les deux change avec la surface, le plafond jamais. À l'échelle
 d'une page, la tache a mille pixels pour s'installer et porte la moitié du plafond. À
-l'échelle d'un bloc — une porte de l'accueil fait 160 px de haut — une tache qui décroît
+l'échelle d'un bloc (une porte de l'accueil fait 160 px de haut), une tache qui décroît
 sur cette hauteur laisse le bas de la carte au fond plat seul : mesuré à l'écran, les
 quatre portes se lisaient alors quasiment beiges. La part constante monte donc à 6 %, et
 la tache se réduit à une modulation.
@@ -935,8 +935,8 @@ la tache se réduit à une modulation.
 
 **Il ne vient pas du texte.** `--encre-douce` tient encore 5,95:1 à 7,88 %, très au-dessus
 du seuil AA de 4,5:1. Il vient des jetons `--accent-vif`, qui portent les filets et les
-arêtes et doivent tenir **3:1** (WCAG 1.4.11). Sur le fond réellement peint — `#EDE9E0`,
-le bas du dégradé d'atelier et non `--fond` — `--pole-data-vif` n'est déjà qu'à **3,29:1**
+arêtes et doivent tenir **3:1** (WCAG 1.4.11). Sur le fond réellement peint (`#EDE9E0`,
+le bas du dégradé d'atelier et non `--fond`), `--pole-data-vif` n'est déjà qu'à **3,29:1**
 nu. Il reste 0,29 point de marge, et le lavis en consomme la quasi-totalité : à 9 % il
 passe sous 3:1.
 
@@ -945,7 +945,7 @@ d'abord de rouvrir la palette des `-vif`, dont les seize valeurs sont plus haut.
 
 En thème sombre le plafond change de nature : tout y tient au-dessus de 6:1, et la
 contrainte n'est plus le contraste mais la teinte elle-même. Les couleurs de pôle y sont
-choisies **claires** pour porter du texte sur un fond à 6 % de luminance — `--pole-data`
+choisies **claires** pour porter du texte sur un fond à 6 % de luminance : `--pole-data`
 passe de `#00697B` à `#01B6D4`. À part égale, le même lavis y serait deux fois plus
 présent et virerait au fond coloré.
 
@@ -953,7 +953,7 @@ présent et virerait au fond coloré.
 
 Le calque plein document ne porte plus aucune couleur de pôle. Il garde le grain, la
 trame, le dégradé d'atelier, et **une seule tache** en haut du document, dans
-`--lavis-tache` — c'est-à-dire, hors de tout `data-pole`, dans le cuivre : la couleur de
+`--lavis-tache`, c'est-à-dire, hors de tout `data-pole`, dans le cuivre : la couleur de
 la maison. Ce n'est pas la maille par une autre porte. La maille prétendait dire quel pôle
 on lisait, à des coordonnées qui ne le savaient pas ; celle-ci ne dit rien d'un pôle, elle
 éclaire l'entrée du document et donne au verre de l'en-tête de la matière à courber.
@@ -969,11 +969,11 @@ on lisait, à des coordonnées qui ne le savaient pas ; celle-ci ne dit rien d'u
 | Aucune information portée par la seule couleur | Le lavis est un décor : le nom du pôle, son libellé de place et son temps restent écrits en toutes lettres (WCAG 1.4.1). |
 | Lighthouse à la cible de 95 | Mesuré après le lot : accueil 96, page de pôle 96, blog / article / réalisations 97 ; A11y, bonnes pratiques et SEO à 100. (Le plancher bloquant de performance est passé à 80 le 2026-08-24, issue #146 ; la cible visée reste 95.) |
 
-### Contraste — mesuré, pas supposé
+### Contraste : mesuré, pas supposé
 
 Deux mesures indépendantes, et les deux sont dans le dépôt de la PR #104 : le calcul
-analytique sur la couleur composée, puis la **lecture au pixel du rendu réel** — grain,
-trame et lueur de seuil compris — dans les deux thèmes.
+analytique sur la couleur composée, puis la **lecture au pixel du rendu réel** (grain,
+trame et lueur de seuil compris) dans les deux thèmes.
 
 Calcul, pire cas : lavis à sa densité maximale, sur le fond le plus défavorable du dégradé
 d'atelier (`#EDE9E0` en clair, `#14181D` en sombre).
@@ -1004,7 +1004,7 @@ Le seuil AA du texte est à 4.5:1, celui des éléments non-texte à 3:1 : les d
 le second de justesse et par construction.
 
 **Le verre par-dessus.** Le lavis est ce que `GlassSurface` floute : un fond plus coloré
-change ce qu'il rend. Contrôlé sur les quatre teintes, dans les deux thèmes —
+change ce qu'il rend. Contrôlé sur les quatre teintes, dans les deux thèmes :
 `--encre-douce` sur un panneau posé sur le lavis le plus dense vaut **6.79 à 6.82:1** en
 clair et **5.23 à 5.28:1** en sombre. Le panneau *améliore* le contraste en clair (son
 voile blanc éclaircit le fond) et le réduit en sombre sans jamais l'approcher du seuil.
@@ -1012,13 +1012,13 @@ voile blanc éclaircit le fond) et le réduit en sombre sans jamais l'approcher 
 > **Un écart relevé au passage, toujours valable.** Les ratios des tableaux de jetons plus
 > haut sont mesurés sur `--fond` (`#F2EFE8`), alors que le fond réellement peint est le
 > dégradé de `.fond-atelier`, qui descend à `#EDE9E0`. Les vrais ratios sont donc
-> légèrement plus bas que ceux affichés — `--encre-douce` est à 6.65:1 et non 7.02:1.
+> légèrement plus bas que ceux affichés : `--encre-douce` est à 6.65:1 et non 7.02:1.
 > Tous restent au-dessus du seuil, mais la documentation est optimiste d'environ un tiers
 > de point. C'est cet écart qui rend le plafond du lavis si serré : la marge des `-vif`
 > est comptée sur `#EDE9E0`, pas sur `#F2EFE8`.
 
-> **Un filet non conforme, antérieur au lavis.** `--accent` dilué à 45 % — le chiffre de
-> place de `PoleHero`, le filet de preuve de `PoleEntries` — est à **1,9 à 2,5:1** sur le
+> **Un filet non conforme, antérieur au lavis.** `--accent` dilué à 45 % (le chiffre de
+> place de `PoleHero`, le filet de preuve de `PoleEntries`) est à **1,9 à 2,5:1** sur le
 > fond, et l'était déjà avant ce lot (le lavis lui coûte 0,07 point, teinte et fond
 > bougeant ensemble). Les deux sont décoratifs et l'information qu'ils accompagnent est
 > écrite à côté, mais le point est ouvert et n'est pas traité ici.
@@ -1041,14 +1041,14 @@ Le constat : dans `ChainDiagram`, le maillon « data » **contient** les deux br
 ```
 
 Peindre `.maillon` et `.branche` empilerait donc deux lavis sous les plaques de l'IA et du
-SEA & UX, à `1-(1-7,88 %)(1-7,88 %) = 15,14 %` — le double du plafond.
+SEA & UX, à `1-(1-7,88 %)(1-7,88 %) = 15,14 %`, le double du plafond.
 
 La conclusion « donc on ne peint pas » ne suit pas, parce qu'il existe dans cet arbre un
 niveau où la composition est **impossible par construction** : la `.plaque`. Aucune plaque
-n'en contient une autre — c'est une **feuille**. Peindre la feuille plutôt que le nœud
+n'en contient une autre : c'est une **feuille**. Peindre la feuille plutôt que le nœud
 supprime le problème au lieu de le surveiller : il n'y a plus de pire cas géométrique à
-tenir, puisqu'il n'y a plus de recouvrement possible. Les `<li>` gardent `data-pole` — ils
-portent la teinte pour toute leur descendance — mais ne peignent plus rien du tout.
+tenir, puisqu'il n'y a plus de recouvrement possible. Les `<li>` gardent `data-pole` (ils
+portent la teinte pour toute leur descendance), mais ne peignent plus rien du tout.
 
 C'est une règle générale, pas une astuce locale : **la teinte descend par la cascade, la
 peinture reste sur les feuilles.** Tout porteur de `data-pole` susceptible d'en contenir un
@@ -1063,12 +1063,12 @@ de la place au lavis supprimerait le matériau. Ni l'un ni l'autre.
 
 Le lavis passe donc **sous** le voile, en couches de `background` empilées sur la plaque
 elle-même. L'ordre se lit de l'avant vers l'arrière : voile de verre, puis tache, puis fond
-plat. Le voile n'est ni retiré ni affaibli — il est déplacé d'une propriété du module vers
+plat. Le voile n'est ni retiré ni affaibli : il est déplacé d'une propriété du module vers
 la première couche de `.lavis-feuille`, à la valeur identique.
 
 La troisième couche ne rouvre pas la règle « deux couches et pas plus » : ce qu'elle
 interdisait, c'est une troisième **tache**, dont le recouvrement dépendrait de la
-géométrie. Le voile est un aplat plein cadre — il ne se recouvre avec rien, il recouvre
+géométrie. Le voile est un aplat plein cadre : il ne se recouvre avec rien, il recouvre
 tout, également. Le pire cas reste `1-(1-fond)(1-tache)`, atténué d'un facteur constant.
 
 #### La compensation est dérivée, jamais réglée
@@ -1095,23 +1095,23 @@ disent la même opacité, l'une du côté du verre, l'autre du côté de ce qu'i
 **elles bougent ensemble**. Remonter le voile sans descendre cette valeur ferait pâlir
 toutes les feuilles d'un coup, sans qu'aucune règle ne le signale.
 
-### Les autres porteurs de `data-pole` — peints ou écartés
+### Les autres porteurs de `data-pole` : peints ou écartés
 
 Aucun n'est laissé sans décision.
 
 | Porteur | Décision | Raison |
 |---|---|---|
 | `ChainDiagram` | **peint** | `.lavis-feuille` sur `.plaque`, la feuille de l'arbre. Non-composition mesurée au pixel. |
-| `PoleTagList` | **écarté, et corrigé** | Il portait déjà un lavis, écrit à la main à 8 % — voir ci-dessous. |
-| `RealisationCard` | **écarté** | `IRealisation.poles` est un tableau : les fiches portent 1, 2 ou 3 pôles. Aucun lavis unique n'est possible sans affirmer une hiérarchie que le modèle nie, et un dégradé des pôles rattachés se lirait comme une succession — sur `['data','ia','sea-ux']`, il dirait que l'IA vient avant le SEA & UX. Les pôles sont déjà rendus **tous**, à facture identique, par `PoleTagList`. |
-| `PoleStickyBar` | **écarté** | C'est une **bande**, pas un panneau. `verre.css` documente pourquoi les deux ne partagent pas leurs réglages : une bande collante passe sur du texte et compense par un voile plus opaque (`--verre-voile-barre`, 82 %), qui ne laisserait passer que 18 % d'un lavis. La barre porte déjà son pôle par `--accent` — le chiffre de temps et le filet du bas. |
+| `PoleTagList` | **écarté, et corrigé** | Il portait déjà un lavis, écrit à la main à 8 %, voir ci-dessous. |
+| `RealisationCard` | **écarté** | `IRealisation.poles` est un tableau : les fiches portent 1, 2 ou 3 pôles. Aucun lavis unique n'est possible sans affirmer une hiérarchie que le modèle nie, et un dégradé des pôles rattachés se lirait comme une succession : sur `['data','ia','sea-ux']`, il dirait que l'IA vient avant le SEA & UX. Les pôles sont déjà rendus **tous**, à facture identique, par `PoleTagList`. |
+| `PoleStickyBar` | **écarté** | C'est une **bande**, pas un panneau. `verre.css` documente pourquoi les deux ne partagent pas leurs réglages : une bande collante passe sur du texte et compense par un voile plus opaque (`--verre-voile-barre`, 82 %), qui ne laisserait passer que 18 % d'un lavis. La barre porte déjà son pôle par `--accent`, le chiffre de temps et le filet du bas. |
 | `SiteHeader` | **écarté** | Bande également, et surtout : ses quatre entrées portent **quatre** `data-pole` différents dans une seule barre de navigation. Quatre lavis côte à côte sur 40 px de haut ne se liraient pas comme quatre pôles mais comme un dégradé sale. Le chiffre de temps porte déjà la teinte. |
 | `SlabScene` | **écarté** | La scène du seuil a déjà ses dégradés par pôle, **en SVG**, un par dalle. Un lavis HTML par-dessus dupliquerait la même information dans un second système de couleur. |
 
-### `PoleTagList` — le dernier littéral de densité, et il était hors norme
+### `PoleTagList` : le dernier littéral de densité, et il était hors norme
 
 L'étiquette était le seul endroit du site où une surface était teintée à la teinte de son
-pôle par un **littéral écrit à la main** — `--accent` à 8 %, puis 16 % au survol —
+pôle par un **littéral écrit à la main** (`--accent` à 8 %, puis 16 % au survol)
 antérieur au plafond. Lui ajouter `.lavis-bloc` aurait empilé un second lavis sur le
 premier : exactement la composition que ce lot supprime ailleurs.
 
@@ -1120,16 +1120,16 @@ Mesuré au pixel sur `/realisations/` en thème clair, cet aplat mettait l'étiq
 (seuil 3:1, WCAG 1.4.11) ; le SEA & UX suivait à 2,97:1. La cause est propre à ce
 composant : ailleurs le lavis porte de l'**encre**, ici il portait **sa propre teinte**.
 Les seize ratios des tableaux de jetons sont mesurés sur `--fond`, jamais sur un lavis de
-la couleur qu'ils servent — un `--accent` posé sur son propre lavis perd des deux côtés à
+la couleur qu'ils servent : un `--accent` posé sur son propre lavis perd des deux côtés à
 la fois, la teinte et le fond se rapprochant ensemble.
 
 Baisser l'aplat au jeton gouverné (`--lavis-bloc-fond`, 6 %) a été essayé et **mesuré** :
 la donnée remonte à 4,41:1, toujours sous le seuil, et la marge restante dépend de
-l'endroit de la page où la carte tombe — le dégradé d'atelier n'a pas la même clarté en
+l'endroit de la page où la carte tombe : le dégradé d'atelier n'a pas la même clarté en
 haut et en bas de la liste. Un seuil qui se tient à 0,09 point près selon la position d'une
 carte n'est pas tenu.
 
-**L'aplat est donc retiré, pas rebaissé** — et c'est ce que disait déjà la première ligne
+**L'aplat est donc retiré, pas rebaissé**, et c'est ce que disait déjà la première ligne
 du module : *un filet à gauche plutôt qu'une pastille pleine*. L'aplat contredisait
 l'intention qu'il était censé servir. Le filet passe de `--accent-vif` à `--accent` :
 `--accent-vif` est documenté « non-texte » et tient 3:1 sur `--fond`, pas sur un lavis de
@@ -1148,28 +1148,28 @@ d'ombres**.
 
 Trois couches, et chacune dit une chose :
 
-1. la **lumière** au ras du haut — la tranche qui prend le jour ;
-2. le **rebond** au ras du bas — la face inférieure, qui ne reçoit que ce que le papier lui
+1. la **lumière** au ras du haut, la tranche qui prend le jour ;
+2. le **rebond** au ras du bas, la face inférieure, qui ne reçoit que ce que le papier lui
    renvoie : plus faible, et jamais blanche ;
-3. l'**ombre portée** sous la bande — sans elle, le verre est dans le plan de la page au
+3. l'**ombre portée** sous la bande : sans elle, le verre est dans le plan de la page au
    lieu de flotter au-dessus. C'est ce décollement qui manquait.
 
 L'ombre portée est large et très diluée : une ombre courte et dense se lirait comme une
 bordure, pas comme de la distance.
 
-La **réfraction** arrive aussi sur la bande, sous le même verrou que les panneaux — Blink
+La **réfraction** arrive aussi sur la bande, sous le même verrou que les panneaux : Blink
 seul, Safari et Firefox exclus par une clause `not (…)` qui survit à la minification. Le
 gate est recopié plutôt que factorisé : une classe partagée entre un panneau et une bande
 obligerait l'une à porter les réglages de l'autre, et c'est exactement ce qui produit les
-traînées colorées. Elle n'a de sens que depuis que le fond porte de la couleur — le lavis
+traînées colorées. Elle n'a de sens que depuis que le fond porte de la couleur : le lavis
 du pôle qu'on lit, désormais, plus la lueur de seuil de `.fond-atelier`.
 
 
-## Le verre marqué — la recalibration mesurée du 2026-08-23
+## Le verre marqué : la recalibration mesurée du 2026-08-23
 
 Section ajoutée **à côté** de « Le verre de la bande » ci-dessus, qu'elle révise sans la
 remplacer : le raisonnement d'origine reste juste sur le matériau, il l'était moins sur
-ce qui coûte la lisibilité. Demande de Jérôme MARICHEZ, issue #115 — **un effet de verre
+ce qui coûte la lisibilité. Demande de Jérôme MARICHEZ, issue #115 : **un effet de verre
 plus marqué sur la navigation, les boutons, les appels à l'action et les zones à impact**.
 
 Les planches avant / après sont dans [`captures/`](./captures/), quatre cases chacune
@@ -1185,16 +1185,16 @@ L'effet existait déjà partout où il était demandé. S'il ne se voyait pas, c
 n'est pas la même selon la bande ni selon le thème.
 
 **Les 88 % de l'en-tête n'étaient pas prudents : ils étaient déjà le plancher.** Au pire
-cas mesuré — l'**aplat d'`--accent` du bouton d'action du seuil**, qui passe sous
-l'en-tête vers 528px de défilement sur l'accueil — `--pole-data` à 13px n'y valait que
+cas mesuré (l'**aplat d'`--accent` du bouton d'action du seuil**, qui passe sous
+l'en-tête vers 528px de défilement sur l'accueil), `--pole-data` à 13px n'y valait que
 **4.74:1**, soit 0,24 point au-dessus du seuil AA. Ce n'était pas un réglage confortable
 qu'on pouvait dépenser : c'était la marge entière.
 
 **Le flou n'achète pas de transparence, contrairement à ce qu'on pouvait attendre.** À
 32px comme à 20px, le plancher de voile de l'en-tête ne bouge pas d'un point (85 %). Un
 flou ne moyenne que ce qui a du **dessin** ; le pire cas de ce site est un aplat de
-150 × 40px, plus large que le noyau. Le flou reste ce qui fait le **matériau** — c'est lui
-qui dissout la trame de 32px sous la bande et la laisse nette dehors — mais il ne fait pas
+150 × 40px, plus large que le noyau. Le flou reste ce qui fait le **matériau** (c'est lui
+qui dissout la trame de 32px sous la bande et la laisse nette dehors), mais il ne fait pas
 de marge de contraste. La saturation, elle, ne coûte qu'un point de plancher entre 1.1
 et 1.3.
 
@@ -1203,14 +1203,14 @@ où le fond porte un aplat d'accent.**
 
 ### Les réglages, avant et après
 
-| Jeton | Avant | Après — clair | Après — sombre |
+| Jeton | Avant | Après (clair) | Après (sombre) |
 |---|---|---|---|
 | `--verre-flou-bande` | `14px` | `20px` | `20px` |
 | `--verre-saturation-bande` | `1.1` | `1.3` | `1.3` |
 | `--verre-voile-bande` (en-tête) | `88%` | **`86%`** | **`73%`** |
 | `--verre-voile-barre` (barre de pôle) | `82%` | **`76%`** | **`58%`** |
 
-Ce que cela change en part de fond réellement traversée — c'est elle qu'on voit, pas le
+Ce que cela change en part de fond réellement traversée, c'est elle qu'on voit, pas le
 voile :
 
 | Bande | Thème | Avant | Après |
@@ -1221,8 +1221,8 @@ voile :
 | barre de pôle | sombre | 18 % | **42 %** |
 
 Les voiles deviennent **dépendants du thème**, et c'est une conséquence de la palette, pas
-un goût. En thème sombre `--accent` est **clair** — les quatre teintes de pôle y sont
-choisies claires pour porter du texte sur un fond à 6 % de luminance — tandis que le fond
+un goût. En thème sombre `--accent` est **clair** (les quatre teintes de pôle y sont
+choisies claires pour porter du texte sur un fond à 6 % de luminance), tandis que le fond
 composé sous la bande reste très sombre. Le texte et son fond s'y éloignent au lieu de se
 rapprocher, l'aplat du bouton cesse d'être le pire cas, et le plancher tombe de 15 points
 sur l'en-tête, de 21 sur la barre.
@@ -1230,7 +1230,7 @@ sur l'en-tête, de 21 sur la barre.
 ### La méthode, et les trois pièges qui la faussent
 
 Le plancher est relevé **au pixel sur le rendu servi**, pas calculé sur une couleur
-supposée. Le contenu de la bande est masqué (`visibility: hidden` — la mise en page ne
+supposée. Le contenu de la bande est masqué (`visibility: hidden`, la mise en page ne
 bouge pas), la bande est rendue transparente, et ce qui est capturé est le fond **déjà
 filtré** par `backdrop-filter`. Le voile n'étant qu'une composition alpha par-dessus, il
 se balaie ensuite analytiquement ; le modèle a été contrôlé contre le composé réel et
@@ -1241,17 +1241,17 @@ rencontrés :
 
 | Piège | Conséquence | Parade |
 |---|---|---|
-| `page.screenshot({ clip })` interprète `clip` dans les coordonnées du **document**, `getBoundingClientRect()` dans celles du **viewport** | sur une bande `sticky`, dont le rect vaut toujours y≈0, chaque capture relit la même bande de haut de document — la mesure ne dépend plus du défilement et paraît stable | capturer le **viewport entier**, recadrer au canvas |
+| `page.screenshot({ clip })` interprète `clip` dans les coordonnées du **document**, `getBoundingClientRect()` dans celles du **viewport** | sur une bande `sticky`, dont le rect vaut toujours y≈0, chaque capture relit la même bande de haut de document : la mesure ne dépend plus du défilement et paraît stable | capturer le **viewport entier**, recadrer au canvas |
 | `document.querySelector('header')` ne suffit pas : `EditorialSection` rend un `<header>` lui aussi | une règle `header > * { visibility: hidden }` masque les **titres de section**, c'est-à-dire exactement le contenu sombre dont on cherche le pire cas ; le fond mesuré ressort bien plus clair qu'il n'est | sélecteur porté sur la classe du module |
-| un pas de défilement de 70 ou 110px | il **saute** le pire cas, atteint quand un aplat ou un `h1` se trouve pile sous la bande — une trentaine de pixels de défilement | pas de **24px**, page entière |
+| un pas de défilement de 70 ou 110px | il **saute** le pire cas, atteint quand un aplat ou un `h1` se trouve pile sous la bande, une trentaine de pixels de défilement | pas de **24px**, page entière |
 
 Pages balayées : accueil, `/services/data/`, `/services/sea-ux/`, un article. Les deux
 bandes, les deux thèmes, à 1440 × 900.
 
-### Contraste — le pire cas, pas le cas moyen
+### Contraste : le pire cas, pas le cas moyen
 
-Planchers relevés, et ce qui les bloque. Le jeton qui bloque n'est ni `--encre` — qui
-tient jusqu'à un voile de 30 % — ni `--encre-douce`, mais **`--accent` à 13px** : les
+Planchers relevés, et ce qui les bloque. Le jeton qui bloque n'est ni `--encre` (qui
+tient jusqu'à un voile de 30 %) ni `--encre-douce`, mais **`--accent` à 13px** : les
 quatre chiffres de temps de l'en-tête, et celui de la barre de pôle.
 
 | Bande | Thème | Plancher | Bloqué par | Pire fond composé | Où |
@@ -1265,8 +1265,8 @@ Les valeurs retenues sont posées **au-dessus** de ces planchers, d'un à cinq p
 la bande : le balayage a un pas de 24px et porte sur quatre gabarits, il n'épuise pas les
 positions possibles.
 
-Contraste effectivement obtenu **aux valeurs retenues**, sur le pire pixel rencontré —
-c'est le tableau qui compte, les planchers ci-dessus ne servaient qu'à les choisir :
+Contraste effectivement obtenu **aux valeurs retenues**, sur le pire pixel rencontré.
+C'est le tableau qui compte, les planchers ci-dessus ne servaient qu'à les choisir :
 
 | Bande | Thème | Voile retenu | Pire contraste | Seuil | Marge |
 |---|---|---|---|---|---|
@@ -1279,14 +1279,14 @@ Dans les quatre cas, le texte qui fixe la marge est `--accent` à 13px. Le reste
 portent les bandes est très au-dessus : `--encre` à 15 et 18px vaut 10.2 à 13.1:1, et
 `--encre-douce` à 13px vaut 4.93 à 5.86:1.
 
-Le relevé a été **rejoué après l'intégration de `dev`** — le lavis de `ChainDiagram`, les
+Le relevé a été **rejoué après l'intégration de `dev`** : le lavis de `ChainDiagram`, les
 nouvelles sections de pôle et les articles ajoutés changent ce qui défile sous les bandes.
 Les quatre valeurs sont inchangées au centième près ; seule la position du pire cas de la
 barre a suivi l'allongement de la page de pôle (3288 → 4440px).
 
 Ces marges sont **minces, et c'est leur nature** : un plancher mesuré est par définition
 une valeur qu'on approche. Elles sont du même ordre que celle du lavis de pôle (0,02 point
-sur `--pole-data-vif`, issue #104) et se lisent de la même façon — toute baisse future
+sur `--pole-data-vif`, issue #104) et se lisent de la même façon : toute baisse future
 d'un voile de bande demande de rouvrir cette mesure, pas de l'estimer.
 
 Le **bouton d'action** de chaque bande n'entre pas dans ce tableau, et c'est volontaire :
@@ -1297,19 +1297,19 @@ Il vaut 6.02:1 en clair et 7.18:1 en sombre, comme avant.
 
 Il faut le dire tel quel plutôt que de le laisser deviner : **en thème clair, l'en-tête ne
 descend que de deux points**. La demande d'un verre plus marqué sur la **navigation** y
-est arrêtée par un contraste, pas par un choix de réglage — et ce contraste était déjà
+est arrêtée par un contraste, pas par un choix de réglage, et ce contraste était déjà
 juste avant ce lot.
 
 Ce qui bloque est identifié, et ce n'est pas le verre : ce sont **les quatre chiffres de
 temps de l'en-tête, en `--accent` à 13px, qui passent au-dessus de l'aplat d'`--accent` du
 bouton du seuil**. Deux couleurs de la même famille, donc de luminances voisines. Le même
-en-tête tiendrait un voile de **68 %** si ces chiffres prenaient `--encre-douce` — c'est
+en-tête tiendrait un voile de **68 %** si ces chiffres prenaient `--encre-douce` (c'est
 la valeur relevée sur le sous-titre « Ingénieur-conseil… », qui est exactement ce jeton à
-la même taille dans la même bande — et de **30 %** avec `--encre`.
+la même taille dans la même bande) et de **30 %** avec `--encre`.
 
 Les prendre à `--encre` rendrait le verre franchement visible sur la navigation, dans les
 deux thèmes. Mais ce serait renoncer à ce que l'en-tête soit **la légende de la palette du
-site** — chaque entrée y porte `data-pole`, et son chiffre prend la teinte de son pôle.
+site** : chaque entrée y porte `data-pole`, et son chiffre prend la teinte de son pôle.
 C'est un arbitrage de **système de design**, pas un réglage de verre : il revient à
 Jérôme MARICHEZ et n'est pas pris ici.
 
@@ -1317,23 +1317,23 @@ Jérôme MARICHEZ et n'est pas pris ici.
 
 | Surface | Décision | Raison |
 |---|---|---|
-| `SiteHeader` — bande | voile au plancher, flou 20px, saturation 1.3 | aucune ligne du module n'a bougé : la recalibration est entièrement dans les jetons, ce que l'extraction de `verre.css` promettait |
-| `PoleStickyBar` — bande | idem, **plus** la pile d'ombres de l'en-tête | deux bandes qui s'empilent doivent se ressembler ; à 82 % l'écart ne se voyait pas, à 76 % la barre serait la seule sans tranche éclairée ni décollement |
-| `HomeHero` — action **secondaire** | passe des jetons de **bande** à ceux de **panneau** | elle n'est pas une bande : rien ne défile dessous, elle ne fait pas la largeur de l'écran, son texte est en `--encre`. Ce qui la rangeait avec les bandes était sa taille, et la taille ne dit rien de ce qui passe derrière |
-| `HomeView` — bloc de **contact** | devient un vrai panneau de verre (`backdrop-filter` derrière `@supports`) | il avait la géométrie d'un panneau et rien de son matériau. C'est le bloc où l'on décide, et il n'est pas `sticky` : son fond défile avec lui, le compositeur n'a pas à le reflouter à chaque image |
-| `HomeHero` — action **principale** | **écartée**, reste un aplat | c'est le seul élément du seuil dont le contraste texte/fond est critique. Un fond translucide le rendrait dépendant de ce qui passe derrière — et c'est précisément cet aplat qui bloque déjà l'en-tête |
+| `SiteHeader`, bande | voile au plancher, flou 20px, saturation 1.3 | aucune ligne du module n'a bougé : la recalibration est entièrement dans les jetons, ce que l'extraction de `verre.css` promettait |
+| `PoleStickyBar`, bande | idem, **plus** la pile d'ombres de l'en-tête | deux bandes qui s'empilent doivent se ressembler ; à 82 % l'écart ne se voyait pas, à 76 % la barre serait la seule sans tranche éclairée ni décollement |
+| `HomeHero`, action **secondaire** | passe des jetons de **bande** à ceux de **panneau** | elle n'est pas une bande : rien ne défile dessous, elle ne fait pas la largeur de l'écran, son texte est en `--encre`. Ce qui la rangeait avec les bandes était sa taille, et la taille ne dit rien de ce qui passe derrière |
+| `HomeView`, bloc de **contact** | devient un vrai panneau de verre (`backdrop-filter` derrière `@supports`) | il avait la géométrie d'un panneau et rien de son matériau. C'est le bloc où l'on décide, et il n'est pas `sticky` : son fond défile avec lui, le compositeur n'a pas à le reflouter à chaque image |
+| `HomeHero`, action **principale** | **écartée**, reste un aplat | c'est le seul élément du seuil dont le contraste texte/fond est critique. Un fond translucide le rendrait dépendant de ce qui passe derrière, et c'est précisément cet aplat qui bloque déjà l'en-tête |
 | Mur de preuves | **écarté** | il est déjà **dans** un `GlassSurface` : la section « preuves » est vitrable (`glass-policy.ts`), et vitrer ses tuiles ferait du verre dans du verre |
 | Les quatre portes de pôle | **écarté** | elles portent déjà leur lavis (issue #104), et quatre `backdrop-filter` de plus sur la page qui porte le LCP dépenseraient la marge de budget que la réfraction avait déjà montrée épaisse d'un point |
 
 ### Coût
 
-Une surface floutée de plus sur l'accueil — le bloc de contact — et aucune sur les pages
+Une surface floutée de plus sur l'accueil (le bloc de contact) et aucune sur les pages
 de pôle. Les deux bandes `sticky`, qui sont les seules refloutées **à chaque image** de
 défilement, n'ont pas changé de nombre ni de taille ; leur flou passe de 14 à 20px, sur
 une bande de 68px de haut. Le repli `@supports` est intact partout, préfixe `-webkit-`
 **avant** le standard, et le seuil de 1024px des bandes n'a pas bougé.
 
-Mesuré après le lot, `make budgets` — **identique au relevé d'avant**, page pour page :
+Mesuré après le lot, `make budgets` (**identique au relevé d'avant**, page pour page) :
 
 | Page | Perf | A11y | Bonnes prat. | SEO |
 |---|---|---|---|---|
@@ -1342,5 +1342,5 @@ Mesuré après le lot, `make budgets` — **identique au relevé d'avant**, page
 | blog, article, réalisations, fiche | 97 | 100 | 100 | 100 |
 
 axe-core : **0 violation** sur les six gabarits. La surface floutée ajoutée n'a rien coûté,
-et c'est cohérent avec ce qui la distingue des bandes — elle n'est pas `sticky`, son fond
+et c'est cohérent avec ce qui la distingue des bandes : elle n'est pas `sticky`, son fond
 défile avec elle, le compositeur n'a pas à la reflouter image par image.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -9,7 +9,7 @@ unique via Make.
 Le site étant en `output: 'export'` (voir [architecture](./architecture.md)), il n'y a
 **rien à exécuter au runtime** : l'étape de build produit `out/`, et l'image de runtime
 est un **nginx qui sert des fichiers**, pas un Node qui rend des pages. `next start` ne
-fonctionne pas sur une sortie exportée — c'est la raison du changement, pas une
+fonctionne pas sur une sortie exportée : c'est la raison du changement, pas une
 préférence.
 
 ```bash
@@ -21,10 +21,10 @@ make docker-down        # arrêt
 
 ## Règles
 
-- **Aucun secret dans les images** : variables sensibles via `.env` (gitignoré) —
-  le modèle documenté est **`.env.example`** (à tenir à jour à chaque variable ajoutée).
+- **Aucun secret dans les images** : variables sensibles via `.env` (gitignoré).
+  Le modèle documenté est **`.env.example`** (à tenir à jour à chaque variable ajoutée).
 - Données persistées via **volumes** (jamais dans le conteneur).
-- Images de prod **multi-stage** (build → runtime minimal) — c'est le cas des
+- Images de prod **multi-stage** (build → runtime minimal) : c'est le cas des
   `Dockerfile` générés (`node:24-alpine`).
 
 ## Services
@@ -36,24 +36,24 @@ make docker-down        # arrêt
 Configuration nginx : [`docker/nginx.conf`](../docker/nginx.conf). Trois règles y comptent :
 
 - `trailingSlash: true` fait sortir chaque route en `<route>/index.html`, que la directive
-  `index` résout nativement — **aucune règle de réécriture à tenir**.
+  `index` résout nativement : **aucune règle de réécriture à tenir**.
 - Les assets de `/_next/static/` sont immuables (leur nom change à chaque build) et
   portent `max-age=31536000, immutable` ; le HTML porte `max-age=0, must-revalidate`,
   sans quoi une mise en production resterait invisible pour les visiteurs déjà venus.
-- **La compression est déclarée explicitement** — voir ci-dessous.
+- **La compression est déclarée explicitement**, voir ci-dessous.
 
 ## Compression
 
 `nginx:alpine` livre la directive `gzip` **commentée**. Tant qu'on ne la déclare pas,
 le site part en clair : l'accueil sortait en **120 Kio de HTML brut**, ce qui coûtait
-15 points de performance mobile aux budgets (LCP à 5,3 s pour un FCP à 1,7 s — du
-transfert, pas du calcul). Une configuration nginx qu'on ne complète pas est une
+15 points de performance mobile aux budgets (LCP à 5,3 s pour un FCP à 1,7 s, donc du
+transfert et pas du calcul). Une configuration nginx qu'on ne complète pas est une
 configuration qui ne compresse pas ; ça ne se voit pas en desktop, et ça se paie
 intégralement en 4G.
 
 | Réglage | Valeur | Pourquoi cette valeur |
 |---------|--------|-----------------------|
-| `gzip_comp_level` | `6` | Mesuré, pas recopié : sur l'`index.html` de l'accueil, le niveau 6 rend 22 226 octets, le niveau 9 en rend 22 092 — **134 octets de mieux (0,6 %) pour environ deux fois le temps CPU**. Le gain se joue entre 1 et 6. |
+| `gzip_comp_level` | `6` | Mesuré, pas recopié : sur l'`index.html` de l'accueil, le niveau 6 rend 22 226 octets, le niveau 9 en rend 22 092. **134 octets de mieux (0,6 %) pour environ deux fois le temps CPU**. Le gain se joue entre 1 et 6. |
 | `gzip_min_length` | `1024` | En deçà de 1 Kio, l'en-tête gzip et les tables de Huffman mangent le gain, et la réponse tient de toute façon dans la première fenêtre de congestion : elle arrive dans le même aller-retour, compressée ou non. Le défaut de nginx (20 octets) fait l'inverse. |
 | `gzip_vary` | `on` | Une même URL répond désormais en clair ou compressé selon `Accept-Encoding` : sans `Vary`, un cache intermédiaire servirait du gzip à un client qui ne l'a pas demandé. |
 | `gzip_proxied` | `any` | Par défaut nginx refuse de compresser une réponse relayée à un proxy. Le site est destiné à vivre derrière un reverse proxy / CDN : sans cette ligne, la compression s'éteindrait justement en production. |
@@ -61,18 +61,18 @@ intégralement en 4G.
 
 **gzip et pas brotli** : le module `ngx_brotli` n'est pas dans l'image officielle, et
 l'ajouter imposerait de compiler nginx nous-mêmes. L'écart brotli/gzip sur du HTML est
-de l'ordre de 15 % — il ne justifie pas, aujourd'hui, une image maison à maintenir. Le
+de l'ordre de 15 % : il ne justifie pas, aujourd'hui, une image maison à maintenir. Le
 jour où elle existe pour une autre raison, brotli s'y ajoute.
 
 ### Le harnais de mesure reflète cette configuration
 
-[`scripts/serve-out.mjs`](../scripts/serve-out.mjs) — le serveur qu'utilisent les tests
-e2e et `make budgets` — reproduit ces réglages : mêmes types, même seuil, même niveau,
+[`scripts/serve-out.mjs`](../scripts/serve-out.mjs), le serveur qu'utilisent les tests
+e2e et `make budgets`, reproduit ces réglages : mêmes types, même seuil, même niveau,
 même `Vary`.
 
 **Le sens de la dépendance est fixe et ne s'inverse jamais : `docker/nginx.conf`
 décide, le harnais reflète.** Un harnais qui compresserait sans que la production
-compresse annoncerait une performance que le visiteur ne reçoit pas — c'est un truquage
+compresse annoncerait une performance que le visiteur ne reçoit pas : c'est un truquage
 de la mesure au sens de la règle 8 du `CLAUDE.md`. L'inverse (harnais en clair,
 production compressée) condamne un site qui va bien. Toute évolution des réglages
 commence donc par `docker/nginx.conf`.
@@ -80,7 +80,7 @@ commence donc par `docker/nginx.conf`.
 ## Contrôles automatisés de l'image
 
 `docker/nginx.conf` **décide du comportement du site en production** : résolution des
-routes, statut d'erreur, compression. Longtemps rien ne l'a vérifié — une faute de
+routes, statut d'erreur, compression. Longtemps rien ne l'a vérifié : une faute de
 frappe dans une directive passait toute la CI au vert et ne se manifestait qu'au premier
 `docker compose up`. Le cas nominal est le pire : la compression vaut **15 points de
 performance mobile**, et un site qui cesse de compresser reste un site qui répond 200.
@@ -97,14 +97,14 @@ minutes, il en prend cinquante secondes (`npm ci` + `next build` dans une image 
 cache), soit **moins que le contrôle d'accessibilité déjà placé sur `dev`**. Le critère
 du dépôt est la durée ; à ce prix-là, faire attendre la PR de production n'a plus de
 justification. Le premier contrôle reste malgré tout utile : il tient en 10 s **sans
-build applicatif**, donc il répond encore quand `npm ci` est cassé — il sépare « la
+build applicatif**, donc il répond encore quand `npm ci` est cassé : il sépare « la
 configuration nginx est fausse » de « l'application ne construit pas ».
 
 ### `nginx -t` teste bien le fichier du dépôt
 
 Le point mérite d'être dit, parce que c'est l'erreur qui rendrait le contrôle décoratif :
 `nginx -t` charge `/etc/nginx/nginx.conf`, qui fait `include /etc/nginx/conf.d/*.conf`.
-Le script monte le fichier versionné **à la place** du `default.conf` livré par l'image —
+Le script monte le fichier versionné **à la place** du `default.conf` livré par l'image :
 c'est donc bien `docker/nginx.conf`, dans le contexte `http` réel de l'image, et pas la
 configuration par défaut. La version de nginx n'est pas recopiée dans le script : elle
 est **lue dans le `Dockerfile`**, une directive pouvant être valide sur une version et
@@ -119,7 +119,7 @@ Une configuration syntaxiquement valide peut ne rien faire. `make docker-smoke` 
 |-----------|--------------------|
 | `GET /` → **200** | `index` + `try_files` résolvent `<route>/index.html` (`trailingSlash: true`) |
 | `GET /url-absente/` → **404** | `error_page 404 /404.html` sert la page **sans** transformer le statut en 200 |
-| `Content-Encoding: gzip` sur le HTML | les six directives de compression **s'appliquent** — les 15 points |
+| `Content-Encoding: gzip` sur le HTML | les six directives de compression **s'appliquent** : les 15 points |
 | `Vary: Accept-Encoding` | un cache intermédiaire ne servira pas du gzip à un client qui n'en veut pas |
 
 C'est l'assertion gzip qui justifie d'aller jusqu'au conteneur démarré : un
@@ -127,14 +127,14 @@ C'est l'assertion gzip qui justifie d'aller jusqu'au conteneur démarré : un
 se discute pas.
 
 Le conteneur est attendu par **sonde HTTP**, jamais par un `sleep` arbitraire, et retiré
-par un `trap` — y compris en cas d'échec, sans conteneur orphelin.
+par un `trap`, y compris en cas d'échec, sans conteneur orphelin.
 
 ### `.dockerignore`
 
 Le `Dockerfile` fait `npm ci` **puis** `COPY . .`. Sans `.dockerignore`, le
 `node_modules` de la machine hôte écrase celui que `npm ci` vient d'installer : sur un
 poste macOS, les binaires natifs copiés dans l'image Linux ne sont pas les bons. La CI ne
-voyait pas le défaut (checkout vierge) — un poste de développement, si.
+voyait pas le défaut (checkout vierge). Un poste de développement, si.
 
 <!-- TODO : ajouter ici les services d'infrastructure (base de données, cache…)
      au fur et à mesure, avec leurs volumes. -->

--- a/docs/frontend-practices.md
+++ b/docs/frontend-practices.md
@@ -3,7 +3,7 @@
 Principes transverses appliqués par l'agent `opus-frontend` (voir
 [`model-routing.md`](./model-routing.md)). Neutres vis-à-vis de la stack : ils
 valent que le projet soit sous Vite ou Next, avec ou sans Storybook. Un encart
-« Exemple réel » en fin de page illustre une implémentation concrète — à titre
+« Exemple réel » en fin de page illustre une implémentation concrète, à titre
 indicatif, **pas** normatif.
 
 ## État : serveur vs client
@@ -11,11 +11,11 @@ indicatif, **pas** normatif.
 La décision frontend la plus structurante. Deux natures de données à ne jamais
 confondre :
 
-- **État serveur** — données distantes (listes, entités, réponses d'API). Géré par
+- **État serveur** : données distantes (listes, entités, réponses d'API). Géré par
   une couche de **cache/fetching** (SWR, React Query…) : dédup des requêtes,
-  revalidation, invalidation. **Jamais recopié** dans un store global — la source
+  revalidation, invalidation. **Jamais recopié** dans un store global : la source
   de vérité reste le cache.
-- **État client** — état d'interface (formulaire en cours, onglet actif, modale
+- **État client** : état d'interface (formulaire en cours, onglet actif, modale
   ouverte). État **local** au composant par défaut ; remonté dans un store partagé
   (Redux Toolkit, Zustand…) seulement s'il est réellement partagé entre plusieurs
   vues.
@@ -33,14 +33,14 @@ lint ailleurs que dans ce service (voir [`tooling.md`](./tooling.md)).
 ## Style
 
 Une **seule** stratégie de style par projet, décidée dans [`design.md`](./design.md)
-(CSS Modules, styled/emotion, ou utilitaire type Tailwind) — pas de mélange. Style
+(CSS Modules, styled/emotion, ou utilitaire type Tailwind), pas de mélange. Style
 **co-localisé** avec le composant, approche **mobile-first**, valeurs tirées des
 **tokens** de design (couleurs, espacements, typo) plutôt qu'en dur.
 
 ## Performance
 
 - **Virtualiser** les longues listes et tableaux (ne pas monter 10 000 lignes).
-- `memo` / `useMemo` / `useCallback` sur des rendus coûteux **mesurés** — jamais par
+- `memo` / `useMemo` / `useCallback` sur des rendus coûteux **mesurés**, jamais par
   réflexe.
 - **Code-splitting / lazy-load** des vues et dépendances lourdes (éditeurs, graphes,
   export PDF…).
@@ -73,7 +73,7 @@ fois trop grand, dans une scène large de 457 px.
 Règles :
 
 - Dans un contexte imbriqué, la taille passe par les **attributs** `width` / `height`,
-  seuls fiables — jamais par le CSS.
+  seuls fiables, jamais par le CSS.
 - Ne pas poser les deux « pour être sûr » : une règle CSS l'emporte sur un attribut de
   présentation, donc la taille demandée serait perdue précisément là où elle est la seule
   à fonctionner. Un composant servant dans les deux contextes expose une prop de taille

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -4,8 +4,8 @@
 
 | Branche | Rôle |
 |---------|------|
-| `main` | Production — stable, déployable, **protégée**. |
-| `dev`  | Intégration — base des développements. |
+| `main` | Production : stable, déployable, **protégée**. |
+| `dev`  | Intégration : base des développements. |
 | `feature/<nom>` | Une fonctionnalité = une branche, depuis `dev`. |
 | `hotfix/<nom>`  | Correctif urgent, depuis `main`, fusionné dans `main` **et** `dev`. |
 
@@ -14,13 +14,13 @@
 1. Créer une **issue** décrivant le besoin.
 2. Créer `feature/<nom>` depuis `dev`.
 3. Développer (tests unitaires systématiques, doc mise à jour).
-4. Ouvrir une **PR vers `dev`** — description liée à l'issue.
+4. Ouvrir une **PR vers `dev`**, description liée à l'issue.
 5. CI verte → merge (auto-merge autorisé).
 6. Mise en production : **PR `dev` → `main`**, fusion **réservée à un humain**.
 
 ## Protections de `main`
 
-- Push direct interdit — PR obligatoire.
+- Push direct interdit : PR obligatoire.
 - Checks CI requis au vert.
 - Revue approuvée obligatoire.
 
@@ -28,5 +28,5 @@
 
 ## Conventions de commit
 
-Format : `type: description courte` — types : `feat`, `fix`, `docs`, `test`,
+Format : `type: description courte`. Types : `feat`, `fix`, `docs`, `test`,
 `refactor`, `chore`, `ci`.

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -10,19 +10,19 @@ heuristique instantanée + subagents pré-définis + escalade.
 1. **`.claude/hooks/route-task.sh`** (UserPromptSubmit) classifie le prompt
    (regex FR/EN + longueur, zéro appel réseau, zéro latence) et **injecte une
    recommandation** de subagent dans le contexte.
-2. **`.claude/agents/`** définit les subagents — le modèle **et** le niveau
+2. **`.claude/agents/`** définit les subagents : le modèle **et** le niveau
    d'effort sont portés par leur frontmatter (`model:`, `effort:`), mécanisme
    natif de Claude Code :
 
 | Subagent | Modèle | Effort | Tâches |
 |----------|--------|--------|--------|
 | `opus-architect` | opus | xhigh | architecture, conception, migrations, sécurité, auth, paiement, concurrence, debugging profond, questions ouvertes (« pourquoi », « comment devrait-on ») |
-| `opus-dev` | opus | medium | features, refactoring ciblé, bugfix non trivial, tests — **et toute la zone grise** |
+| `opus-dev` | opus | medium | features, refactoring ciblé, bugfix non trivial, tests, **et toute la zone grise** |
 | `opus-frontend` | opus | medium | composants React, pages/vues, styles, responsive, accessibilité, Storybook, formulaires, **tableaux de données**, **dataviz/graphes**, **upload/import de fichiers**, animations (absent des projets `package` sans Storybook) |
-| `haiku-mechanic` | haiku | — | doc, renommages, formatage, commits, recherches de fichiers |
+| `haiku-mechanic` | haiku | *sans objet* | doc, renommages, formatage, commits, recherches de fichiers |
 
 3. Le modèle principal **peut outrepasser** la recommandation (il voit tout le
-   contexte de la session, pas seulement le prompt) — c'est un second classifieur
+   contexte de la session, pas seulement le prompt) : c'est un second classifieur
    gratuit. Consigne : dans le doute, un cran **au-dessus**.
 
 ## Garde-fous anti-perte de précision
@@ -34,7 +34,7 @@ heuristique instantanée + subagents pré-définis + escalade.
 - **Routage frontend conditionnel.** Les signaux UI (composant, css, responsive,
   accessibilité, storybook, formulaires, tableaux de données, dataviz/graphes,
   upload/import…) routent vers `opus-frontend` **seulement si l'agent existe** dans
-  `.claude/agents/` — sinon repli naturel sur `opus-dev`. Les signaux de risque (UP)
+  `.claude/agents/`, sinon repli naturel sur `opus-dev`. Les signaux de risque (UP)
   restent prioritaires : « sécurise le formulaire de paiement » va à l'architecte,
   pas au frontend.
 - **Escalade (cascade).** Les prompts de `opus-dev`, `opus-frontend` et `haiku-mechanic` imposent
@@ -44,7 +44,7 @@ heuristique instantanée + subagents pré-définis + escalade.
 - **Signaux de risque prioritaires.** sécurité, auth, paiement, migration,
   concurrence → toujours `opus-architect`, quelle que soit la taille du prompt.
 - **L'effort porte l'économie, pas la qualité du modèle.** Les deux paliers hauts
-  restent sur Opus — seule la profondeur de raisonnement varie (`xhigh` pour
+  restent sur Opus : seule la profondeur de raisonnement varie (`xhigh` pour
   l'architecture, recommandation officielle pour le code ; `medium` pour le
   développement courant). Les économies viennent de l'effort réduit et de Haiku
   sur le mécanique, jamais d'un modèle plus faible sur une tâche de fond.
@@ -56,7 +56,7 @@ heuristique instantanée + subagents pré-définis + escalade.
 ## Budget crédits
 
 Si `CREDITS_LIMIT_TOKENS` (plafond de tokens du bloc de facturation 5 h) est défini
-dans l'environnement, le hook lit la consommation via `ccusage` — **mise en cache
+dans l'environnement, le hook lit la consommation via `ccusage`, **mise en cache
 10 minutes** (aucun appel réseau à chaque prompt) :
 
 - **> 50 % consommés et reset < 2 h** → recommandation plafonnée à `opus-dev`
@@ -67,9 +67,9 @@ dans l'environnement, le hook lit la consommation via `ccusage` — **mise en ca
 ## Journal et évaluation
 
 Chaque classification est journalisée dans `.claude/route-task.log` (JSONL :
-timestamp, classe, subagent, taille du prompt — gitignoré). Règle d'évolution :
+timestamp, classe, subagent, taille du prompt), fichier gitignoré. Règle d'évolution :
 ne **descendre** un type de tâche d'un niveau que si le journal montre qu'il
-n'escalade jamais — « step down only when measured ».
+n'escalade jamais : « step down only when measured ».
 
 ## Sources
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,7 +4,7 @@
 
 ## Règles de base
 
-- **Secrets** : jamais en dur ni commités — variables d'environnement (`.env` gitignoré,
+- **Secrets** : jamais en dur ni commités. Variables d'environnement (`.env` gitignoré,
   `.env.example` documenté). Le serveur **refuse de démarrer** si un secret obligatoire manque
   (pas de valeur par défaut pour un secret).
 - **Authentification** : JWT signé (secret fort, `openssl rand -hex 32`), expiration courte.

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -14,7 +14,7 @@ base pour les revues design et les tests visuels.
 - Les stories utilisent des **fixtures réalistes** (jamais de lorem ipsum pour les données métier).
 
 > **Sans Storybook** : si le projet n'active pas Storybook, ce sont les **tests
-> unitaires (RTL)** qui couvrent ces mêmes états significatifs — ils tiennent lieu
+> unitaires (RTL)** qui couvrent ces mêmes états significatifs : ils tiennent lieu
 > de catalogue. Le routage vers `opus-frontend` reste conditionnel à la présence de
 > Storybook (voir [`model-routing.md`](./model-routing.md)).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,22 +10,22 @@ Les tests **conditionnent la fusion** d'une PR vers `dev` (voir le
 | **unitaire** | composants, hooks, logique pure | **Jest + React Testing Library** | `tests/unitaire/**/*.spec.ts(x)` |
 | **intégration** | plusieurs unités ensemble (composant ↔ service ↔ vraie frontière HTTP pilotée par fixtures) | **Jest + RTL** (+ MSW à la frontière réseau) | `tests/integration/**/*.integration.spec.ts(x)` |
 | **e2e** | parcours **navigateur** contre l'app réelle | **Cypress** | `tests/e2e/**/*.cy.ts` |
-| **système** | **vrai serveur HTTP** (`listen(0)`, port éphémère) appelé par un client réel (`fetch`) — bout en bout **sans navigateur** | **Jest + fetch** | `tests/systeme/**/*.test.ts` |
+| **système** | **vrai serveur HTTP** (`listen(0)`, port éphémère) appelé par un client réel (`fetch`), bout en bout **sans navigateur** | **Jest + fetch** | `tests/systeme/**/*.test.ts` |
 | **système API (rejouable)** | validation documentée de l'API de bout en bout | **Postman** (collection versionnée) | `tests/systeme/postman_collection.json` |
 
 **Acceptation / non-fonctionnel** : parcours métier de bout en bout **et** volets
 **UAT** (disponibilité, sécurité, performance, robustesse) sur la stack réellement
-lancée — runner Node natif (`node:test` + `fetch`), dans `tests/acceptance/` et
+lancée : runner Node natif (`node:test` + `fetch`), dans `tests/acceptance/` et
 `tests/acceptance/uat/<catégorie>/`.
 
 ## Cycle : le test d'abord, écrit par le développeur
 
-L'ordre n'est pas négociable — il est appliqué par le hook
+L'ordre n'est pas négociable. Il est appliqué par le hook
 `.claude/hooks/require-test-first.sh` (PreToolUse) :
 
 1. **Intention.** Le comportement attendu est formulé explicitement : ce qui doit se
    passer, les cas limites, le niveau visé (**unitaire**, **intégration** ou
-   **système** — au moins l'un des trois), le jeu de données utilisé. L'assistant
+   **système** ; au moins l'un des trois), le jeu de données utilisé. L'assistant
    propose cette intention et le contenu du test **dans le chat**.
 2. **Le test est posé par Jérôme MARICHEZ.** L'assistant n'écrit pas les fichiers de test :
    le hook refuse toute écriture sur `*.spec.*`, `*.test.*`, `*.cy.ts` et sur les
@@ -51,10 +51,10 @@ exige alors que chaque test porte en tête un bloc d'intention :
 describe('CartService.total', () => { /* … */ });
 ```
 
-Le garde-fou complet se désarme par `REQUIRE_TEST_FIRST=0` — décision de Jérôme MARICHEZ,
+Le garde-fou complet se désarme par `REQUIRE_TEST_FIRST=0`, décision de Jérôme MARICHEZ,
 jamais de l'assistant.
 
-## Jeux de données — jamais de mocks
+## Jeux de données : jamais de mocks
 
 Un test qui remplace la logique métier par une doublure ne prouve rien. Ici, les
 **vrais services collaborent entre eux** et tournent sur des **jeux de données
@@ -72,18 +72,18 @@ vers un mock.
 
 **Autorisé, parce que ce sont des frontières et non des doublures de métier** :
 
-- **MSW** (`setupServer`) à la frontière réseau — les réponses viennent des fixtures ;
+- **MSW** (`setupServer`) à la frontière réseau : les réponses viennent des fixtures ;
 - **Supertest** ou un **vrai serveur** (`listen(0)`) pour le niveau système ;
 - une **base de test dédiée** (jamais celle de dev/prod), rechargée depuis les fixtures ;
 - `jest.fn()` / `jest.spyOn` pour **observer** un appel (callback, événement) sans
   remplacer un module métier.
 
-Le hook se désarme par `ALLOW_TEST_DOUBLES=1` — décision de Jérôme MARICHEZ, à justifier.
+Le hook se désarme par `ALLOW_TEST_DOUBLES=1`, décision de Jérôme MARICHEZ, à justifier.
 
-## Qualité des tests — mutation testing (Stryker)
+## Qualité des tests : mutation testing (Stryker)
 
 **Stryker** mesure la capacité des tests unitaires/intégration à détecter de vraies
-régressions (score de mutation, seuils dans `stryker.config.json` — le build casse
+régressions (score de mutation, seuils dans `stryker.config.json` : le build casse
 sous le seuil `break`). Lancer : `make test-mutation`.
 
 ## Règles
@@ -96,10 +96,10 @@ sous le seuil `break`). Lancer : `make test-mutation`.
   base propre entre les suites ; garde-fou anti-prod dans le setup.
 - **e2e réservé aux parcours navigateur** ; le bout-en-bout back sans navigateur est le
   niveau **système**.
-- **Couverture** : seuil défini dans la config de test — la CI échoue en dessous.
+- **Couverture** : seuil défini dans la config de test. La CI échoue en dessous.
   <!-- TODO : fixer le seuil (ex. 90 %). -->
 
-## Harnais statique — l'export servi en local
+## Harnais statique : l'export servi en local
 
 Le site est en **export statique** (`output: 'export'`) : il n'y a ni back, ni route
 API, ni serveur applicatif. La « stack » se réduit donc à **servir le dossier `out/`**.
@@ -112,13 +112,13 @@ toujours le second qui laisse un serveur orphelin en CI.
 
 1. **build si nécessaire** : `npm run build` si `out/index.html` manque ;
 2. **serveur statique** : `scripts/serve-out.mjs` sert `out/` sur `127.0.0.1:E2E_PORT`
-   (**4173** par défaut), sans aucune dépendance — `node:http` suffit ;
+   (**4173** par défaut), sans aucune dépendance : `node:http` suffit ;
 3. **attente réelle** : le harnais sonde `GET /` jusqu'à obtenir une réponse HTTP
    (30 s max). Jamais de `sleep` arbitraire ;
 4. **Cypress headless** : `npx cypress run` (les arguments passés à `scripts/e2e.mjs`
    lui sont transmis, ex. `--spec`) ;
 5. **arrêt propre garanti** : le serveur est fermé dans un `finally` et sur
-   `SIGINT`/`SIGTERM` — aucun processus orphelin, même quand les tests échouent. Le
+   `SIGINT`/`SIGTERM` : aucun processus orphelin, même quand les tests échouent. Le
    **code de sortie reste celui de Cypress** : aucun échec n'est absorbé.
 
 `cypress.config.ts` dérive son `baseUrl` du même `E2E_PORT` : le port ne peut pas
@@ -132,7 +132,7 @@ chaque route en `<route>/index.html`. `serve-out.mjs` applique exactement les r�
 statique qui ignorerait cette règle ferait échouer les specs pour la mauvaise raison.
 La traversée de répertoire hors de `out/` est refusée.
 
-## Budgets exécutables — performance et accessibilité
+## Budgets exécutables : performance et accessibilité
 
 Le `CLAUDE.md` pose deux contraintes produit non négociables : **Lighthouse à 95 visé sur
 les quatre catégories** et **accessibilité WCAG AA**. Elles étaient écrites, elles ne sont
@@ -170,8 +170,8 @@ dans `scripts/budgets/`, pas dans `tests/`.
 
 ```bash
 make budgets       # accessibilité + performance
-make budget-a11y   # axe-core seul — rapide (~2 min)
-make budget-perf   # Lighthouse seul — lent (3 passes x 3 pages)
+make budget-a11y   # axe-core seul, rapide (~2 min)
+make budget-perf   # Lighthouse seul, lent (3 passes x 3 pages)
 ```
 
 Prérequis local, une fois : `npx puppeteer browsers install chrome`.
@@ -179,24 +179,24 @@ Prérequis local, une fois : `npx puppeteer browsers install chrome`.
 ### Ce qui est mesuré, et pourquoi
 
 **Trois pages, trois gabarits** (`scripts/budgets/pages.mjs`) : l'accueil (scène animée,
-verre — le gabarit le plus lourd), une page de pôle (sections, preuves, palette dédiée)
+verre, le gabarit le plus lourd), une page de pôle (sections, preuves, palette dédiée)
 et une page d'article (corps long, typographie, fil d'Ariane, JSON-LD). Mesurer le seul
 accueil ne dit rien des deux autres, et c'est là que les régressions se logent.
 
 **Profil de mesure : mobile émulé, réseau bridé « slow 4G », CPU ×4.** C'est le profil
 par défaut de PageSpeed Insights, et le cas sur lequel un prospect jugera le site. Un
-profil desktop sans bridage donnerait des scores flatteurs qui ne protègent de rien — sur
+profil desktop sans bridage donnerait des scores flatteurs qui ne protègent de rien : sur
 ce site, l'écart entre les deux profils est de **dix-sept points** (voir plus bas).
 
 **Médiane de trois passes.** Lighthouse varie de quelques points d'une exécution à
 l'autre. Un budget qui échoue au hasard une fois sur cinq se fait désactiver en une
 semaine ; la médiane le rend crédible. `BUDGET_PASSES` permet de réduire le nombre de
-passes en local pour itérer vite — jamais en CI.
+passes en local pour itérer vite, jamais en CI.
 
 **Un seul Chrome pour toute la campagne** : Lighthouse s'y connecte par le port de
 débogage, axe par l'API puppeteer. Deux navigateurs mesureraient deux sites.
 
-### Première exécution — 2026-08-22
+### Première exécution : 2026-08-22
 
 Mesuré sur l'export de `dev` (commit `596aafd`), médiane de 3 passes, profil mobile.
 
@@ -213,14 +213,14 @@ la page qu'on corrige, jamais le seuil (règle 8 du `CLAUDE.md`). Le diagnostic 
 consigné dans [`ameliorations.md`](./ameliorations.md).
 
 Pour situer : en profil **desktop** non bridé, les mêmes pages sortent à **99 / 100 / 100
-/ 100**. Le site n'est donc pas lent dans l'absolu — il l'est sur un mobile en 4G
+/ 100**. Le site n'est donc pas lent dans l'absolu : il l'est sur un mobile en 4G
 médiocre, ce qui est précisément le cas qui compte.
 
 ## Vérification des types
 
 `make type-check` exécute `tsc --noEmit` : le compilateur vérifie tout le dépôt sans
-écrire un seul fichier. Ce n'est pas un niveau de test — c'est le filet qui attrape ce
-qu'aucun test ne voit (unions fermées, `satisfies`, signatures) — mais il tourne au même
+écrire un seul fichier. Ce n'est pas un niveau de test : c'est le filet qui attrape ce
+qu'aucun test ne voit (unions fermées, `satisfies`, signatures), mais il tourne au même
 titre qu'eux, dans le job `ci-dev-types` de toute PR vers `dev`, et il **fait échouer la
 PR**. `cypress.config.ts` et `tests/e2e` en sont exclus par `tsconfig.json` : leurs types
 Cypress chargent le `expect()` de Chai, qui écrase celui de Jest et casserait la

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,20 +1,20 @@
 # Outillage
 
-## Make — interface de commandes unique
+## Make : interface de commandes unique
 
 Toutes les opérations passent par `make` (voir `Makefile`) : agnostique, documenté
 (`make help`), identique en local et en CI.
 
-## Lint — Biome + limite 300 lignes
+## Lint : Biome + limite 300 lignes
 
 - **Biome** (`biome.json` à la racine) : lint + format TypeScript/React.
   Règles notables : `noExplicitAny` et **`noConsole`** en `error`. Pas de
-  `console.*` dans le code applicatif — passer par le **service de log** du projet
+  `console.*` dans le code applicatif : passer par le **service de log** du projet
   (voir [`frontend-practices.md`](./frontend-practices.md)) ; l'`override` de
   `biome.json` lève la règle pour les fichiers de log, config et scripts.
 - **`scripts/check-max-lines.sh`** : échoue si un fichier source (`.ts`, `.tsx`,
   `.js`, `.jsx`) dépasse **300 lignes**. Exécuté par `make lint`, par la CI et par
-  un hook Claude Code. Remède : extraire (sous-composants, hooks, services) —
+  un hook Claude Code. Remède : extraire (sous-composants, hooks, services),
   jamais d'exclusion de fichier.
 
 ```bash
@@ -33,15 +33,15 @@ make lint
 | `check-new-dependency.sh` | PreToolUse (Bash/Write/Edit/MultiEdit) | Nouvelle dépendance : ≥ 3 contributeurs, OU éditeur de confiance (Meta, Google, Amazon, Microsoft, Vercel… extensible via `TRUSTED_ORGS_EXTRA`) avec ≥ 1000 étoiles ; SemVer obligatoire ; publication > 6 mois → confirmation manuelle. |
 | `check-file-length.sh` | PostToolUse (Write/Edit) | Avertit dès qu'un fichier source dépasse 300 lignes. |
 | `remind-docs.sh` | PostToolUse (Write/Edit) | Rappelle de mettre à jour README/docs après une modification de code (au plus une fois par quart d'heure). |
-| `remind-tests.sh` | PostToolUse (Write/Edit) | Rappelle la politique de tests (unitaire systématique, intégration/e2e sur demande) — même throttle. |
+| `remind-tests.sh` | PostToolUse (Write/Edit) | Rappelle la politique de tests (unitaire systématique, intégration/e2e sur demande), même throttle. |
 
 ## Subagents Claude Code (`.claude/agents/`)
 
 Trois subagents pré-définis portent le routage de modèles (`opus-architect`,
-`opus-dev`, `haiku-mechanic`) — critères, garde-fous et sources dans
+`opus-dev`, `haiku-mechanic`) : critères, garde-fous et sources dans
 [`model-routing.md`](./model-routing.md).
 
 ## Skills Claude Code (`.claude/skills/`)
 
-Ajouter ici les procédures récurrentes du projet (build, déploiement, fixes connus) —
+Ajouter ici les procédures récurrentes du projet (build, déploiement, fixes connus),
 un dossier par skill avec un `SKILL.md` (voir l'exemple fourni).

--- a/src/contenu/accueil.ts
+++ b/src/contenu/accueil.ts
@@ -1,4 +1,4 @@
-// accueil.ts — jeromemarichez-fr
+// accueil.ts (jeromemarichez-fr)
 // Contenu de la page d'accueil : seuil, thèse, et le renvoi vers les quatre pôles.
 //
 // Tous les faits cités ici sont sourcés dans les CV de référence
@@ -10,7 +10,7 @@
 // sections et douze mille pixels, dont trois pôles racontés en court juste au-dessus des
 // pages qui les racontent en long, et deux charnières dupliquées à l'identifiant près.
 // Tout ce détail est descendu sur `/services/<pole>/`. Il ne reste ici qu'une section
-// éditoriale — les deux objections —, parce qu'elle ne relève d'aucun pôle : elle porte
+// éditoriale (les deux objections), parce qu'elle ne relève d'aucun pôle : elle porte
 // sur la façon de travailler, et son second bloc est tenu par les règles de véracité
 // (voir `objections.ts`). Le reste de la page est composé par `HomeView` : seuil, thèse
 // et chaîne, les quatre portes, le mur de preuves, les limites, les certifications, les
@@ -24,12 +24,12 @@ export const HERO_ACCUEIL = {
   titre: "Je construis, j'exploite, je mesure. Le même interlocuteur, du cadrage au run.",
   chapo:
     'Ingénieur-conseil indépendant à Lille, 9 ans. Celui qui cadre est celui qui code, qui mesure ' +
-    'et qui exploite — et c’est lui qui répond de tout.',
+    'et qui exploite. C’est lui qui répond de tout.',
   // Le fil IA se dit dès le seuil, sinon il se découvre au pôle Data et se lit comme une
   // offre. Formulation tenue par les règles de véracité : l'IA instruit et produit, le
-  // test décide — jamais l'inverse.
+  // test décide, jamais l'inverse.
   methode:
-    'Je conçois, je développe et je pilote avec l’IA — Claude Code et Gemini au ' +
+    'Je conçois, je développe et je pilote avec l’IA : Claude Code et Gemini au ' +
     'quotidien, le test tranchant à chaque étape.',
   jetons: [
     { chiffre: '3', libelle: 'migrations sans interruption de service' },
@@ -56,7 +56,7 @@ export const THESE_CHAINE = {
   titre: 'Quatre pôles, une seule chaîne',
   chapo:
     'Pas quatre offres au catalogue : ce qui est construit tourne, ce qui tourne produit de la ' +
-    'donnée — et cette donnée ouvre l’IA et l’arbitrage. L’une, l’autre, ou les deux.',
+    'donnée, et cette donnée ouvre l’IA et l’arbitrage. L’une, l’autre, ou les deux.',
   appui:
     'La chaîne ne tient que parce que c’est la même personne à chaque poste : découpée, elle ' +
     'casse à chaque jointure.',
@@ -65,7 +65,7 @@ export const THESE_CHAINE = {
 export const PAGE_ACCUEIL: IEditorialPage = {
   route: '/',
   meta: {
-    title: 'Jérôme Marichez — Ingénieur-conseil indépendant à Lille',
+    title: 'Jérôme Marichez, ingénieur-conseil indépendant à Lille',
     description:
       'Ingénierie web, data, IA, SEA & UX : un seul interlocuteur du cadrage au run, ' +
       'qui répond de tout. Conception, développement et pilotage avec l’IA. Lille et ' +

--- a/src/contenu/blog/articles.ts
+++ b/src/contenu/blog/articles.ts
@@ -1,9 +1,9 @@
-// articles.ts — jeromemarichez-fr
+// articles.ts (jeromemarichez-fr)
 // La liste des articles publiés. Source unique du blog.
 //
 // Tout le blog part d'ici : la liste, les pages d'articles générées au build, le
 // sitemap et les données structurées. Un article retiré de ce tableau disparaît
-// partout — il n'y a pas de second endroit à mettre à jour.
+// partout : il n'y a pas de second endroit à mettre à jour.
 //
 // L'ORDRE DE CE TABLEAU N'EST PAS L'ORDRE D'AFFICHAGE : le classement par date est une
 // règle métier, elle vit dans `src/services/find-article`.

--- a/src/contenu/blog/blog-index.ts
+++ b/src/contenu/blog/blog-index.ts
@@ -1,4 +1,4 @@
-// blog-index.ts — jeromemarichez-fr
+// blog-index.ts (jeromemarichez-fr)
 // L'en-tête éditoriale de la liste d'articles. Les articles, eux, viennent d'articles.ts.
 
 import type { IBlogIndex } from '@/interfaces/IBlogIndex'
@@ -13,13 +13,13 @@ export const BLOG_INDEX: IBlogIndex = {
   route: ROUTES.blog,
   titre: 'Blog',
   meta: {
-    title: 'Blog — notes d’ingénierie, de data et de mesure',
+    title: 'Blog : notes d’ingénierie, de data et de mesure',
     description:
       'Notes courtes sur des décisions techniques réelles : ce que j’ai tranché, sur quel ' +
       'critère, et ce que ça a coûté. Ni veille, ni tutoriel.',
   },
   chapo:
     'Des notes courtes sur des décisions réelles : ce que j’ai tranché, sur quel critère, ' +
-    'et ce que ça a coûté. Pas de veille, pas de tutoriel — ce que je ne pratique pas ' +
+    'et ce que ça a coûté. Pas de veille, pas de tutoriel : ce que je ne pratique pas ' +
     'moi-même n’a rien à faire ici.',
 }

--- a/src/contenu/blog/carte-de-l-architecture.ts
+++ b/src/contenu/blog/carte-de-l-architecture.ts
@@ -1,5 +1,5 @@
-// carte-de-l-architecture.ts — jeromemarichez-fr
-// Article — de la doc qui pilote un agent à une carte vivante de l'architecture.
+// carte-de-l-architecture.ts (jeromemarichez-fr)
+// Article : de la doc qui pilote un agent à une carte vivante de l'architecture.
 //
 // FIDÉLITÉ AU TEXTE D'ORIGINE (issue #121). Cet article **porte** un post écrit par
 // Jérôme MARICHEZ, il ne le réécrit pas. Une première version avait refait le titre et le
@@ -8,13 +8,13 @@
 // été fait, et rien d'autre : orthographe et syntaxe corrigées (« la carte est
 // synchroniser », « les hooks qui rappellent/modifie »), phrases tronquées reformées,
 // abréviations écrites en toutes lettres (« app » → « application », « doc » →
-// « documentation »), et mise à la forme d'un article web — un chapô, des sections
-// titrées. Les titres de section n'existent pas dans le post : ils sont dérivés des
+// « documentation »), et mise à la forme d'un article web (un chapô, des sections
+// titrées). Les titres de section n'existent pas dans le post : ils sont dérivés des
 // phrases de Jérôme MARICHEZ, jamais d'un plan neuf.
 //
 // TITRE. Celui du post est « De la doc qui pilote une IA (Claude Code) à une carte vivante
 // de l'architecture. (Obsidian / View Graph) ». Les deux parenthèses techniques sont
-// descendues dans le chapô — elles y nomment les mêmes outils — et l'accroche reste le
+// descendues dans le chapô (elles y nomment les mêmes outils) et l'accroche reste le
 // titre. La balise `<title>`, bornée à 60 caractères, perd en plus l'adjectif « vivante ».
 //
 // SLUG. Il a changé une fois, le 2026-08-23, et c'était la DERNIÈRE OCCASION : l'article
@@ -28,7 +28,7 @@
 // commerce, pas une information couverte.
 //
 // Véracité (CLAUDE.md) : la seule preuve avancée est celle que la carte a réellement
-// produite — une dépendance déclarée jamais importée. Aucun gain de temps, aucun nombre
+// produite : une dépendance déclarée jamais importée. Aucun gain de temps, aucun nombre
 // d'incidents évités, aucun pourcentage : rien de tout cela n'a été mesuré.
 //
 // La `source` porte l'URL exacte fournie par Jérôme MARICHEZ. `datePublication` est la
@@ -41,11 +41,11 @@ export const ARTICLE_CARTE_DE_L_ARCHITECTURE: IArticle = {
   slug: 'de-la-doc-qui-pilote-une-ia-a-une-carte-de-l-architecture',
   titre: 'De la doc qui pilote une IA à une carte vivante de l’architecture',
   chapo:
-    'On code de plus en plus avec une IA en autonomie — Claude Code, ici — sur des bases de ' +
+    'On code de plus en plus avec une IA en autonomie (Claude Code, ici) sur des bases de ' +
     'code entières. Ça pose un problème d’ingénierie précis : donner à l’agent le bon ' +
     'contexte et les bonnes règles, sans dupliquer ni l’un ni l’autre, sans faire exploser ' +
     'la charge cognitive de qui supervise. Voici comment j’ai détourné un outil de prise de ' +
-    'notes — Obsidian et sa vue en graphe — pour le tenir.',
+    'notes (Obsidian et sa vue en graphe) pour le tenir.',
   meta: {
     title: 'De la doc qui pilote une IA à une carte de l’architecture',
     description:
@@ -58,7 +58,7 @@ export const ARTICLE_CARTE_DE_L_ARCHITECTURE: IArticle = {
     url: 'https://www.linkedin.com/feed/update/urn:li:ugcPost:7492203940789391360/',
   },
   // La figure « liaison » : des ensembles séparés, un lieu commun plus grand qu'eux, les
-  // liens qui portent vraiment, et un lien tireté qui n'aboutit à rien — la dépendance
+  // liens qui portent vraiment, et un lien tireté qui n'aboutit à rien : la dépendance
   // déclarée que rien n'importe. Aucune quantité n'y est dessinée, pas même un compte de
   // dépôts : les blocs sont là pour être reliés, pas pour être comptés.
   figure: 'liaison',
@@ -84,8 +84,8 @@ export const ARTICLE_CARTE_DE_L_ARCHITECTURE: IArticle = {
       id: 'la-reponse-une-table-d-aiguillage',
       titre: 'La réponse : une table d’aiguillage, et des hooks',
       paragraphes: [
-        'Un fichier de règles à la racine, écrit comme une table d’aiguillage — « cette ' +
-          'demande, ce dépôt, ce piège » —, plus un fichier par dépôt, et des hooks qui ' +
+        'Un fichier de règles à la racine, écrit comme une table d’aiguillage (« cette ' +
+          'demande, ce dépôt, ce piège »), plus un fichier par dépôt, et des hooks qui ' +
           'rappellent la règle et modifient la documentation.',
         'Chaque règle vient d’un incident réel : ça évite de reperdre du temps sur la même ' +
           'erreur.',
@@ -104,12 +104,12 @@ export const ARTICLE_CARTE_DE_L_ARCHITECTURE: IArticle = {
       id: 'la-carte-faite-des-fichiers-eux-memes',
       titre: 'La carte, faite des fichiers eux-mêmes',
       paragraphes: [
-        'Pour ça, j’ouvre ces mêmes fichiers Markdown dans Obsidian — un outil pensé pour ' +
+        'Pour ça, j’ouvre ces mêmes fichiers Markdown dans Obsidian, un outil pensé pour ' +
           'relier des notes personnelles, pas de la documentation technique.',
         'La carte est synchronisée avec les fichiers de documentation du code, les CLAUDE.md, ' +
           'les skills, les agents et le code lui-même. Pas un schéma dessiné à part, ' +
           'déconnecté dès le lendemain.',
-        'Cliquer un nœud pour corriger une incohérence sur place est possible — mais ' +
+        'Cliquer un nœud pour corriger une incohérence sur place est possible, mais ' +
           'accessoire.',
       ],
     },
@@ -126,7 +126,7 @@ export const ARTICLE_CARTE_DE_L_ARCHITECTURE: IArticle = {
         'Chaque dépôt a sa couleur, façon étiquettes macOS.',
         'Les dossiers de documentation sont en pastel de la couleur de leur dépôt : on voit ' +
           'où la documentation est dense et où elle est maigre.',
-        'Les liens ne sont posés qu’aux endroits d’usage réel, vérifiés avant d’être écrits — ' +
+        'Les liens ne sont posés qu’aux endroits d’usage réel, vérifiés avant d’être écrits, ' +
           'ce qui a révélé une dépendance déclarée jamais importée.',
         'Ça montre ce qu’un agent a sous les yeux sur une tâche : ni noyé sous une ' +
           'documentation entière, ni privé de la règle critique.',
@@ -136,7 +136,7 @@ export const ARTICLE_CARTE_DE_L_ARCHITECTURE: IArticle = {
       id: 'le-principe-n-a-pas-change',
       titre: 'Le principe n’a pas changé, la vitesse si',
       paragraphes: [
-        'Ne pas se répéter — DRY — existe depuis toujours en programmation. Ce qui a changé, ' +
+        'Ne pas se répéter (DRY) existe depuis toujours en programmation. Ce qui a changé, ' +
           'c’est la vitesse à laquelle on peut le violer sans s’en apercevoir.',
         'Et rien qu’en construisant cette visualisation, la carte m’a déjà donné une liste de ' +
           'choses à reprendre. Visiblement, j’ai du boulot devant moi…',

--- a/src/contenu/blog/export-statique.ts
+++ b/src/contenu/blog/export-statique.ts
@@ -1,9 +1,9 @@
-// export-statique.ts — jeromemarichez-fr
-// Article — pourquoi ce site est un export statique.
+// export-statique.ts (jeromemarichez-fr)
+// Article : pourquoi ce site est un export statique.
 //
-// Véracité (CLAUDE.md) : tout ce qui est affirmé ici est vérifiable dans ce dépôt —
-// `output: 'export'` et `trailingSlash` dans next.config.mjs, l'absence de route API,
-// le mailto du pied de page. Aucun chiffre de performance n'est revendiqué pour ce
+// Véracité (CLAUDE.md) : tout ce qui est affirmé ici est vérifiable dans ce dépôt
+// (`output: 'export'` et `trailingSlash` dans next.config.mjs, l'absence de route API,
+// le mailto du pied de page). Aucun chiffre de performance n'est revendiqué pour ce
 // site : la cible est annoncée comme une cible, pas comme un résultat mesuré.
 
 import type { IArticle } from '@/interfaces/IArticle'
@@ -13,7 +13,7 @@ export const ARTICLE_EXPORT_STATIQUE: IArticle = {
   titre: 'Pourquoi ce site est un export statique',
   chapo:
     'Ce site ne tourne sur aucun serveur applicatif : la commande de build écrit des ' +
-    'fichiers, et un serveur de fichiers les sert. C’est un arbitrage, pas un réglage — ' +
+    'fichiers, et un serveur de fichiers les sert. C’est un arbitrage, pas un réglage : ' +
     'il ferme des portes, et je préfère dire lesquelles.',
   meta: {
     title: 'Pourquoi ce site est un export statique',
@@ -22,7 +22,7 @@ export const ARTICLE_EXPORT_STATIQUE: IArticle = {
       'ISR, formulaire), ce qu’il ouvre, et quand il ne faut pas le choisir.',
   },
   datePublication: '2026-08-21',
-  // La figure « borne » : ce qui est produit s'arrête à une ligne, et au-delà — tireté —
+  // La figure « borne » : ce qui est produit s'arrête à une ligne, et au-delà (tireté)
   // le serveur applicatif qui n'existe plus. C'est le sujet de l'article, en une forme.
   figure: 'borne',
   sections: [
@@ -64,7 +64,7 @@ export const ARTICLE_EXPORT_STATIQUE: IArticle = {
           'contournements, et les contournements se paient en incidents.',
         'La question à trancher n’est donc pas « statique ou dynamique » mais : qu’est-ce qui, ' +
           'sur ce site, change à quelle fréquence et pour qui ? La réponse décide de la ' +
-          'stratégie de rendu, page par page — et elle peut très bien être différente d’une ' +
+          'stratégie de rendu, page par page, et elle peut très bien être différente d’une ' +
           'page à l’autre du même produit.',
       ],
     },

--- a/src/contenu/blog/mesurer-avant-arbitrer.ts
+++ b/src/contenu/blog/mesurer-avant-arbitrer.ts
@@ -1,10 +1,10 @@
-// mesurer-avant-arbitrer.ts — jeromemarichez-fr
-// Article — mesurer avant d'arbitrer.
+// mesurer-avant-arbitrer.ts (jeromemarichez-fr)
+// Article : mesurer avant d'arbitrer.
 //
 // Véracité (CLAUDE.md) : régies citées limitées à Google Ads et Bing Ads ; outillage de
 // mesure limité à GTM (web et server-side), Measurement Protocol, GA, Matomo et CMP.
 // Les deux chiffres cités sont repris des preuves du site, avec leur contexte exact :
-// +50 % de panier moyen (Verhoeven Joaillier, A/B testing et heatmaps — pas de GTM sur
+// +50 % de panier moyen (Verhoeven Joaillier, A/B testing et heatmaps, pas de GTM sur
 // cette période) et 100 000 € de budget piloté (Truffle Capital, 2017-2019).
 
 import type { IArticle } from '@/interfaces/IArticle'
@@ -14,7 +14,7 @@ export const ARTICLE_MESURER_AVANT_ARBITRER: IArticle = {
   titre: 'Mesurer avant d’arbitrer',
   chapo:
     'Couper un budget d’acquisition ou supprimer une étape de tunnel, c’est une décision ' +
-    'de dirigeant. Elle ne vaut que ce que vaut le chiffre sur lequel elle s’appuie — et ' +
+    'de dirigeant. Elle ne vaut que ce que vaut le chiffre sur lequel elle s’appuie, et ' +
     'ce chiffre se construit dans le code, bien avant le tableau de bord.',
   meta: {
     title: 'Mesurer avant d’arbitrer',
@@ -24,7 +24,7 @@ export const ARTICLE_MESURER_AVANT_ARBITRER: IArticle = {
   },
   datePublication: '2026-08-14',
   // La figure « appui » : un arbitrage en équilibre, porté par une assise de mesure. Le fléau
-  // est strictement horizontal — une balance qui penche afficherait un verdict, donc un chiffre.
+  // est strictement horizontal : une balance qui penche afficherait un verdict, donc un chiffre.
   figure: 'appui',
   sections: [
     {
@@ -33,7 +33,7 @@ export const ARTICLE_MESURER_AVANT_ARBITRER: IArticle = {
       paragraphes: [
         'Un rapport bien présenté ne dit rien de la qualité de ce qu’il agrège. Avant de ' +
           'regarder une courbe, il faut savoir ce qui est envoyé, depuis où, avec quelle clé ' +
-          'd’identification, et ce qui se perd en route — bloqueurs, navigations abandonnées, ' +
+          'd’identification, et ce qui se perd en route : bloqueurs, navigations abandonnées, ' +
           'événements dupliqués.',
         'C’est la raison pour laquelle je pose la mesure dans le code plutôt qu’à côté : ' +
           'balisage serveur quand la fiabilité l’exige, envoi direct côté serveur pour les ' +
@@ -49,7 +49,7 @@ export const ARTICLE_MESURER_AVANT_ARBITRER: IArticle = {
         'Le consentement change ce que la donnée contient, donc ce qu’on a le droit d’en ' +
           'conclure. Un dispositif conforme se conçoit avec la mesure, pas après : quels ' +
           'événements partent sans consentement, ce qui reste anonyme, ce qui est reconstitué ' +
-          'et ce qui est simplement perdu — et assumé comme tel.',
+          'et ce qui est simplement perdu, et assumé comme tel.',
         'Traiter le sujet à la fin donne toujours le même résultat : une bannière posée sur ' +
           'un dispositif qui n’a pas été pensé pour elle, des rapports qui bougent sans qu’on ' +
           'sache pourquoi, et une conformité qui tient sur une capture d’écran.',
@@ -65,7 +65,7 @@ export const ARTICLE_MESURER_AVANT_ARBITRER: IArticle = {
           'clic n’est pas la question ; ce que rapporte un client dans la durée, si.',
         'Deux repères de mon parcours : un budget publicitaire et de référencement de ' +
           '100 000 €, piloté et justifié devant des dirigeants ; et une refonte de parcours ' +
-          'd’achat menée à la mesure — tests A/B, cartes de chaleur, taux de rebond — qui a ' +
+          'd’achat menée à la mesure (tests A/B, cartes de chaleur, taux de rebond) qui a ' +
           'fait progresser le panier moyen de 50 %. Dans les deux cas, la décision a suivi le ' +
           'chiffre, et c’est la même personne qui l’a ensuite implémentée.',
       ],

--- a/src/contenu/blog/plugin-claude-code.ts
+++ b/src/contenu/blog/plugin-claude-code.ts
@@ -1,16 +1,16 @@
-// plugin-claude-code.ts — jeromemarichez-fr
-// Article — le plugin Claude Code qui initialise mes projets TypeScript, ouvert au public.
+// plugin-claude-code.ts (jeromemarichez-fr)
+// Article : le plugin Claude Code qui initialise mes projets TypeScript, ouvert au public.
 //
 // FIDÉLITÉ AU TEXTE D'ORIGINE (issue #121). Cet article **porte** un post écrit par
 // Jérôme MARICHEZ. Une première version en avait refait le titre et le plan ; le défaut
 // signalé sur l'autre article de la même livraison valait mot pour mot pour celui-ci. Le
 // titre, l'ordre des idées, la liste des cinq points et les formulations sont ceux du
 // post. Ce qui a été fait : orthographe et syntaxe, abréviations écrites en toutes
-// lettres, et mise à la forme d'un article web — un chapô, des sections titrées, dont les
-// titres sont dérivés des phrases de Jérôme MARICHEZ.
+// lettres, et mise à la forme d'un article web (un chapô, des sections titrées, dont les
+// titres sont dérivés des phrases de Jérôme MARICHEZ).
 //
 // TROIS ÉCARTS AU POST, ET LEUR RAISON. Ce sont des corrections de véracité et de registre
-// (CLAUDE.md), pas des libertés de rédaction — elles avaient été établies par la PR #116
+// (CLAUDE.md), pas des libertés de rédaction. Elles avaient été établies par la PR #116
 // et elles survivent au retour vers le texte d'origine :
 //
 // 1. La CI. Le post dit « GitHub Actions ou GitLab CI au choix ». Le README du dépôt dit
@@ -21,7 +21,7 @@
 //    est avant tout personnel. L'article le dit comme le README.
 // 3. « Retours et contributions bienvenus » est un appel à l'action de réseau social : il
 //    ne rentre pas dans le contenu publié, pas plus qu'une invitation à mettre une étoile.
-//    Aucune revendication d'adoption non plus — le dépôt est à zéro étoile au 2026-08-23.
+//    Aucune revendication d'adoption non plus : le dépôt est à zéro étoile au 2026-08-23.
 //    L'URL du dépôt qui fermait le post disparaît pour la même raison de registre, et
 //    parce qu'un paragraphe d'article ne porte pas de lien : le dépôt est nommé, il se
 //    trouve sous son nom.
@@ -57,14 +57,14 @@ export const ARTICLE_PLUGIN_CLAUDE_CODE: IArticle = {
   datePublication: '2026-08-23',
   // La figure « gabarit » : une forme ouverte du côté de la sortie, et ce qui en sort déjà
   // complet, jusqu'à son aboutissement. Elle dit qu'un point de départ se produit, jamais
-  // combien de projets en sont sortis — aucun compte n'est affiché nulle part.
+  // combien de projets en sont sortis : aucun compte n'est affiché nulle part.
   figure: 'gabarit',
   sections: [
     {
       id: 'une-seule-commande',
       titre: 'Une seule commande',
       paragraphes: [
-        'Une seule commande — /bootstrap-project — et vous obtenez un projet ' +
+        'Une seule commande (/bootstrap-project), et vous obtenez un projet ' +
           'TypeScript/React prêt pour la production :',
       ],
       liste: [
@@ -82,8 +82,8 @@ export const ARTICLE_PLUGIN_CLAUDE_CODE: IArticle = {
       titre: 'Next.js ou Vite, monorepo ou séparé',
       paragraphes: [
         'Compatible Next.js et Vite, monorepo ou front et back séparés. Le générateur pose ' +
-          'ses questions au démarrage — type de projet, framework, niveaux de tests, ' +
-          'intégration continue — puis écrit l’ensemble.',
+          'ses questions au démarrage (type de projet, framework, niveaux de tests, ' +
+          'intégration continue) puis écrit l’ensemble.',
       ],
     },
     {
@@ -92,11 +92,11 @@ export const ARTICLE_PLUGIN_CLAUDE_CODE: IArticle = {
       paragraphes: [
         'C’est né de mes propres habitudes de développement, et ça reste avant tout ' +
           'personnel : le plugin encode mes conventions, pas celles de tout le monde. Le dépôt ' +
-          'est public sous licence MIT — utilisable par d’autres, à condition de savoir que la ' +
+          'est public sous licence MIT, utilisable par d’autres, à condition de savoir que la ' +
           'structure, les hooks et les règles reflètent ma façon de faire.',
         'C’est écrit en tête du dépôt, plutôt que laissé à découvrir à la troisième question ' +
           'du générateur. L’état de la CI produite se dit de la même façon : ce qui est testé ' +
-          'l’est, ce qui ne l’est pas se signale — c’est exactement ce que j’attends qu’un ' +
+          'l’est, ce qui ne l’est pas se signale. C’est exactement ce que j’attends qu’un ' +
           'prestataire me dise avant que je m’engage sur son travail.',
       ],
     },

--- a/src/contenu/blog/test-avant-code.ts
+++ b/src/contenu/blog/test-avant-code.ts
@@ -1,10 +1,10 @@
-// test-avant-code.ts — jeromemarichez-fr
-// Article — le test avant le code, même avec un agent.
+// test-avant-code.ts (jeromemarichez-fr)
+// Article : le test avant le code, même avec un agent.
 //
 // Véracité (CLAUDE.md) : le développement en IA augmentée piloté par les tests est un
 // différenciateur assumé du site, et l'outillage cité (Jest, Cypress, Stryker, hooks,
 // agents, serveurs MCP) est celui de ce dépôt. La certification citée est ISTQB
-// Foundation — le niveau Avancé n'est pas obtenu et n'est pas mentionné.
+// Foundation : le niveau Avancé n'est pas obtenu et n'est pas mentionné.
 
 import type { IArticle } from '@/interfaces/IArticle'
 
@@ -23,7 +23,7 @@ export const ARTICLE_TEST_AVANT_CODE: IArticle = {
   },
   datePublication: '2026-08-18',
   // La figure « antériorité » : deux temps sur un axe, et le sens inverse fermé d'une croix.
-  // Elle dit l'ordre, jamais un résultat — aucune mesure de qualité n'y est affichée.
+  // Elle dit l'ordre, jamais un résultat : aucune mesure de qualité n'y est affichée.
   figure: 'anteriorite',
   sections: [
     {
@@ -34,7 +34,7 @@ export const ARTICLE_TEST_AVANT_CODE: IArticle = {
           'elle, n’a pas accéléré. Si rien ne change dans la méthode, on relit de moins en ' +
           'moins bien un code de plus en plus abondant, et on finit par valider sur ' +
           'l’apparence : ça compile, ça ressemble à du code correct, donc on passe.',
-        'Le piège n’est pas que l’IA se trompe — un développeur aussi. Le piège est qu’elle se ' +
+        'Le piège n’est pas que l’IA se trompe. Un développeur aussi. Le piège est qu’elle se ' +
           'trompe vite, de façon plausible, et à grande échelle.',
       ],
     },
@@ -57,8 +57,8 @@ export const ARTICLE_TEST_AVANT_CODE: IArticle = {
       titre: 'Et ce qui vérifie les tests',
       paragraphes: [
         'Reste une question que la couverture ne répond pas : est-ce que ces tests détectent ' +
-          'quelque chose ? Les tests de mutation modifient volontairement le code — inverser une ' +
-          'condition, supprimer un appel — et regardent si la suite passe encore. Quand elle ' +
+          'quelque chose ? Les tests de mutation modifient volontairement le code (inverser une ' +
+          'condition, supprimer un appel) et regardent si la suite passe encore. Quand elle ' +
           'passe, le test traversait la ligne sans rien vérifier.',
         'C’est l’outil qui manque le plus souvent sur une base largement générée : elle est ' +
           'couverte au sens du pourcentage, et démunie au sens de la détection. Jest et Cypress ' +
@@ -69,7 +69,7 @@ export const ARTICLE_TEST_AVANT_CODE: IArticle = {
       id: 'ce-que-vous-tranchez',
       titre: 'Ce que ça change côté client',
       paragraphes: [
-        'La bonne question à poser à un prestataire n’est plus « utilisez-vous l’IA ? » — la ' +
+        'La bonne question à poser à un prestataire n’est plus « utilisez-vous l’IA ? » : la ' +
           'réponse est oui presque partout, et elle n’engage à rien. Elle est : qu’est-ce qui ' +
           'rattrape une erreur produite par cette IA avant qu’elle arrive en production, et qui ' +
           'en répond ?',

--- a/src/contenu/certifications.ts
+++ b/src/contenu/certifications.ts
@@ -1,19 +1,19 @@
-// certifications.ts — jeromemarichez-fr
+// certifications.ts (jeromemarichez-fr)
 // Les certifications affichées : un logo, un intitulé, un millésime. Rien d'autre.
 //
 // Règles de véracité (CLAUDE.md), toutes bloquantes :
-//   — ISTQB : seul le niveau **Foundation** est détenu. Le niveau Avancé
+//   - ISTQB : seul le niveau **Foundation** est détenu. Le niveau Avancé
 //     (Automatisation de Test) n'est PAS obtenu et ne doit jamais réapparaître ici.
-//   — Aucune URL de justificatif n'a été fournie à ce jour : `justificatif` reste
+//   - Aucune URL de justificatif n'a été fournie à ce jour : `justificatif` reste
 //     absent partout. Une URL de certification ne s'invente ni ne s'approxime.
-//   — Millésimes arbitrés par Jérôme MARICHEZ le 2026-08-20 : Google Ads en 2021
+//   - Millésimes arbitrés par Jérôme MARICHEZ le 2026-08-20 : Google Ads en 2021
 //     (le CV Tracking Specialist indiquait 2022), et Microsoft Ads confirmée mais
-//     sans année connue — elle s'affiche donc sans millésime.
+//     sans année connue : elle s'affiche donc sans millésime.
 //
 // `logo` suit exactement la même discipline que `justificatif` : il n'est renseigné
 // que pour un fichier réellement déposé dans `public/certifications/`, dont la
 // provenance et la licence sont consignées dans le LISEZMOI de ce dossier. Les quatre
-// certifications qui n'ont pas encore de fichier s'affichent en toutes lettres — c'est
+// certifications qui n'ont pas encore de fichier s'affichent en toutes lettres : c'est
 // le comportement voulu, jamais une image cassée.
 //
 // `largeur` et `hauteur` sont les dimensions intrinsèques du SVG (viewBox 24 × 24) :
@@ -40,7 +40,7 @@ export const CERTIFICATIONS: ICertification[] = [
     },
   },
   {
-    intitule: 'WeLoveDev — Top 5 % React',
+    intitule: 'WeLoveDev, Top 5 % React',
     organisme: 'WeLoveDev',
     annee: 2023,
     pole: 'ingenierie-web',
@@ -73,7 +73,7 @@ export const CERTIFICATIONS: ICertification[] = [
     pole: 'sea-ux',
   },
   {
-    intitule: 'EF SET — Anglais B2 (CECRL)',
+    intitule: 'EF SET, Anglais B2 (CECRL)',
     organisme: 'EF Standard English Test',
     pole: 'transverse',
   },

--- a/src/contenu/contact.ts
+++ b/src/contenu/contact.ts
@@ -1,4 +1,4 @@
-// contact.ts — jeromemarichez-fr
+// contact.ts (jeromemarichez-fr)
 // Les textes du formulaire de contact : libellés, aides, bouton, statuts.
 //
 // Ils vivent ici et non dans le composant pour la même raison que le reste du contenu :

--- a/src/contenu/data-sections.ts
+++ b/src/contenu/data-sections.ts
@@ -1,4 +1,4 @@
-// data-sections.ts — jeromemarichez-fr
+// data-sections.ts (jeromemarichez-fr)
 // Les chapitres de la page Data : métier, gouvernance et droit, stratégie data, puis la
 // problématique et son exploration.
 //
@@ -73,7 +73,7 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'Cette phase se livre pour elle-même',
         texte: 'Un document : règles formalisées, profils identifiés. Vous pouvez vous arrêter là.',
-        decision: 'S’il y a un problème qui mérite d’être traité par la technique — et lequel.',
+        decision: 'S’il y a un problème qui mérite d’être traité par la technique, et lequel.',
       },
     ],
   },
@@ -94,8 +94,8 @@ export const SECTIONS_DATA: IEditorialSection[] = [
       {
         titre: 'Ce qui a le droit d’être collecté et traité',
         preuve:
-          'Conformité RGPD et DORA tenue en appels d’offres grands comptes — distribution, ' +
-          'assurance, banque. Cadrage RGPD des données clients chez un e-commerçant de ' +
+          'Conformité RGPD et DORA tenue en appels d’offres grands comptes (distribution, ' +
+          'assurance, banque). Cadrage RGPD des données clients chez un e-commerçant de ' +
           'joaillerie.',
         decision:
           'Ce que vous collectez, ce que vous n’avez pas le droit de collecter, et pourquoi.',
@@ -104,7 +104,7 @@ export const SECTIONS_DATA: IEditorialSection[] = [
         titre: 'La contrainte oriente la solution',
         texte:
           'Donnée qui ne peut pas sortir de chez vous : le service tiers est écarté, reste un ' +
-          'modèle open-weight hébergé — Llama 3 — ou une règle explicite.',
+          'modèle open-weight hébergé (Llama 3) ou une règle explicite.',
       },
     ],
   },
@@ -208,7 +208,7 @@ export const SECTIONS_DATA: IEditorialSection[] = [
     titre: 'Un métier compris ouvre deux suites, et rien ne les ordonne',
     chapo:
       'Règles écrites, profils identifiés, donnée gouvernée : on tient la matière de l’IA ' +
-      'comme celle de l’arbitrage. L’une, l’autre, ou les deux — et vous pouvez aussi vous ' +
+      'comme celle de l’arbitrage. L’une, l’autre, ou les deux. Et vous pouvez aussi vous ' +
       'arrêter ici.',
     blocs: [
       {
@@ -222,7 +222,7 @@ export const SECTIONS_DATA: IEditorialSection[] = [
         titre: 'Ce que le SEA & UX en reçoit',
         texte:
           'la valeur client dans la durée à la place du coût par clic, et des identités ' +
-          'réconciliées — agrégation multi-sources et dédoublonnage — avant toute lecture de ' +
+          'réconciliées (agrégation multi-sources et dédoublonnage) avant toute lecture de ' +
           'performance.',
       },
       {

--- a/src/contenu/data.ts
+++ b/src/contenu/data.ts
@@ -1,5 +1,5 @@
-// data.ts — jeromemarichez-fr
-// Le pôle Data — le passage obligé. Métadonnées et chapitres.
+// data.ts (jeromemarichez-fr)
+// Le pôle Data, le passage obligé. Métadonnées et chapitres.
 //
 // Le pôle part du métier et finit sur le test de déterminisme : le titre et la description
 // le disent dès la SERP, sinon la page est ouverte avec la mauvaise attente.
@@ -10,7 +10,7 @@
 //
 // Cette page ne porte plus que `data-sections.ts`. Les chapitres de modèles ont rejoint
 // `ia.ts`, qui est désormais un pôle à part entière : la donnée se livre pour elle-même,
-// et l'IA est l'une de ses deux suites — pas sa conclusion.
+// et l'IA est l'une de ses deux suites, pas sa conclusion.
 
 import type { IEditorialPage } from '@/interfaces/IEditorialPage'
 import { SECTIONS_DATA } from './data-sections'
@@ -18,7 +18,7 @@ import { SECTIONS_DATA } from './data-sections'
 export const PAGE_DATA: IEditorialPage = {
   route: '/services/data',
   meta: {
-    title: 'Data : le métier d’abord — Lille',
+    title: 'Data : le métier d’abord | Lille',
     description:
       'Métier, gouvernance et RGPD, stratégie data, exploration : le test qui dit si votre ' +
       'problème demande un modèle. Rien n’oblige à prendre l’IA.',

--- a/src/contenu/espaces.ts
+++ b/src/contenu/espaces.ts
@@ -1,8 +1,8 @@
-// espaces.ts — jeromemarichez-fr
+// espaces.ts (jeromemarichez-fr)
 // Les deux espaces éditoriaux, vus depuis l'accueil.
 //
 // L'accueil vendait ses quatre pôles et taisait ses deux espaces : on n'y arrivait que
-// par le menu ou par un renvoi de tuile de preuve. C'est le point 3 de l'issue #84 —
+// par le menu ou par un renvoi de tuile de preuve. C'est le point 3 de l'issue #84 :
 // l'accueil doit pointer vers ses catégories par des entrées franches.
 //
 // **Les volumes sont DÉRIVÉS des listes sources**, jamais recopiés. C'est la même règle
@@ -11,7 +11,7 @@
 // devant treize est un défaut de véracité, pas une coquille.
 //
 // Ce que ces accroches n'ont PAS le droit de faire : élargir. Elles reprennent ce que
-// chaque espace dit déjà de lui-même dans son propre chapô — les réalisations portent
+// chaque espace dit déjà de lui-même dans son propre chapô : les réalisations portent
 // chacune leur cadre, deux postes salariés et une mission en indépendant, et trois fiches
 // seulement portent un chiffre. Une accroche d'accueil qui laisserait croire à treize
 // références chiffrées vendrait ce qui n'existe pas.
@@ -38,7 +38,7 @@ export const ESPACES_EDITORIAUX: IEspaceEditorial[] = [
     titre: 'Blog',
     route: ROUTES.blog,
     accroche:
-      'Les arbitrages de ce site, écrits pendant qu’ils étaient pris — mesure, tests, rendu.',
+      'Les arbitrages de ce site, écrits pendant qu’ils étaient pris : mesure, tests, rendu.',
     volume: `${ARTICLES.length} notes`,
   },
 ]

--- a/src/contenu/fil-ia.ts
+++ b/src/contenu/fil-ia.ts
@@ -1,16 +1,16 @@
-// fil-ia.ts — jeromemarichez-fr
-// Le fil IA : l'axe transverse — la méthode de production, pas l'offre.
+// fil-ia.ts (jeromemarichez-fr)
+// Le fil IA : l'axe transverse. La méthode de production, pas l'offre.
 //
 // Ce n'est pas un quatrième pôle et ce n'est pas une charnière. Les charnières passent
 // la main d'un pôle au suivant ; ce fil-ci les traverse tous. Il répond à une confusion
-// que le site crée lui-même : l'IA y apparaît deux fois — comme offre (le pôle IA) et
+// que le site crée lui-même : l'IA y apparaît deux fois, comme offre (le pôle IA) et
 // comme méthode de production (partout). Sans cette section, le lecteur les mélange.
 //
 // ## Où il vit, et pourquoi il a bougé (issue #103)
 //
 // Il ouvrait la page d'accueil. L'accueil est devenu une vitrine : le détail est descendu
 // sur les pages de pôle, et une section de méthode de production y est du détail. Elle a
-// donc suivi le mouvement — sur `/services/ingenierie-web/`, la page où le site dit
+// donc suivi le mouvement, sur `/services/ingenierie-web/`, la page où le site dit
 // comment le code est produit, et où le chapitre « qualité » revendiquait déjà le
 // développement piloté par les tests en IA augmentée.
 //
@@ -24,8 +24,8 @@
 //
 // Véracité (CLAUDE.md) : rien ici n'est nouveau. Chaque preuve citée est déjà portée
 // par un pôle et sourcée dans les CV de référence. La seule affirmation propre à cette
-// section est la méthode de travail elle-même — outillage Claude Code / Gemini piloté
-// par les tests — que le CLAUDE.md revendique déjà comme différenciateur assumé.
+// section est la méthode de travail elle-même (outillage Claude Code / Gemini piloté
+// par les tests) que le CLAUDE.md revendique déjà comme différenciateur assumé.
 
 import type { IEditorialSection } from '@/interfaces/IEditorialSection'
 
@@ -39,27 +39,27 @@ export const SECTION_FIL_IA: IEditorialSection = {
     'seconde : elle propose, les tests tranchent.',
   blocs: [
     {
-      titre: 'Concevoir — instruire les options, pas les recevoir',
+      titre: 'Concevoir : instruire les options, pas les recevoir',
       decision: 'Le scénario d’architecture retenu, ceux qui ont été écartés, et sur quel critère.',
     },
     {
-      titre: 'Construire — Claude Code et Gemini, pilotés par les tests',
+      titre: 'Construire : Claude Code et Gemini, pilotés par les tests',
       preuve:
         'Jest, Cypress, Playwright, mutation Stryker. Certification ISTQB Foundation. Ce ' +
         'site est construit ainsi, de bout en bout.',
       decision: 'Ce que vous acceptez de faire produire par une IA, et le filet exigé en dessous.',
     },
     {
-      titre: 'Livrer — l’IA dans le produit qui tourne',
+      titre: 'Livrer : l’IA dans le produit qui tourne',
       texte:
-        'De l’IA qui tourne chez vous, coût d’inférence, latence et RGPD tenus — pas ma ' +
+        'De l’IA qui tourne chez vous, coût d’inférence, latence et RGPD tenus. Pas ma ' +
         'manière d’écrire du code.',
       preuve:
         'Modèle supervisé en production, fine-tuning de Llama 3 sur corpus métier, RAG ' +
         'documentaire fait maison.',
     },
     {
-      titre: 'Piloter — le SEA et l’UX décidés sur ce que la donnée dit',
+      titre: 'Piloter : le SEA et l’UX décidés sur ce que la donnée dit',
       preuve:
         'Panier moyen en hausse de 50 % sur un e-commerce de joaillerie, 100 000 € de budget ' +
         'ADS / SEO pilotés.',

--- a/src/contenu/ia-sections.ts
+++ b/src/contenu/ia-sections.ts
@@ -1,4 +1,4 @@
-// ia-sections.ts — jeromemarichez-fr
+// ia-sections.ts (jeromemarichez-fr)
 // Les chapitres de la page IA : la réponse technique, le coût et la propriété, le langage,
 // la mise en production, puis le retour au produit.
 //
@@ -8,16 +8,16 @@
 //
 // `charniere-arbitrage` a quitté ce fichier pour `data-sections.ts`. Elle y disait « et
 // ensuite, le pôle 3 » : posée sur la page IA, elle affirmait que le SEA & UX vient après
-// l'IA. C'est faux — ce sont les deux suites parallèles de la donnée, et la charnière
+// l'IA. C'est faux : ce sont les deux suites parallèles de la donnée, et la charnière
 // part de la donnée.
 //
 // **Cette page était la plus maigre des quatre (issue #103)** : deux chapitres contre
 // quatre à cinq ailleurs. Une suite visiblement plus pauvre que sa sœur contredit en page
-// ce que le modèle affirme — deux suites de rang égal. Deux sections ont donc été
+// ce que le modèle affirme : deux suites de rang égal. Deux sections ont donc été
 // écrites, à partir de matière déjà sourcée dans le README et les CV, jamais inventée :
 // le chapitre « langage », où le LLM cesse d'être une ligne pour devenir un arbitrage, et
 // la charnière de retour au produit, symétrique de celle du pôle SEA & UX. L'IA ne passe
-// la main à aucun autre pôle — elle est un bout de chaîne, comme le SEA & UX — mais ce
+// la main à aucun autre pôle (elle est un bout de chaîne, comme le SEA & UX), mais ce
 // qu'elle produit retourne dans le produit, et ça, c'est vrai des deux.
 //
 // **Le test de déterminisme et le prix de la donnée (issue #126).** Cette page disait
@@ -52,7 +52,7 @@ export const SECTIONS_IA: IEditorialSection[] = [
     kind: 'chapitre',
     pole: 'ia',
     kicker: 'La réponse technique',
-    titre: 'La solution répond au problème — et ce n’est pas toujours de l’IA',
+    titre: 'La solution répond au problème, et ce n’est pas toujours de l’IA',
     chapo:
       'La technique n’arrive qu’ici, une fois établi sur vos données qu’aucune règle simple ne ' +
       'répond. Les deux issues de ce test ont leur livrable, une seule demande un modèle.',
@@ -72,7 +72,7 @@ export const SECTIONS_IA: IEditorialSection[] = [
       {
         titre: 'Réponse non déterministe : le modèle apprend ce qu’aucune règle ne tient',
         texte:
-          'Supervisé — classification, réseaux de neurones — ou non supervisé, selon ce que la ' +
+          'Supervisé (classification, réseaux de neurones) ou non supervisé, selon ce que la ' +
           'donnée permet. La méthode d’extraction des caractéristiques du signal audio est ' +
           'publiée sur arXiv ; je l’ai implémentée moi-même, adaptée aux données réelles, puis ' +
           'industrialisée. TensorFlow, inférence en cloud functions.',
@@ -184,7 +184,7 @@ export const SECTIONS_IA: IEditorialSection[] = [
       {
         titre: 'Rendre votre produit appelable',
         texte:
-          'Serveurs MCP et plugins n8n, Make et Zapier — conçus, développés et documentés : ' +
+          'Serveurs MCP et plugins n8n, Make et Zapier (conçus, développés et documentés) : ' +
           'votre produit devient appelable par un agent ou un scénario no-code.',
         decision: 'Ce que vous ouvrez à l’automatisation, et ce qui reste fermé.',
       },

--- a/src/contenu/ia.ts
+++ b/src/contenu/ia.ts
@@ -1,5 +1,5 @@
-// ia.ts — jeromemarichez-fr
-// Le pôle IA — l'une des deux suites de la donnée. Métadonnées et chapitres.
+// ia.ts (jeromemarichez-fr)
+// Le pôle IA, l'une des deux suites de la donnée. Métadonnées et chapitres.
 //
 // Le titre et la description disent la thèse du pôle dès la SERP : la solution répond au
 // problème posé au départ, et ce n'est pas toujours un modèle. Un visiteur qui ouvre
@@ -18,7 +18,7 @@ import { SECTIONS_IA } from './ia-sections'
 export const PAGE_IA: IEditorialPage = {
   route: '/services/ia',
   meta: {
-    title: 'IA : règle métier, modèle ou LLM — Lille',
+    title: 'IA : règle métier, modèle ou LLM | Lille',
     description:
       'Un modèle seulement si aucune règle ne répond : supervisé, non supervisé, LLM ou ' +
       'agents. Et une solution qui vous reste si vous coupez.',

--- a/src/contenu/ingenierie-web-sections.ts
+++ b/src/contenu/ingenierie-web-sections.ts
@@ -1,5 +1,5 @@
-// ingenierie-web-sections.ts — jeromemarichez-fr
-// Le pôle Ingénierie web — le socle. Site internet, produit SaaS, application mobile.
+// ingenierie-web-sections.ts (jeromemarichez-fr)
+// Le pôle Ingénierie web, le socle. Site internet, produit SaaS, application mobile.
 //
 // Faits sourcés dans cv-ingenieur-fullstack.md et cv-ai-engineer.md. Règles de
 // véracité du CLAUDE.md appliquées : ISTQB **Foundation** seulement, aucun management
@@ -8,14 +8,14 @@
 // **Ce que cette page a accueilli en descendant de l'accueil (issue #103)** : le chapitre
 // « migrations », qui n'existait nulle part en propre ; l'outillage de test nommé, qui
 // n'était écrit que sur l'accueil ; l'arbitrage monolithe / microservices ; les nuances de
-// la charnière — SLI / SLO / SLA opposables, PCA et PRA testés et pas seulement
-// documentés, et l'exemple qui prouve que le run fabrique la donnée. Le **fil IA** y est
+// la charnière (SLI / SLO / SLA opposables, PCA et PRA testés et pas seulement
+// documentés, et l'exemple qui prouve que le run fabrique la donnée). Le **fil IA** y est
 // aussi descendu : la note de placement est en tête de `fil-ia.ts`.
 //
 // Une exception, et elle est délibérée : la mention « chiffre d'affaires maintenu » qui
 // accompagnait les migrations sur l'accueil n'est PAS descendue. Le périmètre de
 // confidentialité écrit en tête de `realisations/mailingvox-produits.ts` pose que les
-// chiffres de ce projet ne sont publiés nulle part sur le site — l'accueil le
+// chiffres de ce projet ne sont publiés nulle part sur le site. L'accueil le
 // contredisait. La contrainte tenue, elle, est sourcée : aucune interruption de service,
 // aucun gel de la roadmap. Elle suffit.
 
@@ -108,7 +108,7 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
         texte:
           'Node.js et Express, API REST, webhooks, cloud functions, Pub/Sub. PostgreSQL, ' +
           'MySQL, Firebase ; toute entrée externe est validée par un schéma Zod.',
-        decision: 'Ce qui reste synchrone, et ce qui part en file — avec le coût de chaque choix.',
+        decision: 'Ce qui reste synchrone, et ce qui part en file, avec le coût de chaque choix.',
       },
       {
         titre: 'Architecture et exploitation',
@@ -116,11 +116,11 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
           'Docker, CI/CD GitHub Actions, Cloud Run, VM Compute Engine auto-scalées, Pub/Sub, ' +
           'Vercel, Apache, Nginx et Linux. Pas de cluster Kubernetes administré en propre.',
         preuve:
-          'SLI / SLO / SLA définis, suivis et opposables — pas écrits après l’incident. PCA et ' +
+          'SLI / SLO / SLA définis, suivis et opposables. Pas écrits après l’incident. PCA et ' +
           'PRA testés par exercices de bascule, pas seulement documentés. Déploiements sans ' +
           'interruption de service.',
         decision:
-          'Ce qu’on découpe maintenant, ce qu’on garde monolithique et jusqu’à quand — et où ' +
+          'Ce qu’on découpe maintenant, ce qu’on garde monolithique et jusqu’à quand, et où ' +
           'tourne votre produit, avec le coût réel de chaque option.',
       },
     ],
@@ -140,7 +140,7 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
         texte:
           'Critères d’entrée et d’arrêt écrits avant la livraison. C’est le seul niveau que je ' +
           'détiens, et c’est donc le seul que j’affiche.',
-        decision: 'À partir de quand une version est livrable — et qui le dit.',
+        decision: 'À partir de quand une version est livrable, et qui le dit.',
       },
       {
         titre: 'Développement piloté par les tests, en IA augmentée',
@@ -193,7 +193,7 @@ export const SECTIONS_INGENIERIE_WEB: IEditorialSection[] = [
   },
   // Le fil IA descend de l'accueil (issue #103) et se pose ici, sur le socle : c'est la
   // page où le site dit comment le code est produit. Il garde ses quatre étapes, donc son
-  // caractère transverse — livrer et piloter nomment les deux autres suites.
+  // caractère transverse : livrer et piloter nomment les deux autres suites.
   SECTION_FIL_IA,
   {
     id: 'charniere-run',

--- a/src/contenu/ingenierie-web.ts
+++ b/src/contenu/ingenierie-web.ts
@@ -1,5 +1,5 @@
-// ingenierie-web.ts — jeromemarichez-fr
-// Le pôle Ingénierie web — le socle. Métadonnées ; les sections vivent dans le voisin
+// ingenierie-web.ts (jeromemarichez-fr)
+// Le pôle Ingénierie web, le socle. Métadonnées ; les sections vivent dans le voisin
 // (limite de 300 lignes par fichier, docs/tooling.md).
 
 import type { IEditorialPage } from '@/interfaces/IEditorialPage'
@@ -8,7 +8,7 @@ import { SECTIONS_INGENIERIE_WEB } from './ingenierie-web-sections'
 export const PAGE_INGENIERIE_WEB: IEditorialPage = {
   route: '/services/ingenierie-web',
   meta: {
-    title: 'Ingénierie web — site, SaaS et mobile | Lille',
+    title: 'Ingénierie web : site, SaaS et mobile | Lille',
     description:
       'Site, SaaS et mobile conçus, développés et exploités par une seule personne. ' +
       'Qualité certifiée ISTQB Foundation, TDD, migrations sans coupure.',

--- a/src/contenu/jointures.ts
+++ b/src/contenu/jointures.ts
@@ -1,4 +1,4 @@
-// jointures.ts — jeromemarichez-fr
+// jointures.ts (jeromemarichez-fr)
 // Les arêtes de la chaîne : ce que chaque pôle remet au suivant, et à quelle condition.
 //
 // Trois arêtes pour quatre pôles, parce que la donnée en porte deux :

--- a/src/contenu/limites.ts
+++ b/src/contenu/limites.ts
@@ -1,5 +1,5 @@
-// limites.ts — jeromemarichez-fr
-// Ce que je ne fais pas — et ce que je fais à la place.
+// limites.ts (jeromemarichez-fr)
+// Ce que je ne fais pas, et ce que je fais à la place.
 //
 // Ce fichier est la traduction publique de la table des règles de véracité du
 // `CLAUDE.md`. Chaque ligne y correspond à une formulation interdite : au lieu de
@@ -13,7 +13,7 @@ export const LIMITES: IBoundary[] = [
     hors: 'Aucune couche commerciale, aucun transfert de dossier',
     alaPlace:
       'Vous parlez à la personne qui écrit le code, du cadrage au run, sur les quatre pôles. ' +
-      'Si la taille du projet demande un renfort — c’est rare — je le choisis, je le cadre et ' +
+      'Si la taille du projet demande un renfort (c’est rare), je le choisis, je le cadre et ' +
       'j’en réponds : votre interlocuteur, lui, ne change pas.',
   },
   {

--- a/src/contenu/objections.ts
+++ b/src/contenu/objections.ts
@@ -1,4 +1,4 @@
-// objections.ts — jeromemarichez-fr
+// objections.ts (jeromemarichez-fr)
 // Les deux objections que soulève la promesse du site, traitées ensemble.
 //
 // Ce fichier remplace `renforts.ts` et la section `un-seul-interlocuteur` de
@@ -41,21 +41,21 @@ export const SECTION_OBJECTIONS: IEditorialSection = {
         'Certification ISTQB Foundation. AMOA de la startup biotech Artedrone, exploitable par ' +
         'des prestataires non spécialistes du domaine.',
       decision:
-        'Ce que vous exigez de moi contractuellement — documentation, accès, revue de ' +
-        'reprise — et quand vous voulez pouvoir le vérifier.',
+        'Ce que vous exigez de moi contractuellement (documentation, accès, revue de ' +
+        'reprise) et quand vous voulez pouvoir le vérifier.',
     },
     {
-      titre: 'Si le projet me dépasse, je m’entoure — et j’en réponds',
+      titre: 'Si le projet me dépasse, je m’entoure, et j’en réponds',
       texte:
         'Cela arrive rarement : la très grande majorité des projets tient sur une personne, du ' +
         'cadrage au run. Quand la taille le demande, je m’entoure de prestataires que je ' +
-        'choisis, que je cadre et dont je réponds — mes spécifications, mon dépôt, les mêmes ' +
+        'choisis, que je cadre et dont je réponds : mes spécifications, mon dépôt, les mêmes ' +
         'tests. Vous ne gérez personne d’autre que moi.',
       preuve:
         'Environ 25 000 € d’encadrement de prestataires SEA, SEO et SMA chez Verhoeven ' +
         'Joaillier : périmètre, budget et qualité sont restés de mon côté.',
       decision:
-        'À quel moment vous préférez un renfort plutôt qu’un délai, et qui intervient alors — ' +
+        'À quel moment vous préférez un renfort plutôt qu’un délai, et qui intervient alors : ' +
         'périmètre et coût écrits, avant.',
     },
   ],

--- a/src/contenu/poles-nav.ts
+++ b/src/contenu/poles-nav.ts
@@ -1,8 +1,8 @@
-// poles-nav.ts — jeromemarichez-fr
+// poles-nav.ts (jeromemarichez-fr)
 // Les quatre pôles vus depuis la navigation : le strict nécessaire pour se repérer.
 //
 // Le contenu long de chaque pôle vit dans son propre fichier (`ingenierie-web.ts`,
-// `data.ts`, `ia.ts`, `sea-ux.ts`). Cette liste-ci ne porte que l'identité et la place —
+// `data.ts`, `ia.ts`, `sea-ux.ts`). Cette liste-ci ne porte que l'identité et la place :
 // elle est chargée par l'en-tête et le pied de page, donc sur toutes les pages du site.
 //
 // L'ordre du tableau est celui de la lecture, pas celui d'un achat. `ia` et `sea-ux` s'y
@@ -56,6 +56,6 @@ export const POLES_NAV: IPole[] = [
     promesse: 'Je ne dessine pas vos maquettes, je tranche vos parcours.',
     accroche:
       'Mesure construite dans le code, consentement conforme, rentabilité à long terme plutôt ' +
-      'que coût par clic — puis les arbitrages implémentés.',
+      'que coût par clic, puis les arbitrages implémentés.',
   },
 ]

--- a/src/contenu/poles-places.ts
+++ b/src/contenu/poles-places.ts
@@ -1,10 +1,10 @@
-// poles-places.ts — jeromemarichez-fr
+// poles-places.ts (jeromemarichez-fr)
 // Comment chaque place de la chaîne se dit à l'écran.
 //
 // Ces libellés ont remplacé une numérotation (« Pôle 2 », « Pôle 2 sur 3 »). Ce n'est pas
 // un habillage : un numéro sur quatre pôles dont deux sont parallèles affirme un ordre
 // qui n'existe pas, et laisse croire qu'il faut les quatre. La place, elle, se lit sans
-// compter — et elle dit en même temps ce qu'on peut acheter seul.
+// compter, et elle dit en même temps ce qu'on peut acheter seul.
 
 import type { PolePlace } from '@/interfaces/types'
 
@@ -17,7 +17,7 @@ export const LIBELLE_PLACE: Record<PolePlace, string> = {
 
 /** Phrase d'ouverture d'une page de pôle : la place, et ce qu'elle implique. */
 export const SITUATION_PLACE: Record<PolePlace, string> = {
-  socle: 'Le socle — on commence ici quand le produit est à construire',
-  passage: 'Le passage obligé — tout ce qui suit y passe, et il se livre seul',
-  suite: 'Une des deux suites de la donnée — sans ordre avec l’autre',
+  socle: 'Le socle : on commence ici quand le produit est à construire',
+  passage: 'Le passage obligé : tout ce qui suit y passe, et il se livre seul',
+  suite: 'Une des deux suites de la donnée, sans ordre avec l’autre',
 }

--- a/src/contenu/poles-preuves.ts
+++ b/src/contenu/poles-preuves.ts
@@ -1,13 +1,13 @@
-// poles-preuves.ts — jeromemarichez-fr
+// poles-preuves.ts (jeromemarichez-fr)
 // La preuve que chaque porte de l'accueil met sous le nom de son pôle.
 //
 // Pourquoi ici et pas dans `poles-nav.ts` : cette liste-là est chargée par l'en-tête et
 // le pied de page, donc sur toutes les pages du site, et elle ne porte que l'identité et
-// la place. La preuve n'a qu'un seul lecteur — la porte de l'accueil — et elle reste donc
+// la place. La preuve n'a qu'un seul lecteur (la porte de l'accueil) et elle reste donc
 // chez lui.
 //
 // Le `Record<PoleId, string>` est exhaustif par construction : un cinquième pôle ne
-// compilerait pas tant que sa preuve n'est pas écrite. C'est ce que demande l'issue #103 —
+// compilerait pas tant que sa preuve n'est pas écrite. C'est ce que demande l'issue #103 :
 // chaque porte porte une preuve, aucune n'en est dispensée, et le compilateur le tient.
 //
 // **Les deux nombres publiables ne sont pas recopiés ici** : ils sont lus sur la fiche de

--- a/src/contenu/preuves.ts
+++ b/src/contenu/preuves.ts
@@ -1,4 +1,4 @@
-// preuves.ts — jeromemarichez-fr
+// preuves.ts (jeromemarichez-fr)
 // Le mur de preuves. Aucun chiffre ici n'est estimé, arrondi ni reconstitué.
 //
 // Source unique : les CV de référence de /Users/nicolasb/Documents/CV. Un chiffre qui
@@ -6,7 +6,7 @@
 //
 // **Les trois premières tuiles ne portent plus leur chiffre en propre** : elles le lisent
 // sur la fiche de réalisation qui le déplie. C'est la seule façon de garantir que
-// l'accueil et `/realisations/` ne peuvent pas afficher deux valeurs différentes — le
+// l'accueil et `/realisations/` ne peuvent pas afficher deux valeurs différentes : le
 // nombre n'est écrit qu'une fois dans le dépôt. Le `contexte`, lui, reste écrit ici :
 // c'est la version courte, calibrée pour une tuile, pas le résumé de la fiche.
 
@@ -45,7 +45,7 @@ export const PREUVES: IProof[] = [
     libelle: 'migrations sans interruption de service',
     contexte:
       'PHP 5 vers 7 puis réécriture Node.js, jQuery vers React, Ionic 6 vers 8 et Angular ' +
-      '15 vers 19 — aucune coupure, aucun gel de la roadmap.',
+      '15 vers 19. Aucune coupure, aucun gel de la roadmap.',
   },
   {
     chiffre: '9 ans',
@@ -62,7 +62,7 @@ export const PREUVES: IProof[] = [
     libelle: 'interlocuteur, du cadrage au run',
     contexte:
       'Celui qui cadre est celui qui code, qui mesure et qui exploite. Aucune couche ' +
-      'commerciale, aucun transfert de dossier — et si un renfort devient nécessaire, ' +
+      'commerciale, aucun transfert de dossier. Si un renfort devient nécessaire, ' +
       'c’est moi qui le choisis et qui en réponds.',
   },
 ]

--- a/src/contenu/realisations/cadres.ts
+++ b/src/contenu/realisations/cadres.ts
@@ -1,9 +1,9 @@
-// cadres.ts — jeromemarichez-fr
+// cadres.ts (jeromemarichez-fr)
 // Les trois cadres sous lesquels toutes les réalisations du site ont été menées.
 //
 // **Deux postes salariés et une mission en indépendant.** Acetelecom / MailingVox et
-// Verhoeven Joaillier sont des employeurs ; Truffle Capital est un client — le seul cité
-// sur le site, Artedrone étant une participation du fonds et non un second client — pour
+// Verhoeven Joaillier sont des employeurs ; Truffle Capital est un client (le seul cité
+// sur le site, Artedrone étant une participation du fonds et non un second client) pour
 // qui le travail a été mené en auto-entrepreneur entre 2017 et 2019. Chaque cadre porte
 // donc son `statut`, au même rang que le poste, la période et l'équipe : c'est ce qui
 // manquait, et c'est ce qui a laissé publier « trois postes salariés » (issue #107).
@@ -25,7 +25,7 @@ export const CADRE_MAILINGVOX: IRealisationCadre = {
   poste: 'Lead Tech · Ingénieur full stack, mobile & IA',
   periode: '2023-2026',
   equipe:
-    'Équipe technique de trois — deux développeurs et un product owner. Ni QA ni équipe ' +
+    'Équipe technique de trois : deux développeurs et un product owner. Ni QA ni équipe ' +
     'data dédiées. Encadrement d’alternants et de stagiaires.',
 }
 

--- a/src/contenu/realisations/mailingvox-donnee.ts
+++ b/src/contenu/realisations/mailingvox-donnee.ts
@@ -1,4 +1,4 @@
-// mailingvox-donnee.ts — jeromemarichez-fr
+// mailingvox-donnee.ts (jeromemarichez-fr)
 // Acetelecom / MailingVox, 2023-2026 : ce qui a été construit sur la donnée.
 //
 // Séparé de `mailingvox-produits.ts` pour la limite de 300 lignes par fichier, et
@@ -23,7 +23,7 @@ export const REALISATION_PREZAGE_LLAMA: IRealisation = {
     'à côté. Llama 3 a été spécialisé sur un corpus métier, complété par un procédé maison ' +
     'd’augmentation du contexte.',
   meta: {
-    title: 'Prézage — un Llama 3 spécialisé sur un métier',
+    title: 'Prézage : un Llama 3 spécialisé sur un métier',
     description:
       'Fine-tuning de Llama 3 sur corpus métier pour l’application Prézage, complété par un ' +
       'procédé maison d’augmentation du contexte. Aucun framework tiers.',
@@ -59,7 +59,7 @@ export const REALISATION_PREZAGE_LLAMA: IRealisation = {
     'Charge de travail des prestataires réduite. Le résultat n’est pas chiffré : les chiffres ' +
     'du projet sont couverts par l’accord de confidentialité.',
   decision:
-    'Modèle hébergé chez vous ou service tiers — et ce que chacun vous coûte par mois, une ' +
+    'Modèle hébergé chez vous ou service tiers, et ce que chacun vous coûte par mois, une ' +
     'fois la confidentialité mise dans la balance.',
 }
 
@@ -70,16 +70,16 @@ export const REALISATION_DEPOT_VOCAL: IRealisation = {
     'L’échec d’un dépôt vocal ne se constatait qu’après coup, une fois la route déjà empruntée. ' +
     'Un modèle supervisé, entraîné sur les caractéristiques du signal audio, le voit venir.',
   meta: {
-    title: 'Anticiper les échecs de dépôt vocal — modèle supervisé',
+    title: 'Anticiper les échecs de dépôt vocal : modèle supervisé',
     description:
-      'Modèle supervisé en production — TensorFlow, inférence en cloud functions — ' +
+      'Modèle supervisé en production (TensorFlow, inférence en cloud functions) ' +
       'anticipant les échecs de dépôt vocal. Extraction du signal publiée sur arXiv.',
   },
   cadre: CADRE_MAILINGVOX,
   poles: ['data', 'ia'],
   probleme:
     'Certaines routes vocales échouaient au dépôt du message. L’échec ne se constatait qu’après ' +
-    'coup, une fois la route déjà empruntée — et facturée.',
+    'coup, une fois la route déjà empruntée, et facturée.',
   etapes: [
     {
       titre: 'Extraire les caractéristiques du signal',
@@ -104,7 +104,7 @@ export const REALISATION_DEPOT_VOCAL: IRealisation = {
     'Routes vocales coûteuses évitées. Le gain n’est pas chiffré ici : je n’en publie pas de ' +
     'mesure.',
   decision:
-    'À partir de quel taux d’échec un modèle coûte moins cher que les routes qu’il évite — et ' +
+    'À partir de quel taux d’échec un modèle coûte moins cher que les routes qu’il évite, et ' +
     'jusqu’où il faut le surveiller ensuite.',
 }
 
@@ -124,7 +124,7 @@ export const REALISATION_RAG_SUPPORT: IRealisation = {
   poles: ['data', 'ia'],
   probleme:
     'Les tickets de support de niveau 1 posent des questions dont la réponse est déjà dans la ' +
-    'documentation interne. Un modèle qui répond de mémoire invente une réponse plausible — ' +
+    'documentation interne. Un modèle qui répond de mémoire invente une réponse plausible : ' +
     'c’est le pire des deux mondes pour un support.',
   etapes: [
     {
@@ -174,7 +174,7 @@ export const REALISATION_LTV_MULTI_SOURCES: IRealisation = {
     {
       titre: 'Agréger, sur le modèle métier',
       texte:
-        'Régies — Google Ads, Bing Ads —, produit et CRM agrégés dans un même modèle, construit ' +
+        'Régies (Google Ads, Bing Ads), produit et CRM agrégés dans un même modèle, construit ' +
         'sur l’activité plutôt que sur un connecteur générique.',
     },
     {
@@ -193,8 +193,8 @@ export const REALISATION_LTV_MULTI_SOURCES: IRealisation = {
   ],
   resultat:
     'Aucun résultat n’est publié ici : je n’en ai pas de mesuré. Le système existe et il ' +
-    'tourne — c’est tout ce que cette fiche affirme.',
+    'tourne : c’est tout ce que cette fiche affirme.',
   decision:
-    'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre — la ' +
+    'Quelle source d’acquisition vous coupez le mois prochain, et sur quel chiffre : la ' +
     'rentabilité réelle, pas celle que la régie déclare.',
 }

--- a/src/contenu/realisations/mailingvox-produits.ts
+++ b/src/contenu/realisations/mailingvox-produits.ts
@@ -1,4 +1,4 @@
-// mailingvox-produits.ts — jeromemarichez-fr
+// mailingvox-produits.ts (jeromemarichez-fr)
 // Acetelecom / MailingVox, 2023-2026 : ce qui a été construit et exploité.
 //
 // Le cadre d'emploi est partagé par toutes les fiches d'ici (`cadres.ts`). Le fichier est
@@ -23,7 +23,7 @@ export const REALISATION_SMS_EN_MASSE: IRealisationChiffree = {
     'blanche. Il a été remplacé par une plateforme développée en interne, dont le ' +
     'référencement technique est une propriété du code et non d’un fournisseur.',
   meta: {
-    title: 'Plateforme SaaS « Sms En Masse » — 98/100 Lighthouse',
+    title: 'Plateforme SaaS « Sms En Masse » : 98/100 Lighthouse',
     description:
       'Une solution tierce en marque blanche remplacée par une plateforme SaaS développée en ' +
       'interne : rendu arbitré page par page, 98/100 au score Lighthouse.',
@@ -32,7 +32,7 @@ export const REALISATION_SMS_EN_MASSE: IRealisationChiffree = {
   poles: ['ingenierie-web', 'sea-ux'],
   probleme:
     'La plateforme « Sms En Masse » était une solution tierce revendue en marque blanche. ' +
-    'Tout ce qui touchait au produit — sa vitesse, ses pages, son référencement — se ' +
+    'Tout ce qui touchait au produit (sa vitesse, ses pages, son référencement) se ' +
     'décidait ailleurs.',
   etapes: [
     {
@@ -62,10 +62,10 @@ export const REALISATION_SMS_EN_MASSE: IRealisationChiffree = {
     libelle: 'au score Lighthouse',
     portee:
       'Le score porte sur la plateforme livrée, mesuré par Lighthouse. C’est une mesure de la ' +
-      'page — pas une mesure d’audience, pas un chiffre d’affaires.',
+      'page, pas une mesure d’audience, pas un chiffre d’affaires.',
   },
   decision:
-    'Quelle page se rend au build, laquelle à la requête — et ce que chacune coûte en serveur ' +
+    'Quelle page se rend au build, laquelle à la requête, et ce que chacune coûte en serveur ' +
     'comme en référencement.',
 }
 
@@ -76,7 +76,7 @@ export const REALISATION_PREZAGE_MIGRATION: IRealisation = {
     'L’application Prézage tournait sur Ionic 6 et Angular 15. Les deux migrations ont été ' +
     'menées pendant que le produit continuait d’évoluer, sans interruption de service.',
   meta: {
-    title: 'Prézage — migrer Ionic et Angular sans coupure',
+    title: 'Prézage : migrer Ionic et Angular sans coupure',
     description:
       'Migration Ionic 6 vers 8 et Angular 15 vers 19 de l’application mobile Prézage, sans ' +
       'interruption de service ni gel de la roadmap produit.',
@@ -152,7 +152,7 @@ export const REALISATION_ANTI_FRAUDE: IRealisation = {
       titre: 'Implémentées dans le produit',
       texte:
         'Les règles ont été intégrées au produit par la même personne que celle qui les a ' +
-        'définies — aucun aller-retour de spécification entre l’analyse et le code.',
+        'définies : aucun aller-retour de spécification entre l’analyse et le code.',
     },
   ],
   resultat:

--- a/src/contenu/realisations/realisations-index.ts
+++ b/src/contenu/realisations/realisations-index.ts
@@ -1,4 +1,4 @@
-// realisations-index.ts — jeromemarichez-fr
+// realisations-index.ts (jeromemarichez-fr)
 // L'en-tête éditoriale de la liste. Les fiches, elles, viennent de `realisations.ts`.
 
 import type { IRealisationsIndex } from '@/interfaces/IRealisationsIndex'
@@ -6,11 +6,11 @@ import { ROUTES } from '@/routes'
 
 /**
  * Le libellé « Réalisations » est repris à l'identique dans la navigation, le fil
- * d'Ariane, le titre de la page et l'URL — même règle que pour le blog.
+ * d'Ariane, le titre de la page et l'URL, même règle que pour le blog.
  *
  * Le chapô porte le cadre, et il le porte en clair plutôt qu'en note de bas de page : un
  * visiteur qui arrive ici cherche des références clients, et il doit apprendre en deux
- * phrases à quel titre chaque travail a été mené — deux postes salariés, une mission en
+ * phrases à quel titre chaque travail a été mené : deux postes salariés, une mission en
  * indépendant. Le dire franchement vaut mieux que le laisser découvrir fiche par fiche, et
  * mieux que l'ancienne formule « trois postes salariés », qui était fausse pour Truffle
  * Capital (issue #107).
@@ -19,14 +19,14 @@ export const REALISATIONS_INDEX: IRealisationsIndex = {
   route: ROUTES.realisations,
   titre: 'Réalisations',
   meta: {
-    title: 'Réalisations — ce que j’ai construit, et dans quel cadre',
+    title: 'Réalisations : ce que j’ai construit, et dans quel cadre',
     description:
       'Treize réalisations avec leur cadre réel : statut, intitulé de poste, période, ' +
       'équipe. Trois portent un chiffre, les autres n’en portent aucun.',
   },
   chapo:
     'Deux postes salariés et une mission en indépendant. Chaque fiche porte le cadre dans ' +
-    'lequel elle a été menée — statut, intitulé exact, période, équipe. Trois fiches ' +
+    'lequel elle a été menée : statut, intitulé exact, période, équipe. Trois fiches ' +
     'portent un chiffre ; les autres n’en portent aucun, parce que je ne publie que les ' +
     'chiffres que je peux tenir.',
 }

--- a/src/contenu/realisations/realisations.ts
+++ b/src/contenu/realisations/realisations.ts
@@ -1,8 +1,8 @@
-// realisations.ts — jeromemarichez-fr
+// realisations.ts (jeromemarichez-fr)
 // La liste des réalisations publiées. Source unique de l'espace `/realisations/`.
 //
 // Tout part d'ici : la liste, les fiches générées au build, le sitemap et les données
-// structurées. Une fiche retirée de ce tableau disparaît partout — il n'y a pas de second
+// structurées. Une fiche retirée de ce tableau disparaît partout : il n'y a pas de second
 // endroit à mettre à jour.
 //
 // L'ORDRE DE CE TABLEAU EST L'ORDRE D'AFFICHAGE, à l'intérieur de chaque cadre d'emploi.
@@ -10,7 +10,7 @@
 // `src/services/find-realisation` et suit l'ordre de `CADRES`.
 //
 // Une convention tenue à la main : chaque cadre s'ouvre sur sa fiche chiffrée quand il en
-// a une, puis déroule du produit vers la donnée. Le type ne peut pas l'imposer — trois
+// a une, puis déroule du produit vers la donnée. Le type ne peut pas l'imposer : trois
 // fiches chiffrées sur treize ne font pas une règle exprimable.
 
 import type { IRealisation } from '@/interfaces/IRealisation'

--- a/src/contenu/realisations/truffle.ts
+++ b/src/contenu/realisations/truffle.ts
@@ -1,11 +1,11 @@
-// truffle.ts — jeromemarichez-fr
+// truffle.ts (jeromemarichez-fr)
 // Truffle Capital, 2017-2019 : capital-risque, sites du fonds et de ses participations.
 //
 // Trois précautions valent pour tout ce fichier :
 //
 // - **Artedrone est une participation du fonds**, jamais un second client. Le client est
 //   Truffle Capital, et l'AMOA a été menée au bénéfice d'Artedrone **dans le cadre de la
-//   mission Truffle**. La fiche le dit, et le rôle tenu y est l'AMOA — rien n'est affirmé
+//   mission Truffle**. La fiche le dit, et le rôle tenu y est l'AMOA : rien n'est affirmé
 //   sur le dispositif médical. (Arbitré par Jérôme MARICHEZ le 2026-08-23, issue #107.)
 // - Le **100 000 €** est un budget **piloté**, jamais un résultat. Aucun retour sur
 //   investissement, aucun coût d'acquisition, aucun volume de trafic n'existe en source.
@@ -56,7 +56,7 @@ export const REALISATION_BUDGET_ADS: IRealisationChiffree = {
   ],
   resultat:
     'Le budget a été piloté de bout en bout, mesuré et justifié. Cette fiche ne publie aucun ' +
-    'résultat de campagne — ni retour sur investissement, ni coût d’acquisition, ni trafic : ' +
+    'résultat de campagne (ni retour sur investissement, ni coût d’acquisition, ni trafic) : ' +
     'je n’en publie pas de mesure.',
   chiffre: {
     chiffre: '100 000 €',
@@ -66,7 +66,7 @@ export const REALISATION_BUDGET_ADS: IRealisationChiffree = {
       'ça a rapporté. La durée sur laquelle il court n’est pas publiée.',
   },
   decision:
-    'Ce que vous présentez à votre conseil pour tenir une ligne budgétaire — et sur quel ' +
+    'Ce que vous présentez à votre conseil pour tenir une ligne budgétaire, et sur quel ' +
     'chiffre, quand la régie et la comptabilité ne disent pas la même chose.',
 }
 
@@ -96,7 +96,7 @@ export const REALISATION_TRUFFLE_SITES: IRealisation = {
       titre: 'Un seul interlocuteur sur les trois',
       texte:
         'Conception, développement, mise en production et exploitation tenus par la même ' +
-        'personne — ce qui évitait d’arbitrer trois fois les mêmes questions.',
+        'personne, ce qui évitait d’arbitrer trois fois les mêmes questions.',
     },
     {
       titre: 'La coordination',
@@ -119,7 +119,7 @@ export const REALISATION_ARTEDRONE_AMOA: IRealisation = {
     'Le besoin était porté par des équipes scientifiques et dirigeantes. Il devait devenir ' +
     'lisible par des prestataires qui ne connaissaient pas le domaine. C’est tout le travail.',
   meta: {
-    title: 'AMOA d’une startup biotech — du besoin aux spécifications',
+    title: 'AMOA d’une startup biotech : du besoin aux spécifications',
     description:
       'AMOA de la startup biotech Artedrone : besoin recueilli auprès des équipes ' +
       'scientifiques et dirigeantes, BPMN 2.0 et cartographie du système d’information.',

--- a/src/contenu/realisations/verhoeven.ts
+++ b/src/contenu/realisations/verhoeven.ts
@@ -1,16 +1,16 @@
-// verhoeven.ts — jeromemarichez-fr
+// verhoeven.ts (jeromemarichez-fr)
 // Verhoeven Joaillier, 2019-2022 : e-commerce de joaillerie de luxe, poste unique.
 //
 // **Interdiction nominative appliquée ici** : Google Tag Manager n'appartient pas à cette
 // période (`CLAUDE.md`). Ce qui est revendiqué chez Verhoeven, c'est Google Analytics, de
-// l'A/B testing et des heatmaps — rien de plus.
+// l'A/B testing et des heatmaps. Rien de plus.
 //
 // Deuxième garde-fou : le poste était unique. Aucune de ces fiches ne doit laisser croire
 // à l'encadrement de développeurs ; ce qui a été encadré, ce sont des prestataires SEA,
 // SEO et SMA, et c'est écrit dans le cadre d'emploi.
 //
 // Troisième : le +50 % porte sur le **panier moyen**. Ni chiffre d'affaires, ni taux de
-// conversion, ni revenus — trois affirmations différentes, dont deux ne sont pas sourcées.
+// conversion, ni revenus : trois affirmations différentes, dont deux ne sont pas sourcées.
 
 import type { IRealisation } from '@/interfaces/IRealisation'
 import type { IRealisationChiffree } from '@/interfaces/IRealisationChiffree'
@@ -22,9 +22,9 @@ export const REALISATION_PARCOURS_ACHAT: IRealisationChiffree = {
   titre: 'Refondre les parcours d’achat d’un e-commerce de joaillerie',
   chapo:
     'Les tunnels d’achat se discutaient au goût. Ils ont été refondus sur ce que la mesure ' +
-    'disait du visiteur réel — et l’arbitrage décidé était implémenté par la même personne.',
+    'disait du visiteur réel, et l’arbitrage décidé était implémenté par la même personne.',
   meta: {
-    title: 'Refonte des parcours d’achat — panier moyen +50 %',
+    title: 'Refonte des parcours d’achat : panier moyen +50 %',
     description:
       'Refonte des tunnels d’achat d’un e-commerce de joaillerie de luxe pilotée par la ' +
       'mesure : A/B testing des pages et des designs, heatmaps, taux de rebond.',
@@ -32,11 +32,11 @@ export const REALISATION_PARCOURS_ACHAT: IRealisationChiffree = {
   cadre: CADRE_VERHOEVEN,
   // Les trois pôles de la chaîne SANS l'IA : construire, mesurer, arbitrer. C'est la
   // démonstration la plus directe que rien n'oblige à acheter de l'IA pour tirer parti de
-  // sa donnée — et elle est vraie, ce travail n'en a jamais employé.
+  // sa donnée. Et elle est vraie, ce travail n'en a jamais employé.
   poles: ['ingenierie-web', 'data', 'sea-ux'],
   probleme:
     'Les tunnels d’achat se discutaient au goût, page par page. Sur un catalogue de pièces ' +
-    'uniques, une étape de trop coûte une commande — encore fallait-il savoir laquelle.',
+    'uniques, une étape de trop coûte une commande. Encore fallait-il savoir laquelle.',
   etapes: [
     {
       titre: 'Mesurer avant de trancher',
@@ -76,7 +76,7 @@ export const REALISATION_VERHOEVEN_MIGRATIONS: IRealisation = {
   titre: 'Deux migrations sans jamais couper le site marchand',
   chapo:
     'PHP 5 vers 7 puis réécriture en Node.js, jQuery vers React. Un site marchand ne se met ' +
-    'pas en maintenance le temps d’une réécriture — et celui-ci a aussi fallu l’exploiter.',
+    'pas en maintenance le temps d’une réécriture, et celui-ci a aussi fallu l’exploiter.',
   meta: {
     title: 'Deux migrations sans couper un site marchand',
     description:
@@ -113,7 +113,7 @@ export const REALISATION_VERHOEVEN_MIGRATIONS: IRealisation = {
     'Les deux migrations ont été menées sans interruption du site marchand, sur un poste ' +
     'unique.',
   decision:
-    'Ce qui se migre par étapes et ce qui se réécrit — et ce que chaque option coûte en ' +
+    'Ce qui se migre par étapes et ce qui se réécrit, et ce que chaque option coûte en ' +
     'risque d’arrêt.',
 }
 

--- a/src/contenu/sea-ux-sections.ts
+++ b/src/contenu/sea-ux-sections.ts
@@ -1,5 +1,5 @@
-// sea-ux-sections.ts — jeromemarichez-fr
-// Le pôle SEA & UX — l'une des deux suites de la donnée. SEA et arbitrages d'expérience.
+// sea-ux-sections.ts (jeromemarichez-fr)
+// Le pôle SEA & UX, l'une des deux suites de la donnée. SEA et arbitrages d'expérience.
 //
 // Point de vigilance éditorial numéro un : rien ici ne doit laisser croire à de la
 // création graphique ou à du design d'interface. Ce qui est vendu, ce sont des

--- a/src/contenu/sea-ux.ts
+++ b/src/contenu/sea-ux.ts
@@ -1,5 +1,5 @@
-// sea-ux.ts — jeromemarichez-fr
-// Le pôle SEA & UX — l'une des deux suites de la donnée. Métadonnées ; les sections
+// sea-ux.ts (jeromemarichez-fr)
+// Le pôle SEA & UX, l'une des deux suites de la donnée. Métadonnées ; les sections
 // vivent dans le fichier voisin.
 //
 // La description suit ce que la page dit vraiment depuis l'issue #128 : le pilotage
@@ -13,7 +13,7 @@ import { SECTIONS_SEA_UX } from './sea-ux-sections'
 export const PAGE_SEA_UX: IEditorialPage = {
   route: '/services/sea-ux',
   meta: {
-    title: 'SEA & arbitrages UX sur la donnée — Lille',
+    title: 'SEA & arbitrages UX sur la donnée | Lille',
     description:
       'Mesure construite dans le code, consentement conforme, campagnes arbitrées sur vos ' +
       'segments et sur la valeur client à long terme, parcours implémentés.',

--- a/src/contenu/select-certifications.ts
+++ b/src/contenu/select-certifications.ts
@@ -1,4 +1,4 @@
-// select-certifications.ts — jeromemarichez-fr
+// select-certifications.ts (jeromemarichez-fr)
 // Sélection des certifications à afficher selon le contexte.
 
 import type { ICertification } from '@/interfaces/ICertification'
@@ -15,7 +15,7 @@ import { CERTIFICATIONS } from './certifications'
  * **Un pôle sans certification à lui n'en affiche aucune, transverses comprises.** Le
  * passage à quatre pôles a créé ce cas : la donnée n'a aujourd'hui aucune certification
  * propre. Rendre malgré tout le bloc afficherait un titre « Ce qui est certifié sur ce
- * pôle » suivi de la seule certification d'anglais — le contraire de ce qu'il annonce.
+ * pôle » suivi de la seule certification d'anglais, le contraire de ce qu'il annonce.
  * Le site vend de la rigueur : mieux vaut ne rien montrer que d'appeler preuve ce qui
  * n'en est pas une ici.
  */


### PR DESCRIPTION
Applique rétroactivement la règle éditoriale « jamais de tiret cadratin dans un texte
destiné à être lu » (règle posée par #123). Traite l'issue #124.

Ce n'est pas une substitution de caractère. Chaque occurrence a été relue dans sa phrase,
et l'outil a été choisi sur le rapport logique entre les deux moitiés : virgule pour une
incise légère, deux-points quand la suite explique, parenthèses pour un aparté vraiment
secondaire, deux phrases quand les deux moitiés tiennent debout seules. Aucun `sed`.

## Le compte, par zone

| Zone | Avant | Après | Repris |
|---|---|---|---|
| `src/contenu/` (contenu publié) | 209 | **0** | oui |
| `docs/` et `README.md` | 483 | **0** | oui |
| `CLAUDE.md` | 37 | **2** | oui, sauf le bloc généré par Next.js |
| Commentaires de code (reste de `src/`) | 622 | **622** | non, hors périmètre |
| **Total repris** | **729** | | |

Le diff fait 52 fichiers, 688 insertions et 688 suppressions : aucune ligne ajoutée ni
retirée, seulement réécrite.

## Les deux occurrences qui restent, et pourquoi

`CLAUDE.md` lignes 397 et 399 sont dans le bloc délimité par
`<!-- BEGIN:nextjs-agent-rules -->`, écrit et réécrit par `next dev`. Vérifié sur ce
poste : reformulées, elles sont revenues à l'identique en quelques secondes au premier
démarrage du serveur. Le code de Next le confirme,
`node_modules/next/dist/server/lib/generate-agent-files.js` remplace tout ce qui se
trouve entre les deux marqueurs. Ce texte est anglais, fourni par une dépendance, et le
projet ne peut pas le tenir. Le critère « `grep` ne renvoie rien sur `CLAUDE.md` » n'est
donc pas atteignable tant que ce bloc existe.

## Quelques reformulations représentatives

| Avant | Après | Outil |
|---|---|---|
| `Celui qui cadre est celui qui code, qui mesure et qui exploite — et c'est lui qui répond de tout.` | `…qui mesure et qui exploite. C'est lui qui répond de tout.` | deux phrases |
| `Je conçois, je développe et je pilote avec l'IA — Claude Code et Gemini au quotidien` | `…avec l'IA : Claude Code et Gemini au quotidien` | deux-points |
| `Si la taille du projet demande un renfort — c'est rare — je le choisis` | `Si la taille du projet demande un renfort (c'est rare), je le choisis` | parenthèses |
| `Ni IA ni SEA & UX ne se font sans elle — sans mesure, l'IA devine` | `…ne se font sans elle : sans mesure, l'IA devine` | deux-points |
| `Supervisé — classification, réseaux de neurones — ou non supervisé` | `Supervisé (classification, réseaux de neurones) ou non supervisé` | parenthèses |
| `une étape de trop coûte une commande — encore fallait-il savoir laquelle.` | `…coûte une commande. Encore fallait-il savoir laquelle.` | deux phrases |
| `disait du visiteur réel — et l'arbitrage décidé était implémenté` | `disait du visiteur réel, et l'arbitrage décidé était implémenté` | virgule |

## Les tirets qui n'étaient pas de la ponctuation

Certains tirets marquaient une cellule vide ou un séparateur d'étiquette. Ils ont reçu un
libellé explicite plutôt qu'un autre signe, et le libellé dit ce que la colonne veut dire :

- `*aucune*` pour une relation d'entité absente (`docs/data-model.md`) ;
- `*sans objet*` pour une mesure sans objet (contraste de `--fond` sur lui-même dans
  `docs/design.md`, niveau d'effort de `haiku-mechanic` dans `docs/model-routing.md`) ;
- `*non renseignée*` pour une année de certification non fournie (`README.md`).

Les bannières de fichier de `src/contenu/` (`// accueil.ts — jeromemarichez-fr`) passent
en `// accueil.ts (jeromemarichez-fr)`, soit 35 lignes. **Point à signaler** : la même
bannière subsiste sur 104 fichiers ailleurs dans `src/`, hors du périmètre de l'issue. Le
dépôt est donc temporairement incohérent sur ce point.

## La règle qui a guidé le choix deux-points / point

Sur les listes à puces du type `- **Étiquette** — description`, très nombreuses dans
`README.md` et `docs/`, le deux-points s'impose quand la phrase n'en porte pas déjà un,
le point sinon. Deux deux-points dans une même phrase est le défaut que cette reprise
devait le plus éviter : un balayage systématique du diff l'a vérifié, et les cinq cas
restants sont des cellules de tableau distinctes ou des phrases distinctes.

## Relecture par un second agent

Trois agents ont relu, sans le contexte de rédaction, sur des couples avant / après
seuls. Ce qu'ils ont relevé et ce qui en a été fait.

**Intégré :**

- **Une dérive de véracité.** Le tiret de la cellule « Année » du README, pour EF SET,
  avait été remplacé par `*sans millésime*`. Or cette formule est l'arbitrage de Jérôme
  MARICHEZ du 2026-08-20 pour **Microsoft Ads** seulement ; l'appliquer à EF SET
  affirmait un fait qu'aucune source ne porte. Les deux cellules disent désormais
  `*non renseignée*`, qui ne dit que ce qui est vrai : l'année n'est pas remplie.
- **Un piège de portée de négation.** `Le piège n'est pas que l'IA se trompe (un
  développeur aussi).` fait tomber l'incise dans la portée de la négation, et on lit un
  instant que le développeur non plus n'est pas le piège. Rétabli en deux phrases.
- **Un mot changé au lieu de la seule ponctuation.** « pas de GTM » était devenu « sans
  GTM » dans un commentaire de véracité du blog. La négation portait une règle
  d'attribution ; « pas de GTM » est restauré.
- Une dizaine de virgules fautives, de deux-points qui annonçaient autre chose que ce qui
  suit, de parenthèses accolées et de fragments sans verbe érigés en phrase.

**Non intégré, et pourquoi :**

- Deux corrections proposées auraient créé un double deux-points, parce que le relecteur
  ne voyait que l'extrait et pas l'étiquette en gras qui ouvrait déjà la puce
  (`- **Découpage** : …`, `- **Couverture** : …`). Le diagnostic était juste, la phrase
  était bancale ; le remède retenu est le point.
- Une demande d'uniformiser toutes les puces du README sur le deux-points est déclinée :
  c'est la règle énoncée plus haut qui décide, et l'uniformiser produirait précisément le
  double deux-points que le même relecteur signale ailleurs.
- Une réécriture qui déplaçait la référence de fichier en fin de phrase dans le README a
  été remplacée par une apposition entre virgules : même lisibilité gagnée, sans
  réordonner le propos.

## Ce que j'ai préféré signaler plutôt que reformuler

1. **`src/contenu/realisations/verhoeven.ts`** porte une faute de syntaxe **antérieure à
   cette PR** : « Un site marchand ne se met pas en maintenance le temps d'une réécriture,
   et celui-ci a aussi fallu l'exploiter. » « celui-ci » ne peut pas être sujet de « a
   fallu ». Le défaut existait avec le tiret, où l'incise le masquait un peu. Le corriger
   demande de toucher aux mots, ce qui sort du périmètre de cette issue. À traiter à part.

2. **`limites.ts`** met « c'est rare » entre parenthèses. Les mots exacts sont conservés,
   mais une parenthèse baisse le volume d'une mention que le `CLAUDE.md` demande de dire.
   Relu au rendu, la phrase reste courte et la mention reste lisible. Si Jérôme MARICHEZ
   préfère la garder dans le flux principal, « ce qui est rare » ferait l'affaire.

3. **Les intitulés de certification** `WeLoveDev, Top 5 % React` et `EF SET, Anglais B2
   (CECRL)` : seul le séparateur a bougé, les mots sont intacts. Si l'un de ces intitulés
   doit être repris à l'identique d'un justificatif, il faut le dire.

4. **Des textes destinés à être lus portent encore des tirets cadratins hors du périmètre
   de l'issue.** C'est le point le plus important de cette PR, et il n'est pas traité ici
   parce que l'issue #124 borne sa vérification à `src/contenu/` et compte tout le reste
   de `src/` comme des commentaires. Ce n'en sont pas. Sont concernés :

   - `src/app/layout.tsx` lignes 29 et 30 : le titre par défaut et le **gabarit de titre
     de toutes les pages**, `%s — Jérôme Marichez` ;
   - `src/app/manifest.ts` ligne 20 : le nom du manifeste ;
   - `src/seo/site.ts` ligne 32 : une description publiée ;
   - `src/components/SiteFooter/index.tsx` ligne 89 : le pied de page, visible sur toutes
     les pages ;
   - `src/components/PoleHero/index.tsx` lignes 78 et 82 : du texte de corps sur chaque
     page de pôle ;
   - `src/components/MotionToggle/index.tsx` ligne 39 : le libellé « réglage système » ;
   - `src/components/RealisationCard/index.tsx` ligne 47 et
     `src/components/HomeHero/index.tsx` ligne 54 : deux **libellés accessibles**, donc
     lus par un lecteur d'écran.

   Vérifié au rendu : la page d'accueil affiche encore « Jérôme Marichez — Ingénieur-conseil
   indépendant à Lille » en pied de page. Les toucher ferait bouger le compte de
   `grep -ro "—" src/` hors `src/contenu/`, que l'issue fige à 622, et croiserait une
   branche ouverte en parallèle sur `src/seo/site.ts`. Une issue de suite est à ouvrir.

## Vérifications

- `grep -rn "—" src/contenu/ docs/ README.md CLAUDE.md` ne renvoie que les deux lignes du
  bloc Next.js.
- `grep -ro "—" src/ --exclude-dir=contenu` : **622**, inchangé. Aucun commentaire de code
  n'a été touché hors `src/contenu/`.
- Aucun emoji ajouté, aucun tiret demi-cadratin introduit (vérifié sur le diff complet).
  Le seul emoji du diff est le `🧩` d'un titre du README, déjà présent avant.
- `make lint` vert, `make test` vert, `npm run build` vert.
- `node scripts/budgets.mjs` sur les sept pages :

  | Page | Perf | A11y | Bonnes prat. | SEO |
  |---|---|---|---|---|
  | accueil | 95 | 100 | 100 | 100 |
  | pôle ingénierie web | 96 | 100 | 100 | 100 |
  | blog | 97 | 100 | 100 | 100 |
  | article | 97 | 100 | 100 | 100 |
  | article avec source | 97 | 100 | 100 | 100 |
  | réalisations | 97 | 100 | 100 | 100 |
  | fiche de réalisation | 97 | 100 | 100 | 100 |

  axe-core : 0 violation sur les sept pages.
- Rendu relu à l'écran sur `npx next dev` : accueil, `/services/data/`, l'article
  « De la doc qui pilote une IA… » et `/realisations/` avec une fiche.

Aucun fichier de test n'a été créé ni modifié. `next-env.d.ts` et `package-lock.json` ne
sont pas dans le diff.

Traite #124. L'issue est à fermer à la main : les PR visent `dev` et la branche par
défaut est `main`.
