### PR TITLE
chore: Biome epingle, et le refus de react-glassy documente

### DIFF
--- a/.github/workflows/ci-dev-lint.yml
+++ b/.github/workflows/ci-dev-lint.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Biome
-        run: npx @biomejs/biome@^2.0.0 check .
+        run: npx @biomejs/biome@2.5.7 check .
       - name: Limite 300 lignes / fichier
         run: ./scripts/check-max-lines.sh

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help: ## Liste les commandes disponibles
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
 
 lint: ## Biome sur tout le dépôt + limite 300 lignes/fichier
-	npx @biomejs/biome@^2.0.0 check .
+	npx @biomejs/biome@2.5.7 check .
 	./scripts/check-max-lines.sh
 
 type-check: ## Vérification des types TypeScript, sans émission de fichiers

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "assist": {
     "actions": { "source": { "organizeImports": "on" } }
   },

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -51,6 +51,46 @@ make lint
 | `remind-docs.sh` | PostToolUse (Write/Edit) | Rappelle de mettre à jour README/docs après une modification de code (au plus une fois par quart d'heure). |
 | `remind-tests.sh` | PostToolUse (Write/Edit) | Rappelle la politique de tests (unitaire systématique, intégration/e2e sur demande), même throttle. |
 
+## Dépendances évaluées puis écartées
+
+Cette section existe pour éviter de refaire une évaluation déjà faite. Un paquet qui
+figure ici a été examiné, et la raison de son refus est écrite.
+
+### `react-glassy` : évalué, refusé, le verre reste maison
+
+Le paquet avait été demandé pour vitrer les boutons, la navbar et le formulaire de
+contact (issue #142). Il est **écarté**. Le système de verre du dépôt (constitué de
+`src/app/verre.css` et des composants qui s'appuient dessus) continue de porter l'effet.
+
+**Refusé d'abord par le garde-fou du dépôt lui-même**, `check-new-dependency.sh`, en
+décision `deny` non levable. Relevé du 2026-08-24 :
+
+| Critère du hook | Seuil | `react-glassy` |
+|---|---|---|
+| Contributeurs GitHub | >= 3 | **1** |
+| Étoiles (voie alternative) | 1000 | **0** |
+| Éditeur de confiance | liste du hook | `zeroqs`, absent |
+| Fraîcheur, SemVer | | conformes |
+
+Un audit du paquet, mené **sans l'installer**, a par ailleurs relevé quatre
+incompatibilités avec la calibration mesurée de la PR #135 :
+
+1. **Aucun `saturate` dans son CSS.** Le jeton `--verre-saturation-bande: 1.3` n'aurait
+   aucun point d'entrée : la saturation mesurée serait simplement perdue.
+2. **Aucun repli `@supports`.** Là où `backdrop-filter` n'existe pas, il ne reste chez
+   lui qu'un voile de 15 %, contre les 86 % en clair et 73 % en sombre du système maison.
+   Le texte posé dessus deviendrait illisible sur ces navigateurs.
+3. **Aucune directive `"use client"` dans son `dist`.** Vitrer la navbar la ferait
+   basculer en composant client, et elle vit dans le layout racine : le surcoût de
+   JavaScript porterait sur les sept pages d'un site qui vise Lighthouse >= 95.
+4. **Ses presets `frost` sont des filtres de déplacement**, de scale 60 à 150. C'est
+   précisément la traînée colorée que `src/app/verre.css` interdit sur les bandes, pour
+   la raison qui y est documentée : une bande porte du texte, un panneau non.
+
+Vendorer l'effet ou abaisser le seuil du hook ont tous deux été écartés : le premier
+reprend la dette sans le paquet, le second désarme un contrôle pour un besoin cosmétique.
+*(Arbitrage rendu par Jérôme MARICHEZ le 2026-08-24, issue #142.)*
+
 ## Subagents Claude Code (`.claude/agents/`)
 
 Trois subagents pré-définis portent le routage de modèles (`opus-architect`,

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -12,6 +12,22 @@ Toutes les opérations passent par `make` (voir `Makefile`) : agnostique, docume
   `console.*` dans le code applicatif : passer par le **service de log** du projet
   (voir [`frontend-practices.md`](./frontend-practices.md)) ; l'`override` de
   `biome.json` lève la règle pour les fichiers de log, config et scripts.
+- **Version épinglée à l'exact : `2.5.7`.** Sans `^` ni `~`, et aux trois endroits qui
+  invoquent l'outil : `package.json`, le `Makefile` et le workflow `ci-dev-lint.yml`.
+  Deux raisons. D'abord, Biome durcit ses règles en mineure : la 2.5.7 a rendu
+  `lint/performance/noImgElement` plus sévère, et une prochaine mineure peut transformer
+  un avertissement en erreur sur un fichier que personne n'aura touché. Ensuite, la CI et
+  le poste local doivent juger le code avec le même outil : un contrôle dont la définition
+  change toute seule n'est plus un contrôle. La montée de version devient ainsi un acte
+  volontaire, visible dans un diff, plutôt qu'un effet de bord de la résolution npm. Le
+  champ `$schema` de `biome.json` suit la même version.
+  *(Arbitrage de Jérôme MARICHEZ, issue #150, 2026-08-24.)*
+- **Une règle qui a tort se lève à l'endroit exact**, avec sa raison écrite
+  (`// biome-ignore <règle>: <raison>`), jamais dans `biome.json` pour tout le dépôt.
+  Seul cas en vigueur : `noImgElement` sur `src/components/CertificationList/index.tsx`.
+  Les logos de certification sont des SVG, et `/_next/image` les refuse tant que
+  `dangerouslyAllowSVG` vaut `false`, ce qu'il doit rester pour des raisons de sécurité.
+  La règle garde toute sa valeur partout ailleurs, elle n'est donc pas assouplie.
 - **`scripts/check-max-lines.sh`** : échoue si un fichier source (`.ts`, `.tsx`,
   `.js`, `.jsx`) dépasse **300 lignes**. Exécuté par `make lint`, par la CI et par
   un hook Claude Code. Remède : extraire (sous-composants, hooks, services),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@axe-core/puppeteer": "^4.13.0",
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "2.5.7",
         "@stryker-mutator/core": "^9.0.0",
         "@stryker-mutator/jest-runner": "^9.0.0",
         "@testing-library/react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@axe-core/puppeteer": "^4.13.0",
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.5.7",
     "@stryker-mutator/core": "^9.0.0",
     "@stryker-mutator/jest-runner": "^9.0.0",
     "@testing-library/react": "^16.3.0",

--- a/src/components/CertificationList/index.tsx
+++ b/src/components/CertificationList/index.tsx
@@ -45,6 +45,7 @@ export function CertificationList({ certifications }: CertificationListProps) {
         <li className={styles.item} key={certification.intitule}>
           <span className={styles.plaque}>
             {certification.logo ? (
+              // biome-ignore lint/performance/noImgElement: les logos sont des SVG, et /_next/image les refuse tant que `dangerouslyAllowSVG` vaut `false`, ce qu'il doit rester pour des raisons de sécurité. La règle vise le cas général de l'image bitmap non optimisée ; ici elle a tort, pas le code. Raisonnement complet dans le commentaire de tête du composant.
               <img
                 alt={certification.organisme}
                 className={styles.logo}


### PR DESCRIPTION
Deux points d'hygiène d'outillage, réunis sur une seule branche : les issues #150 et #142
modifient toutes deux `docs/tooling.md`. Deux notes courtes dans le même fichier, séparées
en deux branches, produiraient un conflit garanti sur des lignes voisines pour aucun
bénéfice. Chaque point garde son commit.

## Point 1 : Biome épinglé (issue #150)

`@biomejs/biome` flottait en `^2.0.0` à **trois** endroits, pas un seul : `package.json`,
le `Makefile` (`npx @biomejs/biome@^2.0.0 check .`) et le workflow `ci-dev-lint.yml`. La
résolution npx ramenait **2.5.10** en local là où `package-lock.json` portait **2.5.7** :
l'outil qui décide de la qualité du code n'était donc déjà pas le même en CI et sur le
poste.

**Version retenue : `2.5.7` exacte**, sans `^` ni `~`, aux trois endroits. C'est la
version que le lock portait déjà : la PR épingle l'existant, elle ne monte pas de version.
Le `$schema` de `biome.json` passe de 2.5.2 à 2.5.7 pour suivre. `package-lock.json` est
régénéré par `npm install --package-lock-only`, il ne change qu'à cette ligne.

### Neutralisation de `noImgElement`, sans affaiblir la règle

`biome.json` n'est **pas** touché côté règles : aucune règle désactivée, aucun seuil
abaissé, aucun `override` ajouté. L'avertissement est levé à l'endroit exact, dans
`src/components/CertificationList/index.tsx`, par un commentaire qui porte sa raison :

```
// biome-ignore lint/performance/noImgElement: les logos sont des SVG, et /_next/image
// les refuse tant que `dangerouslyAllowSVG` vaut `false`, ce qu'il doit rester pour des
// raisons de sécurité. La règle vise le cas général de l'image bitmap non optimisée ;
// ici elle a tort, pas le code. Raisonnement complet dans le commentaire de tête du
// composant.
```

La règle continue donc de s'appliquer sur les 209 autres fichiers du dépôt. C'est la
règle 8 du `CLAUDE.md` : le vert s'obtient par une correction réelle, jamais par un
contrôle assoupli.

`make lint` ne renvoie plus aucun avertissement. Il reste **un `info`**, non lié à cette
PR : Biome 2.5.x déprécie le champ `linter.rules.recommended` au profit de `preset`. Ce
n'est ni une erreur ni un avertissement, et maintenant que la version est épinglée, cette
information est stable. La migration est un sujet à part, elle n'est pas faite ici.

## Point 2 : le refus de `react-glassy` documenté (issue #142)

Jérôme MARICHEZ avait demandé d'installer `react-glassy` et de l'utiliser sur les boutons,
la navbar et le formulaire. Le paquet a été **refusé par le garde-fou du dépôt lui-même**,
`.claude/hooks/check-new-dependency.sh`, en décision `deny` non levable.

**Rien n'est installé, et le hook n'est pas touché.** Le diff le montre : `package.json`
ne gagne aucune dépendance, et la seule ligne qui y change est celle de Biome.

Texte de la note ajoutée à `docs/tooling.md`, dans une nouvelle section
**Dépendances évaluées puis écartées** :

> Cette section existe pour éviter de refaire une évaluation déjà faite. Un paquet qui
> figure ici a été examiné, et la raison de son refus est écrite.
>
> ### `react-glassy` : évalué, refusé, le verre reste maison
>
> Le paquet avait été demandé pour vitrer les boutons, la navbar et le formulaire de
> contact (issue #142). Il est **écarté**. Le système de verre du dépôt (constitué de
> `src/app/verre.css` et des composants qui s'appuient dessus) continue de porter l'effet.
>
> **Refusé d'abord par le garde-fou du dépôt lui-même**, `check-new-dependency.sh`, en
> décision `deny` non levable. Relevé du 2026-08-24 :
>
> | Critère du hook | Seuil | `react-glassy` |
> |---|---|---|
> | Contributeurs GitHub | >= 3 | **1** |
> | Étoiles (voie alternative) | 1000 | **0** |
> | Éditeur de confiance | liste du hook | `zeroqs`, absent |
> | Fraîcheur, SemVer | | conformes |
>
> Un audit du paquet, mené **sans l'installer**, a par ailleurs relevé quatre
> incompatibilités avec la calibration mesurée de la PR #135 :
>
> 1. **Aucun `saturate` dans son CSS.** Le jeton `--verre-saturation-bande: 1.3` n'aurait
>    aucun point d'entrée : la saturation mesurée serait simplement perdue.
> 2. **Aucun repli `@supports`.** Là où `backdrop-filter` n'existe pas, il ne reste chez
>    lui qu'un voile de 15 %, contre les 86 % en clair et 73 % en sombre du système
>    maison. Le texte posé dessus deviendrait illisible sur ces navigateurs.
> 3. **Aucune directive `"use client"` dans son `dist`.** Vitrer la navbar la ferait
>    basculer en composant client, et elle vit dans le layout racine : le surcoût de
>    JavaScript porterait sur les sept pages d'un site qui vise Lighthouse >= 95.
> 4. **Ses presets `frost` sont des filtres de déplacement**, de scale 60 à 150. C'est
>    précisément la traînée colorée que `src/app/verre.css` interdit sur les bandes, pour
>    la raison qui y est documentée : une bande porte du texte, un panneau non.
>
> Vendorer l'effet ou abaisser le seuil du hook ont tous deux été écartés : le premier
> reprend la dette sans le paquet, le second désarme un contrôle pour un besoin
> cosmétique.
> *(Arbitrage rendu par Jérôme MARICHEZ le 2026-08-24, issue #142.)*

## Relecture par un second agent

Les deux passages de `docs/tooling.md` sont passés par `haiku-mechanic`, sans le contexte
de rédaction, sur les quatre points du `CLAUDE.md` (fidélité, table des interdits, ligne
éditoriale, tiret cadratin). Verdict : aucun tiret cadratin, aucun emoji, ton conforme,
chaque affirmation sourcée. **Une remarque, intégrée** : la phrase d'ouverture de la note
`react-glassy` posait `src/app/verre.css` et les composants en apposition d'un sujet
singulier, ce qui rendait l'accord du verbe ambigu à la lecture. Reformulée en incise
parenthétique.

## Vérifications

| Contrôle | Résultat |
|---|---|
| `make lint` | vert, **0 avertissement** (1 `info` de dépréciation Biome, sans rapport) |
| `make test` | vert |
| `npm run build` | vert, export statique intact |
| `node scripts/budgets.mjs` | 7 pages, 4 catégories, toutes à la cible : Perf 95 à 99, A11y 100, Bonnes prat. 100, SEO 100 |
| `grep -n "—" docs/tooling.md` | aucun résultat |
| Nouvelle dépendance | aucune |

`Closes` n'est pas employé : ici les PR visent `dev` alors que la branche par défaut est
`main`, donc `Closes` ne fermerait rien. Les issues **#150** et **#142** sont à fermer à
la main après la fusion.

https://claude.ai/code/session_01Ku16fxvGEdhuGVgnYjXN6R
