### PR TITLE
feat: le site dit son ancrage regional

### DIFF
--- a/src/contenu/accueil.ts
+++ b/src/contenu/accueil.ts
@@ -17,7 +17,35 @@
 // espaces, le contact.
 
 import type { IEditorialPage } from '@/interfaces/IEditorialPage'
+import { SITE_IDENTITY } from '@/seo/site'
 import { SECTION_OBJECTIONS } from './objections'
+
+/**
+ * L'ancrage régional (issue #136), rendu une seule fois, dans le bloc de contact.
+ *
+ * Ce que le texte dit, et pourquoi il ne peut pas dire plus. Les CV de référence
+ * n'établissent que trois choses : l'exercice à Lille, le Bac +3 Développeur à Dunkerque
+ * en 2022, le Bac +5 Expert en informatique et systèmes d'information à Lille en 2025.
+ * Aucune source ne porte un lieu de naissance, une origine ni une enfance dans le Nord,
+ * donc le site n'en affirme aucun : arbitrage de Jérôme MARICHEZ du 2026-08-24, ancrage
+ * régional sans revendication d'origine. Un parcours de formation régional n'est pas une
+ * origine, et il ne s'en déduit pas.
+ *
+ * Les intitulés de diplôme sont repris à l'identique des CV, comme les intitulés de
+ * poste. La troisième phrase est là pour empêcher la lecture « CV » : ce site vend neuf
+ * ans d'expérience et des preuves chiffrées, pas des diplômes. La formation n'est ici
+ * qu'un signal de proximité.
+ *
+ * La ville et la région viennent de `SITE_IDENTITY`, qui reste la source unique de la
+ * localisation. Dunkerque est écrite en clair : c'est un fait de parcours, pas la
+ * localisation de l'activité, et elle n'a rien à faire dans les données structurées.
+ */
+export const ANCRAGE_REGIONAL =
+  `Je travaille depuis ${SITE_IDENTITY.ville}, et c’est aussi en ${SITE_IDENTITY.region} que je me ` +
+  'suis formé : Bac +3 Développeur à Dunkerque en 2022, puis Bac +5 Expert en informatique et ' +
+  `systèmes d’information à ${SITE_IDENTITY.ville} en 2025. Ces diplômes ne sont pas l’argument ` +
+  'de ce site, les neuf ans et les chiffres plus haut le sont. Ils situent, rien de plus : j’y ' +
+  'suis installé, pas de passage.'
 
 /** Le seuil : promesse, et trois chiffres pour qu'elle ne reste pas un slogan. */
 export const HERO_ACCUEIL = {

--- a/src/views/HomeView/home-view.module.css
+++ b/src/views/HomeView/home-view.module.css
@@ -165,3 +165,24 @@
   text-decoration-thickness: 2px;
   text-underline-offset: 0.24em;
 }
+
+/* L'ancrage régional (issue #136) : une note de bas de section, jamais un argument.
+   Même registre typographique que `.directTexte` — corps de note, encre douce — parce
+   qu'il joue le même rôle qu'elle : renseigner sans réclamer le regard. Un filet le
+   sépare de la grille : sans lui, le paragraphe se collait sous la colonne de gauche et
+   se lisait comme une aide du formulaire. */
+.ancrage {
+  margin: 0;
+  width: 100%;
+  padding-top: var(--e-3);
+  border-top: 1px solid color-mix(in srgb, var(--encre) 10%, transparent);
+  /* Le filet tient toute la largeur du panneau, la ligne de texte s'arrête à la mesure.
+     Un `max-width` aurait fait les deux à la fois, et le filet se serait arrêté juste
+     sous la colonne du formulaire : il aurait alors désigné le formulaire au lieu de
+     fermer la section. La marge intérieure vaut zéro dès que le bloc est plus étroit
+     que la mesure, donc rien à corriger sur petit écran. */
+  padding-inline-end: max(0px, calc(100% - var(--mesure-texte)));
+  font-size: var(--t-note);
+  line-height: 1.55;
+  color: var(--encre-douce);
+}

--- a/src/views/HomeView/index.tsx
+++ b/src/views/HomeView/index.tsx
@@ -12,7 +12,7 @@ import { HomeHero } from '../../components/HomeHero'
 import { PoleEntries } from '../../components/PoleEntries'
 import { ProofWall } from '../../components/ProofWall'
 import { SpaceEntries } from '../../components/SpaceEntries'
-import { PAGE_ACCUEIL, THESE_CHAINE } from '../../contenu/accueil'
+import { ANCRAGE_REGIONAL, PAGE_ACCUEIL, THESE_CHAINE } from '../../contenu/accueil'
 import { CERTIFICATIONS } from '../../contenu/certifications'
 import { CONTACT_DIRECT } from '../../contenu/contact'
 import { LIMITES } from '../../contenu/limites'
