### PR TITLE
fix: le titre des pages et le pied de page perdent leur tiret cadratin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,12 +158,24 @@ considération marketing.
 - **Jamais de tiret cadratin dans un texte destiné à être lu.** Ce caractère signe une
   écriture de machine, et ce site vend un interlocuteur humain. La règle couvre le
   contenu publié (`src/contenu/`), la documentation (`docs/`, `README.md`) et ce
-  fichier. Les **commentaires de code en sont exclus** : ils sont denses et raisonnés,
+  fichier. Elle couvre aussi **tout texte lu ailleurs dans `src/`** : métadonnée SEO,
+  gabarit de titre, libellé de manifeste, chaîne rendue, message, et tout attribut lu par
+  une synthèse vocale (`aria-*`, `alt`, `title`, légende de groupe). Un texte lu par un
+  lecteur d'écran est un texte destiné à être lu. Le tri se fait donc **ligne par ligne**,
+  jamais dossier par dossier (issue #153).
+  Les **commentaires de code en sont exclus** : ils sont denses et raisonnés,
   personne ne les lit de l'extérieur, les reformuler abîmerait leur propos sans bénéfice.
   Ce n'est **pas une substitution de caractère** : le tiret y sert de ponctuation, donc la
   phrase se **reformule** (virgule, deux-points, parenthèses, ou deux phrases). Un `sed`
   global est proscrit, il produirait des phrases fausses.
-  *(Règle ajoutée à la demande explicite de Jérôme MARICHEZ, 2026-08-23.)*
+  **Une exception constatée, et non corrigeable** : le bloc délimité par
+  `<!-- BEGIN:nextjs-agent-rules -->` et `<!-- END:nextjs-agent-rules -->`, plus bas dans
+  ce fichier, garde deux tirets cadratins. Il n'est pas écrit à la main :
+  `node_modules/next/dist/server/lib/generate-agent-files.js` le réécrit à l'identique à
+  chaque `next dev`. Reformulé deux fois, il est revenu deux fois en quelques secondes.
+  Ce n'est donc **ni un oubli ni une dette** : inutile d'y revenir une troisième fois.
+  *(Règle ajoutée à la demande explicite de Jérôme MARICHEZ, 2026-08-23 ; périmètre
+  étendu aux textes lus de `src/` et exception du bloc régénéré constatée le 2026-08-24.)*
 - **Tout texte destiné à être lu passe par un second agent avant la PR** : contenu du
   site, articles, `README.md`, `docs/`. Le code et les commentaires n'y passent pas. Ce
   second agent **n'a pas le contexte de rédaction**, et c'est précisément ce qui fait la

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,8 @@ import './lavis.css'
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: `${SITE_IDENTITY.nom} — ${SITE_IDENTITY.titre} à ${SITE_IDENTITY.ville}`,
-    template: `%s — ${SITE_IDENTITY.nom}`,
+    default: `${SITE_IDENTITY.nom} | ${SITE_IDENTITY.titre} à ${SITE_IDENTITY.ville}`,
+    template: `%s | ${SITE_IDENTITY.nom}`,
   },
   description: SITE_PROMESSE,
   authors: [{ name: SITE_IDENTITY.nom, url: SITE_URL }],

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -17,7 +17,7 @@ export const dynamic = 'force-static'
  */
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: `${SITE_IDENTITY.nom} — ${SITE_IDENTITY.titre} à ${SITE_IDENTITY.ville}`,
+    name: `${SITE_IDENTITY.nom} | ${SITE_IDENTITY.titre} à ${SITE_IDENTITY.ville}`,
     short_name: SITE_IDENTITY.nom,
     description: SITE_PROMESSE,
     lang: 'fr',

--- a/src/components/HomeHero/index.tsx
+++ b/src/components/HomeHero/index.tsx
@@ -51,7 +51,7 @@ export function HomeHero() {
       </div>
 
       <div className={styles.volume}>
-        <ChainCanvas description="Quatre dalles de verre — ingénierie web, donnée, puis IA et SEA & UX côte à côte — traversées par un même filet vertical : un seul interlocuteur, du cadrage au run." />
+        <ChainCanvas description="Quatre dalles de verre : ingénierie web, donnée, puis IA et SEA & UX côte à côte. Un même filet vertical les traverse : un seul interlocuteur, du cadrage au run." />
         {/* Le contrôle est posé au pied de la scène, là où le mouvement se voit.
             WCAG 2.2.2 demande un mécanisme de mise en pause : la préférence système
             n'en est pas un, elle ne se change pas depuis la page. */}

--- a/src/components/MotionToggle/index.tsx
+++ b/src/components/MotionToggle/index.tsx
@@ -36,7 +36,7 @@ export function MotionToggle() {
     >
       <span aria-hidden="true" className={styles.temoin} data-fige={actif} />
       {actif ? 'Animation figée' : "Figer l'animation"}
-      {reduced && !fige ? <span className={styles.precision}> — réglage système</span> : null}
+      {reduced && !fige ? <span className={styles.precision}> (réglage système)</span> : null}
     </button>
   )
 }

--- a/src/components/PoleHero/index.tsx
+++ b/src/components/PoleHero/index.tsx
@@ -75,11 +75,11 @@ export function PoleHero({ pole, suites }: PoleHeroProps) {
         </p>
       ) : (
         <p className={styles.suite}>
-          Ce qui est décidé ici retourne dans le produit —{' '}
+          Ce qui est décidé ici retourne dans le produit,{' '}
           <Link className={styles.lienSuite} href={ROUTES['ingenierie-web']}>
             l'ingénierie web
-          </Link>{' '}
-          — et c'est la même personne qui l'implémente.
+          </Link>
+          , et c'est la même personne qui l'implémente.
         </p>
       )}
     </section>

--- a/src/components/RealisationCard/index.tsx
+++ b/src/components/RealisationCard/index.tsx
@@ -44,7 +44,10 @@ export function RealisationCard({ realisation }: RealisationCardProps) {
 
       <p className={styles.chapo}>{realisation.chapo}</p>
 
-      <PoleTagList legende={`Pôles mobilisés pour ${realisation.titre}`} poles={realisation.poles} />
+      <PoleTagList
+        legende={`Pôles mobilisés pour ${realisation.titre}`}
+        poles={realisation.poles}
+      />
     </article>
   )
 }

--- a/src/components/RealisationCard/index.tsx
+++ b/src/components/RealisationCard/index.tsx
@@ -44,7 +44,7 @@ export function RealisationCard({ realisation }: RealisationCardProps) {
 
       <p className={styles.chapo}>{realisation.chapo}</p>
 
-      <PoleTagList legende={`Pôles mobilisés — ${realisation.titre}`} poles={realisation.poles} />
+      <PoleTagList legende={`Pôles mobilisés pour ${realisation.titre}`} poles={realisation.poles} />
     </article>
   )
 }