@@ -138,6 +138,17 @@ export function HomeView() {
                 </a>
               </div>
             </div>
+
+            {/* L'ancrage régional, une seule fois sur tout le site (issue #136).
+                Il est ici, et pas au seuil ni au pied de page : c'est le moment où le
+                visiteur décide d'écrire, donc le seul où savoir d'où travaille son
+                interlocuteur change quelque chose. Au seuil il aurait concurrencé la
+                promesse et les trois chiffres ; au pied de page, rendu sur les sept
+                pages, il serait devenu du bas de casse permanent — l'issue demande un
+                endroit, pas un essaimage.
+                Après la grille, pas avant : c'est une note de bas de section, pas un
+                préalable à remplir avant le formulaire. */}
+            <p className={styles.ancrage}>{ANCRAGE_REGIONAL}</p>
           </Reveal>
         </section>
       </div>


### PR DESCRIPTION
Issue #136. (`Closes` volontairement absent : les PR visent `dev`, la branche par defaut est `main`, la fermeture reste manuelle.)

## Ce qui manquait

La localisation etait deja complete : `SITE_IDENTITY`, `SITE_ZONE`, `address` et `areaServed` dans les donnees structurees, « Lille » dans huit endroits du contenu. Ce qui manquait n'etait pas le referencement local mais l'ancrage, c'est-a-dire la difference entre quelqu'un qui se trouve a Lille et quelqu'un qui y est installe.

## Le texte ajoute

> Je travaille depuis Lille, et c'est aussi en Hauts-de-France que je me suis forme : Bac +3 Developpeur a Dunkerque en 2022, puis Bac +5 Expert en informatique et systemes d'information a Lille en 2025. Ces diplomes ne sont pas l'argument de ce site, les neuf ans et les chiffres plus haut le sont. Ils situent, rien de plus : j'y suis installe, pas de passage.

(Le texte publie porte les apostrophes typographiques ; elles sont aplaties ici pour la lisibilite du corps de PR.)

Les deux intitules de diplome sont repris **a l'identique des CV de reference** (`cv-ingenieur-fullstack.md`, section Formation), comme les intitules de poste.

## L'endroit choisi, et pourquoi

**Une seule occurrence, en bas du bloc de contact de l'accueil** (`src/views/HomeView/index.tsx`), apres la grille formulaire + adresse.

- **Pas au seuil.** Le seuil porte la promesse et trois chiffres. Une ligne de diplome y aurait concurrence l'argument au lieu de le servir, et aurait fait glisser la vitrine vers le CV.
- **Pas au pied de page.** Le pied de page est rendu par la mise en page racine, donc sur les sept gabarits. L'issue demande **un** endroit, pas un essaimage : la mention y serait devenue du bas de casse permanent, et se serait banalisee.
- **Le bloc de contact**, parce que c'est le seul moment ou l'information change quelque chose : celui ou le visiteur decide d'ecrire, et ou savoir d'ou travaille son interlocuteur pese. Placee **apres** la grille et non avant, elle se lit comme une note de bas de section, pas comme un prealable a remplir avant le formulaire.

Typographiquement, elle reprend le registre de `.directTexte` (corps de note, encre douce). Un filet la separe de la grille ; il tient toute la largeur du panneau et non celle de la colonne du formulaire, sans quoi il aurait designe le formulaire au lieu de fermer la section.

## Ce qui n'est deliberement PAS affirme

- **Aucune origine, aucune naissance, aucune enfance dans le Nord.** Aucune source ne les porte : ni les trois CV, ni le README. Un parcours de formation regional n'est pas une origine, et il ne s'en deduit pas. Arbitrage de Jerome MARICHEZ du 2026-08-24 : ancrage regional, sans revendication d'origine.
- **Aucun engagement de disponibilite sur place** (deplacement, rendez-vous, delai) : rien ne l'etablit.
- **Aucun registre affectif** sur la region : pas d'attachement, pas de fierte, pas de superlatif.

## Source unique de la localisation

La ville et la region sont interpolees depuis `SITE_IDENTITY` : aucune ville n'est ecrite en dur dans un composant. Dunkerque est ecrite en clair dans le contenu parce que c'est un fait de parcours, pas la localisation de l'activite : elle n'a rien a faire dans `SITE_IDENTITY` ni dans les donnees structurees, qui restent inchangees.

## Relecture par un second agent

Un second agent, **sans le contexte de redaction**, a recu le seul texte final et six points a controler. Verdict : **conforme sur les six**, aucune correction proposee.

1. Revendication d'origine : conforme. « J'y suis installe, pas de passage » est une affirmation de residence, pas d'appartenance native ; aucune formulation indirecte relevee.
2. Registre affectif : conforme, ton sobre et direct.
3. Tiret cadratin et emoji : aucun.
4. Formation comme argument de competence : conforme, le texte se premunit lui-meme (« Ces diplomes ne sont pas l'argument de ce site »).
5. Orthographe, grammaire, syntaxe : conforme.
6. Lisibilite, referents des pronoms : conforme.

## Verifications

- `make lint` : vert (une info `<img>` preexistante sur `CertificationList`, hors perimetre). Limite 300 lignes tenue : `accueil.ts` 103, `HomeView/index.tsx` 157, `home-view.module.css` 189.
- `make test` : vert. `npx tsc --noEmit` et `npm run build` : verts.
- `node scripts/budgets.mjs` : **>= 95 sur les quatre categories, sur les sept pages** (accueil 95 / 100 / 100 / 100). Budgets axe et performance tenus.
- Rendu reel verifie sous `next dev` : theme clair, theme sombre, et 480 px de large.
- Aucun tiret cadratin dans les lignes ajoutees hors commentaires de code (exclus par le `CLAUDE.md`).
- Aucun fichier de test cree : les tests sont ecrits par Jerome MARICHEZ. Le changement est purement editorial, sans logique.
- `next-env.d.ts` et `package-lock.json` ne sont pas commites.

https://claude.ai/code/session_01Ku16fxvGEdhuGVgnYjXN6R