--- a/src/components/SiteFooter/index.tsx
+++ b/src/components/SiteFooter/index.tsx
@@ -86,7 +86,7 @@ export function SiteFooter() {
 
       <div className={styles.bas}>
         <p className={styles.mentions}>
-          {SITE_IDENTITY.nom} — {SITE_IDENTITY.titre} à {SITE_IDENTITY.ville}. Site conçu, développé
+          {SITE_IDENTITY.nom}. {SITE_IDENTITY.titre} à {SITE_IDENTITY.ville}. Site conçu, développé
           et exploité par moi-même.
         </p>
         <MotionToggle />

--- a/src/seo/site.ts
+++ b/src/seo/site.ts
@@ -29,7 +29,7 @@ export const SITE_IDENTITY = {
  */
 export const SITE_PROMESSE =
   'Un seul interlocuteur pour vos projets digitaux, du cadrage au run. ' +
-  'Celui qui cadre est celui qui code, qui mesure et qui exploite — et qui répond de tout.'
+  "Celui qui cadre est celui qui code, qui mesure et qui exploite. C'est lui qui répond de tout."
 
 /** Rayon d'intervention réellement couvert. */
 export const SITE_ZONE = ['Lille', 'Hauts-de-France', 'France'] as const


### PR DESCRIPTION
Issue #153.

`Closes #153` n'est pas utilisé : les PR visent `dev`, la branche par défaut est `main`, la mention ne fermerait rien. L'issue est à fermer à la main.

## Le gabarit de titre, avant et après

C'est l'endroit le plus vu du site : chaque onglet, chaque résultat de recherche, chaque partage de lien.

```
avant   template: `%s — ${SITE_IDENTITY.nom}`
après   template: `%s | ${SITE_IDENTITY.nom}`
```

Titre exact des onglets, relevé dans l'export statique après `npm run build` :

| Page | Avant | Après |
|------|-------|-------|
| `/services/data/` | `Data : le métier d'abord \| Lille — Jérôme Marichez` | `Data : le métier d'abord \| Lille \| Jérôme Marichez` |
| `/blog/` | `Blog : notes d'ingénierie, de data et de mesure — Jérôme Marichez` | `Blog : notes d'ingénierie, de data et de mesure \| Jérôme Marichez` |
| `/realisations/` | `Réalisations : ce que j'ai construit, et dans quel cadre — Jérôme Marichez` | `Réalisations : ce que j'ai construit, et dans quel cadre \| Jérôme Marichez` |

Le séparateur retenu n'est pas choisi au hasard : la barre verticale est **déjà le séparateur de titre du site**, dans le contenu (`Data : le métier d'abord | Lille`, `IA : règle métier, modèle ou LLM | Lille`). Une seule convention pour les titres, et c'est le glyphe le plus lisible dans un onglet étroit comme dans une SERP.

Pied de page, relevé à l'écran sur l'accueil :

```
avant   Jérôme Marichez — Ingénieur-conseil indépendant à Lille. Site conçu, développé et exploité par moi-même.
après   Jérôme Marichez. Ingénieur-conseil indépendant à Lille. Site conçu, développé et exploité par moi-même.
```

## Ce que le peigne fin a révélé au-delà de la liste de départ

Tout `src/` hors `contenu/` a été relu ligne à ligne. L'issue listait cinq occurrences ; il y en avait **onze**, dans neuf textes lus. Les quatre trouvées en plus :

| Fichier | Nature | Pourquoi c'est un texte lu |
|---------|--------|----------------------------|
| `src/app/manifest.ts:20` | `name` du manifeste d'application | Affiché par le navigateur et le système à l'épinglage du site |
| `src/seo/site.ts:32` | `SITE_PROMESSE` | Sert de `description` à toutes les métadonnées et au manifeste : c'est la promesse centrale, publiée |
| `src/components/PoleHero/index.tsx:78,82` | Prose rendue en bas des pages de pôle | Deux tirets d'incise dans un paragraphe visible |
| `src/components/MotionToggle/index.tsx:39` | Précision affichée à côté du bouton d'animation | Chaîne rendue, visible dans le pied de page et sous la scène de l'accueil |

Réécritures, toutes des reformulations et jamais des substitutions :

- **Promesse du site** : `… qui exploite — et qui répond de tout.` → `… qui exploite. C'est lui qui répond de tout.` Deux phrases. C'est **exactement la formulation déjà retenue dans `src/contenu/accueil.ts`** par la PR #152 : les deux supports disaient la même chose de deux façons, ils la disent maintenant de la même.
- **Description de la scène** (`HomeHero`, lue par un lecteur d'écran) : les deux tirets encadraient une incise au milieu d'une énumération, ce qui est illisible à la synthèse vocale. Découpé en deux phrases : `Quatre dalles de verre : ingénierie web, donnée, puis IA et SEA & UX côte à côte. Un même filet vertical les traverse : un seul interlocuteur, du cadrage au run.`
- **Légende du groupe d'étiquettes** (`RealisationCard`, lue par un lecteur d'écran) : `Pôles mobilisés — <titre>` → `Pôles mobilisés pour <titre>`. Rendu réel : « Pôles mobilisés pour Migrer une application mobile sans geler la roadmap ».
- **PoleHero** : virgules d'apposition autour de `l'ingénierie web`.
- **MotionToggle** : ` — réglage système` → ` (réglage système)`.

## Cas limites tranchés

1. **Le titre par défaut de `layout.tsx` prend la barre verticale, pas la virgule.** L'accueil, qui a son propre titre venu du contenu, écrit `Jérôme Marichez, ingénieur-conseil indépendant à Lille` avec une virgule et en bas de casse. Le `default` de `layout.tsx` n'est qu'un repli pour une page sans titre propre, et il consomme `SITE_IDENTITY.titre` dont la capitale ne se change pas ici : une virgule y produirait `Jérôme Marichez, Ingénieur-conseil…`. Le séparateur de titre a donc été préféré. À rouvrir si la virgule est jugée préférable.
2. **Empilement de deux barres sur les pages de pôle** : `Data : le métier d'abord | Lille | Jérôme Marichez`. Le point médian (`·`, déjà utilisé par les kickers du contenu) aurait distingué le suffixe de marque. La cohérence d'une seule convention pour les titres a été préférée. Dit ici plutôt que tranché en silence.
3. **`src/seo/site.ts` touché sur une seule ligne**, celle de `SITE_PROMESSE`. Aucun séparateur n'y est stocké : la seule occurrence était de la ponctuation de phrase dans un texte publié.
4. **`SlabScene.tsx:74` et `114`, et sept autres lignes de `.tsx`, ressemblent à du code mais sont des commentaires JSX** (`{/* … */}`), continués sur plusieurs lignes. Laissés intacts : c'est l'arbitrage du 2026-08-24. C'est l'illustration que la frontière ne suit ni les dossiers ni le premier caractère de la ligne.
5. **Le bloc `nextjs-agent-rules` du `CLAUDE.md`** n'est pas corrigeable : `node_modules/next/dist/server/lib/generate-agent-files.js` le réécrit à l'identique à chaque `next dev`. **Constaté par écrit dans la règle**, avec sa raison, pour qu'on n'y voie pas un oubli.

Le périmètre de la règle du `CLAUDE.md` a été corrigé au passage : il disait le contenu, la doc et lui-même, il dit maintenant aussi les textes lus du reste de `src/`, avec le tri ligne par ligne.

## Retour du second agent

Relecture par un agent sans contexte de rédaction, à qui seules les phrases avant/après ont été données. Huit textes sur neuf validés sans réserve (sens identique, français juste, aucun chiffre ni intitulé déplacé, ni tiret cadratin ni emoji). **Une réécriture proposée** : `Pôles mobilisés sur <titre>` → `Pôles mobilisés pour <titre>`, « pour » exprimant plus naturellement le lien entre les pôles et le projet. **Intégrée**, aucun refus à motiver.

## Vérification

- **Au rendu**, pas en diff : `npm run build` puis relevé des `<title>` et du pied de page sur l'export statique. **Zéro tiret cadratin dans tout `out/`**, HTML et manifeste compris.
- `node scripts/budgets.mjs` : **95 à 100 sur les 4 catégories et les 7 pages**, **axe-core à 0 violation bloquante et 0 mineure** sur les 7 pages, libellés accessibles touchés compris.
- `make lint`, `make test`, `npm run build` verts.
- **Commentaires inchangés** : 625 occurrences dans `src/` avant, 614 après, soit exactement les 11 textes lus corrigés. Les 614 restantes sont toutes en commentaire, vérifiées une à une.
- Ni `next-env.d.ts` ni `package-lock.json` dans le diff.
