### PR TITLE
feat: Storybook est installe et relie aux composants

### DIFF
--- a/.github/workflows/ci-dev-storybook.yml
+++ b/.github/workflows/ci-dev-storybook.yml
@@ -1,0 +1,28 @@
+name: ci-dev-storybook
+# Check rapide (PR -> dev) : le catalogue de composants se construit.
+#
+# C'est un AJOUT de contrôle, jamais l'assouplissement d'un autre. Il existe pour une
+# raison précise : le dépôt a annoncé Storybook pendant des mois sans l'avoir installé,
+# et personne ne s'en est aperçu parce que rien ne le construisait (issue #140). Un
+# catalogue qui n'est pas construit en intégration pourrit en silence, exactement comme
+# la cible `make storybook` avait pourri.
+#
+# `storybook build` compile toutes les stories : une story qui référence un composant
+# supprimé, une prop renommée ou un contenu disparu fait échouer ce job. C'est le seul
+# endroit où cette rupture se voit avant qu'un développeur ouvre le catalogue.
+on:
+  pull_request:
+    branches: [dev]
+jobs:
+  storybook-build:
+    name: Build du catalogue (make storybook-build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Installation
+        run: make install
+      - name: Build du catalogue
+        run: make storybook-build

--- a/.storybook/jeux-de-donnees.ts
+++ b/.storybook/jeux-de-donnees.ts
@@ -1,0 +1,59 @@
+// .storybook/jeux-de-donnees.ts — jeromemarichez-fr
+//
+// Les données que les stories donnent à voir.
+//
+// Elles ne sont pas inventées : ce sont **les contenus réels du site**, prélevés dans
+// `src/contenu/`. C'est la règle de `docs/storybook.md` — jamais de lorem ipsum pour des
+// données métier — et c'est aussi la seule façon d'avoir un catalogue qui vieillit avec
+// le site : une phrase recopiée ici dériverait du jour où le contenu changerait.
+//
+// Ce module vit dans `.storybook/` et non dans `src/` parce qu'il n'appartient qu'à
+// l'outil : rien de ce qu'il contient ne part au navigateur d'un visiteur.
+
+import { PAGE_ACCUEIL } from '../src/contenu/accueil'
+import { SECTIONS_DATA } from '../src/contenu/data-sections'
+import { SECTION_FIL_IA } from '../src/contenu/fil-ia'
+import { SECTIONS_IA } from '../src/contenu/ia-sections'
+import { SECTIONS_INGENIERIE_WEB } from '../src/contenu/ingenierie-web-sections'
+import type { IEditorialSection } from '../src/interfaces/IEditorialSection'
+import type { SectionKind } from '../src/interfaces/types'
+
+/**
+ * Le premier élément d'une liste, ou un échec bruyant.
+ *
+ * `noUncheckedIndexedAccess` est actif : indexer un tableau rend `T | undefined`, et le
+ * catalogue n'a aucune raison d'être moins strict que le site. Une story qui désigne un
+ * contenu disparu doit s'arrêter en le disant, plutôt que rendre un composant vide qu'on
+ * prendrait pour un défaut de style.
+ */
+export function exiger<T>(liste: readonly T[], quoi: string): T {
+  const [premier] = liste
+  if (premier === undefined) throw new Error(`${quoi} : aucun contenu, le site a changé.`)
+  return premier
+}
+
+/** La première section d'une nature donnée, dans l'ordre de la page. */
+function sectionDeNature(sections: readonly IEditorialSection[], kind: SectionKind) {
+  return exiger(
+    sections.filter((section) => section.kind === kind),
+    `section de nature « ${kind} »`,
+  )
+}
+
+/** La section de preuves de l'accueil : celle qui répond aux objections par des chiffres. */
+export const SECTION_PREUVES = exiger(PAGE_ACCUEIL.sections, 'section de l’accueil')
+
+/** Un chapitre de page de pôle, le rendu le plus courant du site. */
+export const SECTION_CHAPITRE = sectionDeNature(SECTIONS_INGENIERIE_WEB, 'chapitre')
+
+/** Une charnière : la section qui passe la main d'un pôle au suivant. */
+export const SECTION_CHARNIERE = sectionDeNature(SECTIONS_INGENIERIE_WEB, 'charniere')
+
+/** Le fil transverse de la page IA : un axe de méthode, jamais une offre de plus. */
+export const SECTION_FIL = SECTION_FIL_IA
+
+/** Le premier chapitre de la page data, dont les blocs portent des preuves chiffrées. */
+export const SECTION_DATA = sectionDeNature(SECTIONS_DATA, 'chapitre')
+
+/** Le premier chapitre de la page IA. */
+export const SECTION_IA = sectionDeNature(SECTIONS_IA, 'chapitre')

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,46 @@
+// .storybook/main.ts — jeromemarichez-fr
+//
+// Catalogue des composants. Le framework est `@storybook/nextjs-vite` : c'est celui qui
+// sait résoudre `next/font`, `next/image` et `next/link` hors d'un serveur Next, ce dont
+// la moitié des composants du site a besoin. Vite n'est présent que pour lui, et
+// uniquement en `devDependencies` : rien de tout ceci n'entre dans `next build`, qui
+// reste seul responsable de ce qui part au navigateur.
+
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { StorybookConfig } from '@storybook/nextjs-vite'
+
+const racine = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const config: StorybookConfig = {
+  // Les stories sont colocalisées avec leur composant (docs/storybook.md), jamais
+  // regroupées dans un dossier à part : une story qui vit loin de son composant cesse
+  // d'être mise à jour avec lui.
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
+
+  framework: {
+    name: '@storybook/nextjs-vite',
+    options: {},
+  },
+
+  // `output: 'export'` du site n'a pas d'équivalent ici, et n'en a pas besoin : le
+  // catalogue est un outil de développement, pas une page publiée.
+  staticDirs: ['../public'],
+
+  // Le site mesure son audience avec consentement (docs/rgpd.md). L'outil qui sert à le
+  // construire n'a aucune raison d'être moins regardant que lui.
+  core: { disableTelemetry: true },
+
+  viteFinal: async (viteConfig) => {
+    // `@/` est l'alias du dépôt (tsconfig.json). Vite ne lit pas `paths`, il faut le
+    // lui redire, sinon aucun composant ne résout ses imports.
+    viteConfig.resolve = viteConfig.resolve ?? {}
+    viteConfig.resolve.alias = {
+      ...viteConfig.resolve.alias,
+      '@': join(racine, 'src'),
+    }
+    return viteConfig
+  },
+}
+
+export default config

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,107 @@
+// .storybook/preview.tsx — jeromemarichez-fr
+//
+// L'enveloppe commune à toutes les stories. Elle a un seul travail, mais il commande
+// tout le reste : rendre un composant dans les mêmes conditions que le site.
+//
+// Les composants du dépôt ne portent aucune couleur en dur, par règle (docs/design.md) :
+// ils consomment des jetons (`--fond`, `--encre`, `--accent`) déclarés dans les quatre
+// feuilles globales. Une story qui ne les charge pas n'affiche pas un composant sobre,
+// elle affiche un composant faux.
+
+import type { Decorator, Preview } from '@storybook/nextjs-vite'
+import { useEffect } from 'react'
+import { GlassRefraction } from '../src/components/GlassRefraction'
+import { FONT_VARIABLES } from '../src/typography/fonts'
+import { appliquerTheme, type Theme } from './theme-media'
+
+// L'ordre est celui de `src/app/layout.tsx`, et il n'est pas indifférent : `poles.css`,
+// `verre.css` et `lavis.css` s'appuient sur les jetons de `globals.css`, et `lavis.css`
+// dérive les siens de `--accent`, que `poles.css` mappe sur le pôle courant.
+import '../src/app/globals.css'
+import '../src/app/poles.css'
+import '../src/app/verre.css'
+import '../src/app/lavis.css'
+
+/** Les valeurs du contrôle de pôle. `aucun` est le cuivre du socle, hors `data-pole`. */
+const POLES = ['aucun', 'ingenierie-web', 'data', 'ia', 'sea-ux'] as const
+
+/**
+ * Pose les jetons, les fontes et la teinte de pôle autour de chaque story.
+ *
+ * `data-pole` est posé sur l'enveloppe, exactement comme une section de pôle le fait sur
+ * le site : `poles.css` fait tout le reste, et aucun composant n'a besoin de savoir de
+ * quelle couleur il est. C'est la même mécanique qu'en production, pas une imitation.
+ */
+const enveloppe: Decorator = (Story, contexte) => {
+  const theme = contexte.globals.theme as Theme
+  const pole = contexte.globals.pole as (typeof POLES)[number]
+
+  // Après la peinture : les feuilles injectées par Vite doivent être dans le document
+  // avant qu'on en réécrive les règles média. Le `color-scheme` va sur la racine et non
+  // sur l'enveloppe, parce que c'est lui qui commande le fond du canevas et l'apparence
+  // native des contrôles de formulaire.
+  useEffect(() => {
+    document.documentElement.style.colorScheme = appliquerTheme(theme)
+  }, [theme])
+
+  return (
+    // `position: relative` et **aucun fond** : c'est exactement ce que `globals.css` fait
+    // au `<body>`. Le fond de la page vient de la feuille du site et se propage au
+    // canevas ; peindre un fond ici passerait par-dessus `.fond-atelier`, dont le
+    // `z-index: -1` le place derrière le contenu mais devant le canevas. Le verre
+    // n'aurait alors plus aucune trame à laisser voir.
+    <div
+      className={FONT_VARIABLES}
+      data-pole={pole === 'aucun' ? undefined : pole}
+      style={{ minHeight: '100vh', padding: '2rem', position: 'relative' }}
+    >
+      {/* Le fond d'atelier et le filtre de réfraction sont déclarés une fois par page sur
+          le site. Sans eux, les panneaux de verre perdent la trame qu'ils sont censés
+          laisser voir, et l'effet ne se juge plus. */}
+      <div aria-hidden="true" className="fond-atelier" />
+      <GlassRefraction />
+      <Story />
+    </div>
+  )
+}
+
+const preview: Preview = {
+  decorators: [enveloppe],
+
+  globalTypes: {
+    theme: {
+      description: 'Thème clair ou sombre. « auto » suit le système, comme le site.',
+      toolbar: {
+        title: 'Thème',
+        icon: 'contrast',
+        items: [
+          { value: 'auto', title: 'Auto (système)' },
+          { value: 'clair', title: 'Clair' },
+          { value: 'sombre', title: 'Sombre' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+    pole: {
+      description: 'Teinte de pôle appliquée par `data-pole`, comme sur le site.',
+      toolbar: {
+        title: 'Pôle',
+        icon: 'paintbrush',
+        items: POLES.map((valeur) => ({ value: valeur, title: valeur })),
+        dynamicTitle: true,
+      },
+    },
+  },
+
+  initialGlobals: { theme: 'auto', pole: 'aucun' },
+
+  parameters: {
+    // Le fond vient des jetons du site, pas d'une palette de Storybook : deux sources de
+    // couleur donneraient deux vérités, et celle qui compte est celle du site.
+    backgrounds: { disable: true },
+    controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } },
+    layout: 'fullscreen',
+  },
+}
+
+export default preview

--- a/.storybook/theme-media.ts
+++ b/.storybook/theme-media.ts
@@ -1,0 +1,81 @@
+// .storybook/theme-media.ts — jeromemarichez-fr
+//
+// Forcer le thème d'une story sans toucher au CSS du site.
+//
+// Le site n'a pas de bascule de thème : tout son thème sombre tient dans quatre règles
+// `@media (prefers-color-scheme: dark)` (`globals.css`, `poles.css`, `verre.css`,
+// `lavis.css`). Un catalogue qui ne montrerait qu'une des deux ambiances rendrait
+// invisible la moitié du travail de contraste.
+//
+// La solution retenue réécrit au runtime le `mediaText` de ces règles via le CSSOM :
+// `all` pour que la règle s'applique toujours (sombre forcé), `not all` pour qu'elle ne
+// s'applique jamais (clair forcé), et la valeur d'origine pour rendre la main au système.
+// Aucun jeton n'est dupliqué, aucun fichier du site n'est modifié, et une teinte ajoutée
+// demain au thème sombre est prise en compte sans rien changer ici.
+
+/** Les trois positions du contrôle de thème de la barre d'outils. */
+export type Theme = 'auto' | 'clair' | 'sombre'
+
+const CONDITION = 'prefers-color-scheme'
+
+/**
+ * Le `mediaText` d'origine de chaque règle, retenu à la première réécriture.
+ *
+ * Une `WeakMap` plutôt qu'un tableau : Vite remplace les feuilles de style à chaud, et
+ * une liste figée retiendrait des règles mortes tout en manquant les nouvelles.
+ */
+const origines = new WeakMap<CSSMediaRule, string>()
+
+/**
+ * Les règles média du document qui portent sur le thème.
+ *
+ * Une feuille servie par un autre domaine lève à la lecture de `cssRules` : le cas est
+ * absorbé plutôt que propagé, sinon une seule feuille inaccessible priverait le
+ * catalogue de sa bascule.
+ */
+function reglesDeTheme(): CSSMediaRule[] {
+  const trouvees: CSSMediaRule[] = []
+  for (const feuille of Array.from(document.styleSheets)) {
+    let regles: CSSRuleList
+    try {
+      regles = feuille.cssRules
+    } catch {
+      continue
+    }
+    for (const regle of Array.from(regles)) {
+      if (regle instanceof CSSMediaRule && regle.conditionText.includes(CONDITION)) {
+        trouvees.push(regle)
+      }
+    }
+  }
+  return trouvees
+}
+
+/** Le `mediaText` à poser sur une règle de thème sombre, selon la position choisie. */
+function cible(theme: Theme, origine: string): string {
+  if (theme === 'sombre') return 'all'
+  if (theme === 'clair') return 'not all'
+  return origine
+}
+
+/**
+ * Applique le thème demandé à tout le document.
+ *
+ * Retourne le `color-scheme` à poser sur l'enveloppe de la story : `globals.css` déclare
+ * `color-scheme: light dark` sur `:root`, ce qui laisserait les contrôles de formulaire
+ * et le fond du canevas suivre le système même quand les jetons, eux, ont basculé.
+ */
+export function appliquerTheme(theme: Theme): string {
+  for (const regle of reglesDeTheme()) {
+    let origine = origines.get(regle)
+    if (origine === undefined) {
+      origine = regle.media.mediaText
+      origines.set(regle, origine)
+    }
+    const voulu = cible(theme, origine)
+    if (regle.media.mediaText !== voulu) regle.media.mediaText = voulu
+  }
+  if (theme === 'sombre') return 'dark'
+  if (theme === 'clair') return 'light'
+  return 'light dark'
+}

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ budget-perf: ## Budget de performance seul (Lighthouse, mobile bride)
 budget-a11y: ## Budget d'accessibilite seul (axe-core) — rapide
 	node scripts/budgets.mjs a11y
 
-storybook: ## Storybook en local (http://localhost:6006) — après npx storybook@latest init
+storybook: ## Catalogue de composants en local (http://localhost:6006)
 	@if [ -d front ]; then cd front && npm run storybook; else npm run storybook; fi
 
 storybook-build: ## Build statique Storybook

--- a/README.md
+++ b/README.md
@@ -515,6 +515,20 @@ L'application est servie sur **http://localhost:3000**. Les variables d'environn
 requises sont décrites dans `.env.example` (elles sont validées par un schéma Zod au
 démarrage).
 
+### Catalogue de composants
+
+```bash
+make storybook          # catalogue local (http://localhost:6006)
+make storybook-build    # build statique, dans storybook-static/ (non versionné)
+```
+
+Trente et un composants sur trente-quatre y ont une story, chacune colocalisée avec son
+composant. Le catalogue charge les
+jetons CSS du site et ouvre deux réglages que les pages ne permettent pas : le thème
+clair ou sombre, et les quatre teintes de pôle. Les paquets Storybook sont uniquement en
+`devDependencies`, donc rien n'en part au navigateur d'un visiteur. Détails,
+conventions et exclusions motivées : [`docs/storybook.md`](./docs/storybook.md).
+
 ## 🧪 Tests & qualité
 
 ```bash

--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,7 @@
       "!dist",
       "!build",
       "!coverage",
+      "!storybook-static",
       "!.claude/worktrees",
       "!**/postman_collection.json",
       "!next-env.d.ts"

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -6,7 +6,7 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
 
 | Déclencheur | Workflows | Objectif |
 |-------------|-----------|----------|
-| **PR → `dev`** | `ci-dev-lint`, `ci-dev-types`, `ci-dev-tests`, `ci-dev-a11y`, `ci-dev-nginx`, `ci-dev-docker` | Checks **rapides** : lint (Biome + limite 300 lignes), vérification des types, tests unitaires et intégration, contrôle d'accessibilité (axe), validation de la configuration nginx de production. |
+| **PR → `dev`** | `ci-dev-lint`, `ci-dev-types`, `ci-dev-tests`, `ci-dev-a11y`, `ci-dev-nginx`, `ci-dev-docker`, `ci-dev-storybook` | Checks **rapides** : lint (Biome + limite 300 lignes), vérification des types, tests unitaires et intégration, contrôle d'accessibilité (axe), validation de la configuration nginx de production, build du catalogue de composants. |
 | **PR → `main`** | `ci-main-e2e`, `ci-main-system`, `ci-main-build`, `ci-main-budgets` | Checks **complets** avant production : e2e navigateur, tests système, build, budgets Lighthouse + axe. |
 
 ## Jobs
@@ -23,6 +23,14 @@ Deux familles de pipelines, alignées sur le [workflow Git](./git-workflow.md) :
   Cypress y chargent le `expect()` de Chai, qui écrase celui de Jest ; Cypress
   type-vérifie ses propres specs.
 - **tests (dev)** : unitaires + intégration, front et back.
+- **storybook (dev)** : `make storybook-build`, le build statique du catalogue de
+  composants. C'est un **ajout** de contrôle, pas l'assouplissement d'un autre, et il a
+  une raison datée : le dépôt a annoncé Storybook pendant des mois sans l'avoir installé,
+  et personne ne s'en est aperçu parce que rien ne le construisait (issue #140).
+  `storybook build` compile toutes les stories : une story qui référence un composant
+  supprimé, une prop renommée ou un contenu disparu fait échouer la PR. Sans ce job, la
+  rupture n'apparaîtrait qu'au prochain développeur qui ouvrirait le catalogue, c'est-à-dire
+  potentiellement jamais.
 - **e2e (main)** : `make test-e2e`, le harnais `scripts/e2e.mjs` construit l'export
   statique si `out/` manque, le sert sur `127.0.0.1:E2E_PORT` (4173 par défaut) avec les
   règles de résolution de `docker/nginx.conf`, **attend que le port réponde** (sonde

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -1,32 +1,114 @@
 # Storybook
 
-<!-- TODO : compléter après `npx storybook@latest init`. -->
-
 ## Rôle
 
 Catalogue vivant des composants React : développement isolé, documentation visuelle,
-base pour les revues design et les tests visuels.
+base pour les revues design.
 
-## Conventions
-
-- Une story par composant réutilisable : `<Composant>.stories.tsx`, **à côté du composant**.
-- Chaque story couvre les **états significatifs** (défaut, chargement, erreur, vide, désactivé).
-- Les stories utilisent des **fixtures réalistes** (jamais de lorem ipsum pour les données métier).
-
-> **Sans Storybook** : si le projet n'active pas Storybook, ce sont les **tests
-> unitaires (RTL)** qui couvrent ces mêmes états significatifs : ils tiennent lieu
-> de catalogue. Le routage vers `opus-frontend` reste conditionnel à la présence de
-> Storybook (voir [`model-routing.md`](./model-routing.md)).
+Sur ce site, il sert surtout à une chose que les pages ne savent pas faire : montrer les
+**états qu'on ne peut pas atteindre en naviguant**. Le refus d'un formulaire de contact
+vide, le lien d'évitement au focus, les cinq figures d'article côte à côte, les quatre
+teintes de pôle sur un même composant. Chacun de ces états existe en production, aucun
+ne se laisse observer sans effort.
 
 ## Commandes
 
 ```bash
 make storybook          # démarrage local (http://localhost:6006)
-make storybook-build    # build statique (déployable)
+make storybook-build    # build statique, dans storybook-static/ (non versionné)
 ```
+
+## L'installation
+
+| Paquet | Rôle |
+|--------|------|
+| `storybook` | le noyau et la ligne de commande |
+| `@storybook/nextjs-vite` | le framework : il résout `next/font`, `next/image` et `next/link` hors d'un serveur Next |
+| `vite` | le bundler dont dépend le framework |
+
+Les trois sont en **`devDependencies` uniquement**. Rien n'entre dans `next build`, donc
+rien ne part au navigateur d'un visiteur : le poids du JavaScript des pages est
+inchangé, et l'export statique n'est pas concerné.
+
+La configuration tient dans quatre fichiers :
+
+- `.storybook/main.ts` : le framework, où chercher les stories, l'alias `@/` que Vite ne
+  lit pas dans `tsconfig.json`, et la télémétrie désactivée ;
+- `.storybook/preview.tsx` : l'enveloppe commune, décrite ci-dessous ;
+- `.storybook/theme-media.ts` : la bascule de thème ;
+- `.storybook/jeux-de-donnees.ts` : les contenus réels prélevés dans `src/contenu/`.
+
+## Les jetons, le piège de ce dépôt
+
+**Aucun composant du site ne porte de couleur en dur** : ils consomment des jetons
+déclarés dans quatre feuilles globales. Une story qui ne les charge pas n'affiche pas un
+composant sobre, elle affiche un composant faux.
+
+`preview.tsx` importe donc `globals.css`, `poles.css`, `verre.css` puis `lavis.css`
+**dans l'ordre exact de `src/app/layout.tsx`**. L'ordre n'est pas indifférent : les trois
+dernières s'appuient sur les jetons de la première, et `lavis.css` dérive les siens de
+`--accent`, que `poles.css` mappe sur le pôle courant.
+
+L'enveloppe pose aussi `FONT_VARIABLES` (les deux familles chargées par `next/font`), le
+fond d'atelier et le filtre de réfraction, comme la mise en page racine les pose.
+
+Un détail qui a coûté un aller-retour : **l'enveloppe ne peint aucun fond**. Le fond de
+la page vient de `globals.css`, qui le pose sur le `<body>` d'où il se propage au
+canevas. Peindre un fond sur l'enveloppe passerait par-dessus `.fond-atelier`, dont le
+`z-index: -1` le place derrière le contenu mais devant le canevas : le verre n'aurait
+alors plus aucune trame à laisser voir, et il n'y aurait plus moyen d'en juger l'effet.
+
+## Les deux contrôles de la barre d'outils
+
+**Thème** (auto, clair, sombre). Le site n'a pas de bascule : tout son thème sombre tient
+dans quatre règles `@media (prefers-color-scheme: dark)`. Le contrôle réécrit au runtime
+le `mediaText` de ces règles via le CSSOM : `all` pour forcer le sombre, `not all` pour
+forcer le clair, la valeur d'origine pour rendre la main au système. **Aucun jeton n'est
+dupliqué et aucun fichier du site n'est modifié** : une teinte ajoutée demain au thème
+sombre est prise en compte sans rien changer au catalogue.
+
+**Pôle** (aucun, et les quatre pôles). Le contrôle pose `data-pole` sur l'enveloppe,
+exactement comme une section de pôle le fait sur le site ; `poles.css` fait tout le
+reste. Sans ce contrôle, le catalogue ne montrerait que le cuivre par défaut. Quelques
+stories posent leur propre `data-pole` sur leurs éléments, `PoleEntries` et
+`ChainDiagram` notamment, et sont donc insensibles au contrôle : c'est le comportement du
+site.
+
+## Conventions
+
+- Une story par composant **réutilisable** : `<Composant>.stories.tsx`, **à côté du
+  composant**. Une story qui vit loin de son composant cesse d'être mise à jour avec lui.
+- Chaque story couvre les **états significatifs** (défaut, erreur, vide, cas limite), et
+  en priorité ceux qu'on ne peut pas atteindre sur le site.
+- Les stories utilisent des **données réelles**, prélevées dans `src/contenu/`, jamais du
+  lorem ipsum ni un chiffre recopié à la main : un nombre écrit deux fois dans un dépôt
+  finit par valoir deux valeurs différentes.
+- La limite de **300 lignes** s'applique aux fichiers de story comme au reste.
+- Les stories ne sont **pas des tests** : ce sont les tests de `tests/` qui conditionnent
+  la fusion, et ils sont écrits par Jérôme MARICHEZ (voir [`testing.md`](./testing.md)).
 
 ## Composants couverts
 
-| Composant | Stories | États couverts |
-|-----------|---------|----------------|
-| _TODO_ | | |
+Trente et un composants sur trente-quatre ont une story.
+
+| Groupe | Composants |
+|--------|------------|
+| Socle | `SiteHeader`, `SiteFooter`, `SkipLink`, `Breadcrumb` |
+| Verre | `GlassSurface` |
+| Mouvement | `MotionToggle`, `Reveal` |
+| Pôles | `PoleGlyph`, `PoleHero`, `PoleTagList`, `PoleStickyBar`, `PoleEntries`, `ChainDiagram` |
+| Éditorial | `EditorialSection`, `HingeSection`, `ThreadSection`, `HingeNote`, `ExpertiseBlock`, `BoundaryList`, `ProofWall`, `CertificationList`, `SpaceEntries` |
+| Accueil | `HomeHero`, `ChainCanvas` |
+| Blog | `ArticleCard`, `ArticleFigure`, `ArticleSource` |
+| Réalisations | `RealisationCard`, `EmploymentFrame` |
+| Contact | `ContactField`, `ContactForm` |
+
+### Les trois exclusions, et leur raison
+
+| Composant | Pourquoi pas de story |
+|-----------|-----------------------|
+| `StructuredData` | Il n'émet que du JSON-LD dans un `<script>`. Aucun rendu visuel : une story vide vaudrait moins que la raison écrite de son absence. |
+| `MotionState` | Il rend `null`. Son seul effet est un attribut posé sur `<html>`, que le CSS lit. Il n'y a rien à montrer. |
+| `GlassRefraction` | C'est un filtre SVG inerte, invisible par lui-même. L'enveloppe des stories le rend déjà partout, et c'est dans `GlassSurface` que son effet se juge. |
+
+`MagneticAction` n'apparaît pas non plus : il a été supprimé du dépôt.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -37,6 +37,27 @@ Toutes les opérations passent par `make` (voir `Makefile`) : agnostique, docume
 make lint
 ```
 
+Biome et `check-max-lines.sh` écartent les mêmes sorties de build : `node_modules`,
+`.next`, `out`, `dist`, `build`, `coverage` et `storybook-static`. Ce sont des fichiers générés,
+jamais du code du dépôt : les écarter n'assouplit aucun contrôle.
+
+## Storybook : le catalogue de composants
+
+Storybook est installé et en service. Trois paquets, tous en `devDependencies` : `storybook`,
+`@storybook/nextjs-vite` (le framework, seul à savoir résoudre `next/font` hors d'un
+serveur Next) et `vite`. Rien n'entre dans `next build`, donc le poids du JavaScript des
+pages est inchangé.
+
+```bash
+make storybook          # http://localhost:6006
+make storybook-build    # build statique, dans storybook-static/ (non versionné)
+```
+
+Les stories sont **colocalisées** avec leur composant. La configuration charge les quatre
+feuilles de jetons du site dans l'ordre de `src/app/layout.tsx`, et ajoute deux contrôles
+de barre d'outils : le thème, et la teinte de pôle. Conventions, mécanique et exclusions
+motivées : [`storybook.md`](./storybook.md).
+
 ## Hooks Claude Code (`.claude/`)
 
 | Hook | Événement | Rôle |

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.13.0",
         "@biomejs/biome": "2.5.7",
+        "@storybook/nextjs-vite": "^10.5.10",
         "@stryker-mutator/core": "^9.0.0",
         "@stryker-mutator/jest-runner": "^9.0.0",
         "@testing-library/react": "^16.3.0",
@@ -29,9 +30,18 @@
         "jest-environment-jsdom": "^30.0.0",
         "lighthouse": "^13.4.1",
         "puppeteer": "^25.8.0",
+        "storybook": "^10.5.10",
         "ts-jest": "^29.4.0",
-        "typescript": "^5.9.0"
+        "typescript": "^5.9.0",
+        "vite": "^8.2.2"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@apm-js-collab/code-transformer": {
       "version": "0.18.1",
@@ -1252,6 +1262,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -2934,6 +3386,71 @@
         "node": ">=8"
       }
     },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+      "integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3273,6 +3790,734 @@
         "node": ">=14"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.2.tgz",
+      "integrity": "sha512-xQoCRv+gKax9KTdwdaQNnAFOai8neay7g3jExDIORzhbrejwGSJaZNTdOJHR5ziLg2joMxOCMOFMo4zuxza2uQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.2.tgz",
+      "integrity": "sha512-HF5oiE2L05yInPYCFD/4uxSrEZW4SuIfn99Y6L1xnJnzl066JR+MJs2rIdstw8A2MPlAKH+13dpFPNycjqzvGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.2.tgz",
+      "integrity": "sha512-UX4u49CVCAD8QZNELaW8eMGgMAGwFWYEPbvNsh+3r/gs4NX3KfpiACMVwRQT0EuH3uat9hM5Zl+Ppm9pJD8tgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.2.tgz",
+      "integrity": "sha512-J9xPx7YBkrRmJ+xl561ztnMWEc1aOyjEIxBiGX1dVb3u7bGSnfObfcZk+Pd+uM0HZAPNsQ1xvD8j52A/uOSqNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.2.tgz",
+      "integrity": "sha512-fRlt7OvSaQkWj6+EDTVxawVxOlqJB2QSnBfkeCyK4RTvsGctbw3BiH2Tb7DzMs7bikc4BRBpvWP5zF9K8b54Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.2.tgz",
+      "integrity": "sha512-gK+vPUcPQITkGwBKpZGrcDHSlU6eDGl7AQacxS2CEKAZIBHWkOVFeJwLZ4tYnA1acJqRM5lt7yYwPCVqGHIJ7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.2.tgz",
+      "integrity": "sha512-L/Rgas7SrOKy/z7IH+HxSFRqVO4PuLDKLEGKvnhoCBBq3UJ0YzGBou3qMzaAGgkJwsIvX2pBF+7ojzfUhLiZxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.2.tgz",
+      "integrity": "sha512-CUEYvlX1Fk7E9kUMzuswru1J9HLxMwnpDeQGjQuI4ZH+iNCoa2X9T+pvyzrbsgl7WnIeTFTlNlHsRfVdf5g9/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.2.tgz",
+      "integrity": "sha512-ViN1ZibQyxwC67GpoP33oo+S9UyUnkog13vzQb9+v9bCNvrVzJuk0MRdacjtv/9xfRMVF/eqHFyl8YOeykI10Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.2.tgz",
+      "integrity": "sha512-CU1sCqWnhGqYD5I1HedHk5pujrn7ssDkNB/AEQd/pd3D/EojVSgJUlpbafwIbyhia3PgIfkvdFpRPWSALzVumA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.2.tgz",
+      "integrity": "sha512-jWVyZtIHca4Gb96x7dag+y69vlei7ffjrsveLkmf2ZhqEAz6ZSBnY1GWvgZUaZlwZP62A3xD092BW97Q5VGc+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.2.tgz",
+      "integrity": "sha512-LF29obFqNgBUgDX7rmUK7M4D0JQG5LxhYzn3xXmECcHU9aQAdWG7NiY052qybtesEdwHQXKNTWYQ7mTsybNvWg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.2.tgz",
+      "integrity": "sha512-+NYcm+cCHBbtdQQ3A4phQTSuVRYnNHz7wrl9XRAPEovcdoqi0mb1K5ZOl+jN54ZD+q1zz3V0vltbFJmzecJKmw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.2.tgz",
+      "integrity": "sha512-UQqZDdG2r2HhAOsZEgufkIWHPQ886IUyuJQkoZByvzhW8j51R4UNzGBJFkTiTnLhQnggwJRdJgFWK4uY6ZVIMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.2.tgz",
+      "integrity": "sha512-3Q9PMRjalWkT6NZ4jfujuqTCFwoWErg3y3BnOgb544B8IMw4PktiwWOigMfOHNRLMghZeJ7hpfpZf4CP7rV7Og==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.2.tgz",
+      "integrity": "sha512-Eljeq3ndtyKhM+Es8LITi4Zl2htzuRZcrPMF3kMCsrILztvU6AjZ3FuEhHHKobPUB9rMpzLpJP5bDqXI7r+iog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.2.tgz",
+      "integrity": "sha512-HGDbNsIywqc4LxU38+CTJNnB/6BF7rheWOJ259b4eE0aEnelYblC8x+1tEd63bp31fYne63RQz9Jb4yVnC7Yig==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.0",
+        "@emnapi/runtime": "1.11.0",
+        "@napi-rs/wasm-runtime": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.2.tgz",
+      "integrity": "sha512-iWx25CBEgH49iE9q5coEGI/jb1jl5kkCY9z6U5Og67xCkQ/WFMDc2J5U78+AE91SUxM2NqSLhJC8/PLfWnImww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.2.tgz",
+      "integrity": "sha512-VPoCAhKvCQTlG7vxqaBXcmuvbh77BfnGXj8g0pbvVXpm1F/R8rDVwqIWcEbMzrI1JvJlm8v7T9uMVQb6UctMRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@paulirish/trace_engine": {
       "version": "0.0.65",
       "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.65.tgz",
@@ -3464,6 +4709,309 @@
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -3631,6 +5179,211 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.10.tgz",
+      "integrity": "sha512-O4GgIP0tKLRueom3EmU3OaBUHKjNYj+jkOvmTIkn3PYTiWVkCuHqSKEs4ADvRyaQuLH+peHhFe4JtkNC9KbtrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.10",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.10",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.10.tgz",
+      "integrity": "sha512-TaCLBrqVEr767+w58QDotDUiCTuE5cyRJuRcDlsKQyUIyGBv+lYD3lu8wBiVCYxgIjB/gu9HmqiC+0yx1rHzaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.5.10",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/nextjs-vite": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/nextjs-vite/-/nextjs-vite-10.5.10.tgz",
+      "integrity": "sha512-kDzhmW3pXWVI/trOcBu0XG7irieTBBdezL3gtmw6ZVyY7RJWWMlkzbVdXha76eWCM78kseLHafAxu8KgOsCI4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/builder-vite": "10.5.10",
+        "@storybook/react": "10.5.10",
+        "@storybook/react-vite": "10.5.10",
+        "styled-jsx": "5.1.6",
+        "vite-plugin-storybook-nextjs": "^3.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "next": "^14.1.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.10",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.10.tgz",
+      "integrity": "sha512-4MBV5e1SXIMfPynLHzr+Mp0dwGv/FW1bklWAsS4ynBOAbC98W9p/I9vqBnUctsvE3BJkhzHQQyPwMHL5tTcHVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.5.10",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.10",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.10.tgz",
+      "integrity": "sha512-rbu62ILo/VE3iXKmu+kWXFpD1H1Lwi0f19q/x7JnDsD2dxKS9w5znLEqPIq2qxpzi/wjjIb2iUP1cRG1d/9W5A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.10"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.10.tgz",
+      "integrity": "sha512-xOztxefUnqKeuyvcnjspqmlDnER4cExL+liltrpdXLPJVqfFNr9lgM49FyEPajzsUVG9W/vHJWjbaQGGu1UsYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.5.10",
+        "@storybook/react": "10.5.10",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.2",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.10",
+        "typescript": ">= 4.9.x",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@stryker-mutator/api": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
@@ -3779,7 +5532,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3793,6 +5545,33 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -3822,6 +5601,20 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -3838,8 +5631,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3885,6 +5677,31 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -3988,6 +5805,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -4402,6 +6226,84 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4565,7 +6467,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4588,6 +6489,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/astring": {
@@ -4969,6 +6893,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cachedir": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
@@ -5057,6 +6997,23 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -5086,6 +7043,16 @@
       "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chrome-launcher": {
       "version": "1.2.1",
@@ -5464,6 +7431,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -5778,6 +7752,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -5786,6 +7770,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -5814,7 +7828,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5834,8 +7847,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5864,13 +7877,25 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dot-prop": {
       "version": "9.0.0",
@@ -5960,6 +7985,16 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -6090,6 +8125,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6145,6 +8222,23 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter2": {
@@ -6312,6 +8406,24 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/figures": {
@@ -6616,6 +8728,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6891,6 +9010,19 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
     "node_modules/image-ssim": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
@@ -6943,6 +9075,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6992,6 +9134,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -7032,6 +9190,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally": {
@@ -8875,6 +11068,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
@@ -9002,6 +11202,279 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -9324,6 +11797,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9340,7 +11820,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9468,6 +11947,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -9527,6 +12016,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.3.4.tgz",
+      "integrity": "sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -9818,6 +12314,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.2.tgz",
+      "integrity": "sha512-w5tLwYN3Zo24w5EeWJjJWZOwhYqTtC8PS2B1tIt7BZUuqTIcU07sQValbDw+rq7+AuAGzOHklgK+ifsy4lpXfw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.21.2",
+        "@oxc-resolver/binding-android-arm64": "11.21.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.21.2",
+        "@oxc-resolver/binding-darwin-x64": "11.21.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.21.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.21.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.21.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.21.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.21.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.21.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.21.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.21.2"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -9955,6 +12520,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -9978,6 +12550,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -10092,7 +12674,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10263,6 +12844,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-docgen": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+      "integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__traverse": "^7.20.7",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
@@ -10280,8 +12893,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -10298,6 +12910,60 @@
       "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/recast": {
+      "version": "0.23.21",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.21.tgz",
+      "integrity": "sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/request-progress": {
       "version": "3.0.0",
@@ -10341,6 +13007,28 @@
       },
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -10400,12 +13088,69 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.146.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+      }
+    },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -10787,6 +13532,87 @@
         "node": ">=10"
       }
     },
+    "node_modules/storybook": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.10.tgz",
+      "integrity": "sha512-Rz8k9ejFHsi7lbtJTaxZlhCUz4GkbJIKEoKDjXeLfr/ZhXip73E6keKxW0KH8iGeKiCqHAbJCV4YIQrxTOLiig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "11.21.2",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/storybook/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -10971,6 +13797,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -11038,6 +13877,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {
@@ -11175,6 +14027,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -11265,6 +14161,16 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.4.12",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
@@ -11329,6 +14235,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tslib": {
@@ -11502,6 +14455,22 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -11581,6 +14550,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -11609,6 +14588,160 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-storybook-nextjs": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-storybook-nextjs/-/vite-plugin-storybook-nextjs-3.3.2.tgz",
+      "integrity": "sha512-emY992wwyOfG5kDEmo7br/OWCz8YMOYhc/0YQo/vGdSqYQhTCRSvHHjjeysAr6co1F2cyoK50szd4nMitZ0k8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.3.0-preview.5",
+        "image-size": "^2.0.0",
+        "magic-string": "^0.30.11",
+        "module-alias": "^2.2.3",
+        "ts-dedent": "^2.2.0",
+        "vite-tsconfig-paths": "^5.1.4"
+      },
+      "peerDependencies": {
+        "next": "^14.1.0 || ^15.0.0 || ^16.0.0",
+        "storybook": "^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/vite-plugin-storybook-nextjs/node_modules/@next/env": {
+      "version": "16.3.0-preview.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0-preview.5.tgz",
+      "integrity": "sha512-XqdVR0utAWMsVc1OIyO48D32vrdmC4/uAgI3Ds088YlOO4vfGKXXVyvkGFkOZkOK0xg7bNYNfJAarX4A0tYqGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -11664,6 +14797,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
@@ -11891,6 +15031,38 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "next": "^16.0.0",
@@ -18,6 +20,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.13.0",
     "@biomejs/biome": "2.5.7",
+    "@storybook/nextjs-vite": "^10.5.10",
     "@stryker-mutator/core": "^9.0.0",
     "@stryker-mutator/jest-runner": "^9.0.0",
     "@testing-library/react": "^16.3.0",
@@ -31,7 +34,9 @@
     "jest-environment-jsdom": "^30.0.0",
     "lighthouse": "^13.4.1",
     "puppeteer": "^25.8.0",
+    "storybook": "^10.5.10",
     "ts-jest": "^29.4.0",
-    "typescript": "^5.9.0"
+    "typescript": "^5.9.0",
+    "vite": "^8.2.2"
   }
 }

--- a/scripts/check-max-lines.sh
+++ b/scripts/check-max-lines.sh
@@ -16,7 +16,8 @@ while IFS= read -r f; do
   fi
 done < <(find "$ROOT" \
   \( -path '*/node_modules' -o -path '*/.next' -o -path '*/out' -o -path '*/dist' \
-     -o -path '*/build' -o -path '*/coverage' -o -path '*/.git' \) -prune -o \
+     -o -path '*/build' -o -path '*/coverage' -o -path '*/.git' \
+     -o -path '*/storybook-static' \) -prune -o \
   -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
   ! -name '*.test.*' ! -name '*.spec.*' ! -name '*.cy.ts' ! -name '*.config.*' ! -name '*.d.ts' \
   ! -path '*/tests/*' \

--- a/src/components/ArticleCard/ArticleCard.stories.tsx
+++ b/src/components/ArticleCard/ArticleCard.stories.tsx
@@ -1,0 +1,48 @@
+// ArticleCard.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { listArticles } from '@/services/find-article'
+import { exiger } from '../../../.storybook/jeux-de-donnees'
+import { ArticleCard } from '.'
+
+const ARTICLE = exiger(listArticles(), 'article du blog')
+
+const meta = {
+  title: 'Blog/ArticleCard',
+  component: ArticleCard,
+  args: { article: ARTICLE },
+  argTypes: { headingLevel: { control: 'inline-radio', options: ['h2', 'h3'] } },
+} satisfies Meta<typeof ArticleCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** La carte telle qu'elle paraît sur l'index du blog. */
+export const Defaut: Story = {}
+
+/**
+ * Le niveau de titre abaissé, pour la liste des articles liés en bas de fiche.
+ *
+ * Rien ne change à l'écran : ce qui change est la hiérarchie du document. Deux `h2` de
+ * rangs différents dans la même page cassent la navigation par titres d'un lecteur
+ * d'écran, et cela ne se voit sur aucune capture.
+ */
+export const NiveauAbaisse: Story = { args: { headingLevel: 'h3' } }
+
+/**
+ * Les cartes du blog les unes sous les autres.
+ *
+ * C'est l'alignement qu'on vient juger : des titres de longueurs très inégales ne
+ * doivent pas décaler les dates ni les figures d'une carte à l'autre.
+ */
+export const EnListe: Story = {
+  render: () => (
+    <ul style={{ display: 'grid', gap: '1.5rem', listStyle: 'none', margin: 0, padding: 0 }}>
+      {listArticles().map((article) => (
+        <li key={article.slug}>
+          <ArticleCard article={article} />
+        </li>
+      ))}
+    </ul>
+  ),
+}

--- a/src/components/ArticleFigure/ArticleFigure.stories.tsx
+++ b/src/components/ArticleFigure/ArticleFigure.stories.tsx
@@ -1,0 +1,41 @@
+// ArticleFigure.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import type { ArticleFigureId } from '@/interfaces/types'
+import { ArticleFigure } from '.'
+
+const FIGURES: readonly ArticleFigureId[] = ['borne', 'anteriorite', 'appui', 'gabarit', 'liaison']
+
+const meta = {
+  title: 'Blog/ArticleFigure',
+  component: ArticleFigure,
+  args: { figure: 'borne' },
+  argTypes: { figure: { control: 'inline-radio', options: FIGURES } },
+} satisfies Meta<typeof ArticleFigure>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Une figure isolée, à choisir dans le contrôle. */
+export const Seule: Story = {}
+
+/**
+ * Les cinq figures ensemble.
+ *
+ * Le site ne les montre jamais côte à côte : chaque article n'en porte qu'une. C'est
+ * pourtant la seule vue qui permette de vérifier ce qui compte, à savoir qu'aucune des
+ * cinq ne se confond avec une autre au premier coup d'oeil, et qu'aucune ne simule une
+ * donnée chiffrée. Les noms disent la structure dessinée, jamais le sujet de l'article.
+ */
+export const LesCinq: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(auto-fit, 16rem)' }}>
+      {FIGURES.map((figure) => (
+        <div key={figure}>
+          <ArticleFigure figure={figure} />
+          <p style={{ color: 'var(--encre-douce)', fontSize: '0.8rem' }}>{figure}</p>
+        </div>
+      ))}
+    </div>
+  ),
+}

--- a/src/components/ArticleSource/ArticleSource.stories.tsx
+++ b/src/components/ArticleSource/ArticleSource.stories.tsx
@@ -1,0 +1,26 @@
+// ArticleSource.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ArticleSource } from '.'
+
+const meta = {
+  title: 'Blog/ArticleSource',
+  component: ArticleSource,
+  args: {
+    source: {
+      reseau: 'linkedin',
+      url: 'https://www.linkedin.com/feed/update/urn:li:activity:0000000000000000000/',
+    },
+  },
+} satisfies Meta<typeof ArticleSource>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le renvoi vers la première parution du texte.
+ *
+ * Le libellé du réseau se déduit de `reseau`, il n'est jamais recopié dans un contenu :
+ * une casse écrite à la main finit toujours par varier d'un article à l'autre.
+ */
+export const Defaut: Story = {}

--- a/src/components/BoundaryList/BoundaryList.stories.tsx
+++ b/src/components/BoundaryList/BoundaryList.stories.tsx
@@ -1,0 +1,26 @@
+// BoundaryList.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { LIMITES } from '@/contenu/limites'
+import { BoundaryList } from '.'
+
+const meta = {
+  title: 'Editorial/BoundaryList',
+  component: BoundaryList,
+  args: { limites: LIMITES },
+} satisfies Meta<typeof BoundaryList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Les limites assumées : ce qui n'est pas proposé, et ce qui l'est à la place.
+ *
+ * Le composant est une liste de définitions, pas un tableau : chaque « hors » est un
+ * terme, chaque « à la place » sa définition. C'est le balisage qui rend la paire
+ * intelligible à un lecteur d'écran, et il ne se voit qu'en inspectant le DOM.
+ */
+export const Defaut: Story = {}
+
+/** Une paire isolée, pour juger le rapport de force visuel entre les deux colonnes. */
+export const UneSeule: Story = { args: { limites: LIMITES.slice(0, 1) } }

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,49 @@
+// Breadcrumb.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { Breadcrumb } from '.'
+
+const meta = {
+  title: 'Socle/Breadcrumb',
+  component: Breadcrumb,
+  args: { fil: [{ nom: 'Data', route: '/services/data/' }] },
+} satisfies Meta<typeof Breadcrumb>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Un seul niveau sous l'accueil : le cas des pages de pôle. */
+export const UnNiveau: Story = {}
+
+/**
+ * Deux niveaux : une fiche à l'intérieur d'un espace éditorial.
+ *
+ * Le dernier niveau n'est jamais un lien et porte `aria-current="page"`. C'est ce qui
+ * distingue « où je suis » de « où je peux aller », et cela ne se voit qu'ici.
+ */
+export const DeuxNiveaux: Story = {
+  args: {
+    fil: [
+      { nom: 'Réalisations', route: '/realisations/' },
+      { nom: 'SMS en masse, la plateforme', route: '/realisations/sms-en-masse-plateforme/' },
+    ],
+  },
+}
+
+/**
+ * Un libellé long, dans un fil déjà à deux niveaux.
+ *
+ * Le cas limite du composant : la ligne doit se replier sans casser les séparateurs ni
+ * pousser la page en défilement horizontal.
+ */
+export const LibelleLong: Story = {
+  args: {
+    fil: [
+      { nom: 'Blog', route: '/blog/' },
+      {
+        nom: 'De la documentation qui pilote une IA à une carte de l’architecture',
+        route: '/blog/de-la-doc-qui-pilote-une-ia-a-une-carte-de-l-architecture/',
+      },
+    ],
+  },
+}

--- a/src/components/CertificationList/CertificationList.stories.tsx
+++ b/src/components/CertificationList/CertificationList.stories.tsx
@@ -1,0 +1,45 @@
+// CertificationList.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { CERTIFICATIONS } from '@/contenu/certifications'
+import { selectCertificationsByPole } from '@/contenu/select-certifications'
+import { CertificationList } from '.'
+
+const meta = {
+  title: 'Editorial/CertificationList',
+  component: CertificationList,
+  args: { certifications: CERTIFICATIONS },
+} satisfies Meta<typeof CertificationList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Toutes les certifications, telles qu'elles paraissent sur l'accueil. */
+export const Toutes: Story = {}
+
+/** La sélection d'une page de pôle : seules les certifications qui la concernent. */
+export const PourUnPole: Story = {
+  args: { certifications: selectCertificationsByPole('sea-ux') },
+  globals: { pole: 'sea-ux' },
+}
+
+/**
+ * Une certification sans millésime.
+ *
+ * Le cas existe réellement — Microsoft Ads est confirmée sans année connue — et la ligne
+ * d'année doit alors disparaître au lieu d'afficher un vide. C'est un point de véracité
+ * autant que de mise en page.
+ */
+export const SansAnnee: Story = {
+  args: { certifications: CERTIFICATIONS.filter((c) => c.annee === undefined) },
+}
+
+/**
+ * Une certification sans justificatif publié.
+ *
+ * L'intitulé cesse alors d'être un lien : le site ne publie jamais une certification
+ * derrière une URL morte ou approximative.
+ */
+export const SansJustificatif: Story = {
+  args: { certifications: CERTIFICATIONS.filter((c) => c.justificatif === undefined) },
+}

--- a/src/components/ChainCanvas/ChainCanvas.stories.tsx
+++ b/src/components/ChainCanvas/ChainCanvas.stories.tsx
@@ -1,0 +1,47 @@
+// ChainCanvas.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { MotionToggle } from '@/components/MotionToggle'
+import { ChainCanvas } from '.'
+
+const DESCRIPTION =
+  'Quatre plaques gravées : le socle, le passage de la donnée, et les deux suites qu’elle ouvre.'
+
+const meta = {
+  title: 'Accueil/ChainCanvas',
+  component: ChainCanvas,
+  args: { description: DESCRIPTION },
+} satisfies Meta<typeof ChainCanvas>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * La scène du seuil, en mouvement.
+ *
+ * C'est un décor : le conteneur est `aria-hidden`, et la description ne sert qu'au
+ * substitut affiché quand la scène ne peut pas être peinte. Rien de ce qui s'y dit n'est
+ * annoncé, donc rien de ce qui s'y dit ne doit être une information nécessaire à la
+ * compréhension de la page.
+ */
+export const EnMouvement: Story = {}
+
+/**
+ * La scène avec sa commande de mise en pause.
+ *
+ * L'état figé s'atteint en un clic ici, alors qu'il demande de trouver le bouton sur le
+ * site. Ce qu'on vient vérifier est que la scène reste lisible à l'arrêt : une
+ * composition qui n'aurait de sens qu'en mouvement ne satisferait pas WCAG 2.2.2. Le
+ * réglage système `prefers-reduced-motion` produit le même arrêt, sans clic.
+ *
+ * L'état est partagé par tout le catalogue, comme il l'est par tout le site : il reste
+ * tel quel en passant à une autre story.
+ */
+export const AvecCommande: Story = {
+  render: (args) => (
+    <div style={{ display: 'grid', gap: '1rem', justifyItems: 'start' }}>
+      <MotionToggle />
+      <ChainCanvas {...args} />
+    </div>
+  ),
+}

--- a/src/components/ChainDiagram/ChainDiagram.stories.tsx
+++ b/src/components/ChainDiagram/ChainDiagram.stories.tsx
@@ -1,0 +1,23 @@
+// ChainDiagram.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ChainDiagram } from '.'
+
+const meta = {
+  title: 'Poles/ChainDiagram',
+  component: ChainDiagram,
+} satisfies Meta<typeof ChainDiagram>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le modèle de l'offre, en entier : le tronc, le passage obligé, l'embranchement.
+ *
+ * C'est le composant où une erreur de mise en page coûte le plus cher, parce qu'il ne
+ * décore pas le modèle, il l'énonce. Deux choses se vérifient ici et nulle part
+ * ailleurs : les deux suites sont à la même hauteur, et aucune numérotation ne les
+ * ordonne. En largeur réduite, la bifurcation se replie en colonne, et c'est le moment
+ * où le sens est le plus fragile.
+ */
+export const Defaut: Story = {}

--- a/src/components/ContactField/ContactField.stories.tsx
+++ b/src/components/ContactField/ContactField.stories.tsx
@@ -1,0 +1,73 @@
+// ContactField.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { CONTACT_FORMULAIRE } from '@/contenu/contact'
+import { LONGUEUR_MAX_MESSAGE } from '@/schemas/contact.schema'
+import { MESSAGE_URL_TROP_LONGUE } from '@/services/contact-mailto'
+import { formatContactCounter } from '@/utils/format-contact-counter'
+import { ContactField } from '.'
+
+const meta = {
+  title: 'Contact/ContactField',
+  component: ContactField,
+  args: {
+    champ: 'nom',
+    label: CONTACT_FORMULAIRE.champs.nom.label,
+    aide: CONTACT_FORMULAIRE.champs.nom.aide,
+    marqueObligatoire: CONTACT_FORMULAIRE.marqueObligatoire,
+    valeur: '',
+    onChange: () => {},
+  },
+} satisfies Meta<typeof ContactField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Le champ vide, avec son libellé, sa marque d'obligation et son texte d'aide. */
+export const Vide: Story = {}
+
+/** Le champ rempli. La valeur est pilotée par le parent, jamais par le champ. */
+export const Rempli: Story = { args: { valeur: 'Camille Dubois' } }
+
+/**
+ * Le champ en erreur.
+ *
+ * Trois choses changent d'un coup et doivent être vérifiées ensemble : le message
+ * apparaît sous la saisie, `aria-invalid` passe à `true`, et le message rejoint
+ * `aria-describedby` derrière le texte d'aide. Un message visible qui ne serait pas
+ * rattaché au champ ne serait jamais lu par un lecteur d'écran.
+ */
+export const EnErreur: Story = {
+  args: { erreur: 'Indiquez le nom sous lequel je vous réponds.' },
+}
+
+/** Le champ multiligne avec son compteur de caractères, tel qu'il sert au message. */
+export const Multiligne: Story = {
+  args: {
+    champ: 'message',
+    label: CONTACT_FORMULAIRE.champs.message.label,
+    aide: CONTACT_FORMULAIRE.champs.message.aide,
+    multiligne: true,
+    valeur: 'Nous refondons notre site et nous ne savons pas quoi mesurer.',
+    complement: formatContactCounter(60, LONGUEUR_MAX_MESSAGE),
+  },
+}
+
+/**
+ * Le champ multiligne en erreur, compteur compris.
+ *
+ * C'est l'empilement le plus chargé du composant : aide, compteur, puis message
+ * d'erreur. L'ordre de lecture doit rester tenable, et le message d'erreur ne doit pas
+ * se confondre avec le compteur.
+ */
+export const MultiligneEnErreur: Story = {
+  args: {
+    champ: 'message',
+    label: CONTACT_FORMULAIRE.champs.message.label,
+    aide: CONTACT_FORMULAIRE.champs.message.aide,
+    multiligne: true,
+    valeur: 'Trop court.',
+    complement: formatContactCounter(11, LONGUEUR_MAX_MESSAGE),
+    erreur: MESSAGE_URL_TROP_LONGUE,
+  },
+}

--- a/src/components/ContactForm/ContactForm.stories.tsx
+++ b/src/components/ContactForm/ContactForm.stories.tsx
@@ -1,0 +1,91 @@
+// ContactForm.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fireEvent } from 'storybook/test'
+import { CONTACT_FORMULAIRE } from '@/contenu/contact'
+import { LONGUEUR_MAX_MESSAGE } from '@/schemas/contact.schema'
+import { SITE_IDENTITY } from '@/seo/site'
+import { ContactForm } from '.'
+
+const meta = {
+  title: 'Contact/ContactForm',
+  component: ContactForm,
+  args: { destinataire: SITE_IDENTITY.email, titreId: 'contact-titre' },
+  decorators: [
+    (Story) => (
+      <section aria-labelledby="contact-titre">
+        <h2 id="contact-titre" style={{ color: 'var(--encre)' }}>
+          Décrire votre besoin
+        </h2>
+        <Story />
+      </section>
+    ),
+  ],
+} satisfies Meta<typeof ContactForm>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Remplit un champ sans passer par la frappe, quand le texte est trop long pour être tapé. */
+function remplir(champ: HTMLElement, valeur: string) {
+  fireEvent.change(champ, { target: { value: valeur } })
+}
+
+/**
+ * Le formulaire au repos.
+ *
+ * La région d'annonce est déjà dans le document, vide : un `role="alert"` inséré en même
+ * temps que son texte est annoncé de façon inégale selon les lecteurs d'écran. Elle est
+ * masquée par `:empty`, jamais par une condition de rendu, donc elle est présente ici
+ * même si rien ne se voit.
+ */
+export const Vierge: Story = {}
+
+/**
+ * Le refus d'un envoi vide.
+ *
+ * Trois messages de champ, le résumé en tête, et le focus porté sur ce résumé. Le résumé
+ * renvoie vers chaque champ par de vrais liens : au clavier on entend le nombre
+ * d'erreurs, on choisit laquelle corriger, et on y va d'une touche. C'est l'état le plus
+ * difficile à atteindre sur le site, puisqu'il faut délibérément soumettre un formulaire
+ * vide.
+ */
+export const EnvoiVide: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: CONTACT_FORMULAIRE.bouton }))
+  },
+}
+
+/**
+ * Le refus d'une saisie trop courte, bornes du schéma à l'appui.
+ *
+ * Les messages ne viennent pas du composant : ils appartiennent au schéma Zod, parce
+ * qu'ils formulent une règle et non un libellé d'écran. Un espace seul compte pour vide,
+ * le `trim()` s'appliquant avant les bornes.
+ */
+export const SaisieTropCourte: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.type(canvas.getByLabelText(/Votre nom/), 'A')
+    await userEvent.type(canvas.getByLabelText(/Le sujet/), '  ')
+    await userEvent.type(canvas.getByLabelText(/Votre message/), 'Trop court.')
+    await userEvent.click(canvas.getByRole('button', { name: CONTACT_FORMULAIRE.bouton }))
+  },
+}
+
+/**
+ * Le refus de longueur : une saisie valide qui produit une URL `mailto:` trop longue.
+ *
+ * Le cas est réel et invisible autrement : le message tient dans ses 1 500 caractères,
+ * mais chaque caractère accentué en pèse six une fois pourcent-encodé, et l'URL dépasse
+ * la limite au-delà de laquelle certains clients mail tronquent en silence. Le refus
+ * sort comme une erreur de champ, pas comme un troisième état : du point de vue du
+ * visiteur, c'est le même geste que pour un message trop long.
+ */
+export const RefusDeLongueur: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.type(canvas.getByLabelText(/Votre nom/), 'Camille Dubois')
+    await userEvent.type(canvas.getByLabelText(/Le sujet/), 'Refonte et mesure')
+    remplir(canvas.getByLabelText(/Votre message/), 'é'.repeat(LONGUEUR_MAX_MESSAGE))
+    await userEvent.click(canvas.getByRole('button', { name: CONTACT_FORMULAIRE.bouton }))
+  },
+}

--- a/src/components/EditorialSection/EditorialSection.stories.tsx
+++ b/src/components/EditorialSection/EditorialSection.stories.tsx
@@ -1,0 +1,45 @@
+// EditorialSection.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import {
+  SECTION_CHAPITRE,
+  SECTION_CHARNIERE,
+  SECTION_FIL,
+  SECTION_PREUVES,
+} from '../../../.storybook/jeux-de-donnees'
+import { EditorialSection } from '.'
+
+const meta = {
+  title: 'Editorial/EditorialSection',
+  component: EditorialSection,
+  args: { section: SECTION_CHAPITRE },
+} satisfies Meta<typeof EditorialSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Un chapitre de page de pôle : entête, chapô, puis les points d'expertise. */
+export const Chapitre: Story = {}
+
+/**
+ * Le même chapitre posé sur du verre réfractant.
+ *
+ * Le verre est plafonné sur le site — une section sur l'accueil, trois sur une page de
+ * pôle — donc la plupart des sections ne le portent jamais. C'est ici, et nulle part
+ * ailleurs, qu'on peut comparer les deux rendus du même contenu.
+ */
+export const SurVerre: Story = { args: { glass: true } }
+
+/**
+ * Une charnière : le composant délègue entièrement à `HingeSection`.
+ *
+ * L'aiguillage se fait sur `kind`, pas sur une prop d'appel. Le vérifier ici évite
+ * qu'une charnière se retrouve un jour rendue comme un chapitre ordinaire.
+ */
+export const Charniere: Story = { args: { section: SECTION_CHARNIERE } }
+
+/** Un fil transverse : délégué à `ThreadSection`, et jamais vitré. */
+export const Fil: Story = { args: { section: SECTION_FIL } }
+
+/** La section de preuves de l'accueil, celle qui répond aux objections par des chiffres. */
+export const Preuves: Story = { args: { section: SECTION_PREUVES } }

--- a/src/components/EmploymentFrame/EmploymentFrame.stories.tsx
+++ b/src/components/EmploymentFrame/EmploymentFrame.stories.tsx
@@ -1,0 +1,53 @@
+// EmploymentFrame.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { groupRealisationsByCadre } from '@/services/find-realisation'
+import { exiger } from '../../../.storybook/jeux-de-donnees'
+import { EmploymentFrame } from '.'
+
+const GROUPES = groupRealisationsByCadre()
+
+const meta = {
+  title: 'Realisations/EmploymentFrame',
+  component: EmploymentFrame,
+  args: { cadre: exiger(GROUPES, 'groupe de réalisations').cadre },
+  argTypes: { niveau: { control: 'inline-radio', options: ['h2', 'p'] } },
+} satisfies Meta<typeof EmploymentFrame>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le cadre tel qu'il paraît sur une fiche : l'organisation en paragraphe.
+ *
+ * Le titre de niveau 2 appartient déjà aux sections du récit ; en donner un au cadre
+ * ferait entrer un intitulé de poste dans le plan du document.
+ */
+export const SurUneFiche: Story = {}
+
+/**
+ * Le même cadre en tête de groupe, sur la liste : l'organisation devient un `h2`.
+ *
+ * C'est la seule différence entre les deux usages, et elle est invisible à l'écran. Le
+ * `titreId` sert alors de nom accessible à la section qui englobe le groupe.
+ */
+export const EnTeteDeGroupe: Story = {
+  args: { niveau: 'h2', titreId: 'cadre-titre' },
+}
+
+/**
+ * Tous les cadres du parcours, les uns sous les autres.
+ *
+ * Les statuts et les intitulés de poste sont repris à l'identique des CV de référence,
+ * jamais réécrits pour coller à une offre de service. Cette vue est le seul endroit où
+ * on peut les relire tous d'un coup.
+ */
+export const TousLesCadres: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      {GROUPES.map((groupe) => (
+        <EmploymentFrame cadre={groupe.cadre} key={groupe.cadre.organisation} />
+      ))}
+    </div>
+  ),
+}

--- a/src/components/ExpertiseBlock/ExpertiseBlock.stories.tsx
+++ b/src/components/ExpertiseBlock/ExpertiseBlock.stories.tsx
@@ -1,0 +1,46 @@
+// ExpertiseBlock.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { exiger, SECTION_DATA } from '../../../.storybook/jeux-de-donnees'
+import { ExpertiseBlock } from '.'
+
+const BLOC = exiger(SECTION_DATA.blocs, 'bloc du chapitre data')
+
+const meta = {
+  title: 'Editorial/ExpertiseBlock',
+  component: ExpertiseBlock,
+  args: { bloc: BLOC },
+  argTypes: { headingLevel: { control: 'inline-radio', options: ['h3', 'h4'] } },
+} satisfies Meta<typeof ExpertiseBlock>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Le bloc tel qu'il paraît dans un chapitre, avec ce que le contenu réel lui donne. */
+export const Defaut: Story = {}
+
+/**
+ * Le bloc complet : texte, preuve chiffrée, et la décision que le client peut trancher.
+ *
+ * C'est la forme visée par la ligne éditoriale — chaque affirmation porte sa preuve, et
+ * chaque bloc se termine sur une décision — mais tous les contenus ne l'atteignent pas.
+ * La story fixe la référence.
+ */
+export const Complet: Story = {
+  args: {
+    bloc: {
+      titre: 'Mesure de l’acquisition',
+      texte:
+        'Le plan de marquage est écrit avant la première balise, et chaque événement ' +
+        'porte le nom de la décision qu’il sert.',
+      preuve: 'Budgets de 100 000 € pilotés sur cette base, sans reprise de marquage.',
+      decision: 'Quel canal vous coûte plus qu’il ne rapporte, et à partir de quel volume.',
+    },
+  },
+}
+
+/** Un bloc réduit à son titre : rien ne doit rester en suspens sous l'intitulé. */
+export const TitreSeul: Story = { args: { bloc: { titre: 'Cadrage' } } }
+
+/** Le niveau de titre abaissé, quand le bloc vit sous un `h3` déjà existant. */
+export const NiveauAbaisse: Story = { args: { headingLevel: 'h4' } }

--- a/src/components/GlassSurface/GlassSurface.stories.tsx
+++ b/src/components/GlassSurface/GlassSurface.stories.tsx
@@ -1,0 +1,61 @@
+// GlassSurface.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SECTION_CHAPITRE } from '../../../.storybook/jeux-de-donnees'
+import { GlassSurface } from '.'
+
+const meta = {
+  title: 'Verre/GlassSurface',
+  component: GlassSurface,
+  args: {
+    children: (
+      <div style={{ color: 'var(--encre)', padding: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>{SECTION_CHAPITRE.titre}</h2>
+        <p style={{ color: 'var(--encre-douce)' }}>{SECTION_CHAPITRE.chapo}</p>
+      </div>
+    ),
+  },
+} satisfies Meta<typeof GlassSurface>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le panneau de verre, posé sur le fond d'atelier.
+ *
+ * Deux choses se jugent ici et se perdent partout ailleurs. La **réfraction** d'abord :
+ * elle se lit sur l'arête et disparaît au centre, comme un vrai verre courbe ce qu'il y
+ * a derrière ; si l'effet se voit au milieu du panneau, c'est un défaut. La **trame du
+ * fond** ensuite : elle doit rester visible à travers le panneau, puisque la
+ * transparence est le sujet de la direction artistique.
+ *
+ * Le filtre de réfraction et le fond d'atelier sont posés par l'enveloppe des stories,
+ * exactement comme la mise en page racine les pose sur le site.
+ */
+export const Defaut: Story = {}
+
+/**
+ * Le verre en thème sombre.
+ *
+ * L'arête du verre est une dilution de `--accent` : elle change donc de couleur avec le
+ * pôle, et de densité avec le thème. C'est le réglage le plus fragile du système, et le
+ * seul endroit où on peut le comparer d'un thème à l'autre sans changer de page.
+ */
+export const Sombre: Story = { globals: { theme: 'sombre' } }
+
+/**
+ * Un panneau étroit.
+ *
+ * L'amplitude de la réfraction est proportionnelle à la taille de la boîte : un petit
+ * panneau courbe donc moins qu'un grand, comme une lentille plus fine. La story existe
+ * pour vérifier que l'effet reste perceptible à cette échelle sans devenir un liseré.
+ */
+export const Etroit: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '22rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/HingeNote/HingeNote.stories.tsx
+++ b/src/components/HingeNote/HingeNote.stories.tsx
@@ -1,0 +1,28 @@
+// HingeNote.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { HingeNote } from '.'
+
+const meta = {
+  title: 'Editorial/HingeNote',
+  component: HingeNote,
+  args: {
+    texte:
+      'Ce qui tourne produit de la donnée. Encore faut-il qu’elle soit gouvernée avant ' +
+      'd’être exploitée.',
+  },
+} satisfies Meta<typeof HingeNote>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** La phrase qui passe la main à la section suivante, sous un chapitre. */
+export const Defaut: Story = {}
+
+/**
+ * Une note courte.
+ *
+ * Le cas limite du composant : le filet et le retrait doivent tenir même quand le texte
+ * ne fait pas une ligne entière.
+ */
+export const Courte: Story = { args: { texte: 'La donnée est le passage obligé.' } }

--- a/src/components/HingeSection/HingeSection.stories.tsx
+++ b/src/components/HingeSection/HingeSection.stories.tsx
@@ -1,0 +1,33 @@
+// HingeSection.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SECTION_CHARNIERE } from '../../../.storybook/jeux-de-donnees'
+import { HingeSection } from '.'
+
+const meta = {
+  title: 'Editorial/HingeSection',
+  component: HingeSection,
+  args: { section: SECTION_CHARNIERE },
+} satisfies Meta<typeof HingeSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * La section qui passe la main d'un pôle au suivant.
+ *
+ * Elle est sa propre révélation : le filet qui se trace est un `::before` de la
+ * `<section>`, ce qui explique qu'elle soit rendue en balise `section` et non en
+ * `div`. Le filet ne se voit qu'à l'entrée dans le champ de vision.
+ */
+export const Defaut: Story = {}
+
+/**
+ * Une charnière sans repères, réduite à son chapô.
+ *
+ * Le contenu du site en porte toujours, mais rien dans le type ne l'impose : la liste
+ * doit simplement disparaître, sans laisser d'espace vide sous le texte.
+ */
+export const SansReperes: Story = {
+  args: { section: { ...SECTION_CHARNIERE, blocs: [] } },
+}

--- a/src/components/HomeHero/HomeHero.stories.tsx
+++ b/src/components/HomeHero/HomeHero.stories.tsx
@@ -1,0 +1,21 @@
+// HomeHero.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { HomeHero } from '.'
+
+const meta = {
+  title: 'Accueil/HomeHero',
+  component: HomeHero,
+} satisfies Meta<typeof HomeHero>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le seuil de l'accueil : le titre, la promesse, les deux actions et la scène animée.
+ *
+ * C'est le bloc qui porte le LCP du site, donc celui où une régression de mise en page
+ * coûte un point de budget. Il porte aussi le premier des deux boutons de mise en pause
+ * des animations, celui qui est immédiatement à côté de ce qui bouge.
+ */
+export const Defaut: Story = {}

--- a/src/components/MotionToggle/MotionToggle.stories.tsx
+++ b/src/components/MotionToggle/MotionToggle.stories.tsx
@@ -1,0 +1,29 @@
+// MotionToggle.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { MotionToggle } from '.'
+
+const meta = {
+  title: 'Mouvement/MotionToggle',
+  component: MotionToggle,
+} satisfies Meta<typeof MotionToggle>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Animations actives : le bouton propose de les figer, `aria-pressed` vaut `false`. */
+export const Actif: Story = {}
+
+/**
+ * Animations figées, après un clic.
+ *
+ * Le libellé change, `aria-pressed` passe à `true` et le témoin bascule. L'état est
+ * porté par un store partagé hors de React : le bouton du pied de page et celui du haut
+ * de l'accueil disent donc toujours la même chose, et cette story le montre en cliquant
+ * plutôt qu'en le forçant.
+ */
+export const Fige: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button'))
+  },
+}

--- a/src/components/PoleEntries/PoleEntries.stories.tsx
+++ b/src/components/PoleEntries/PoleEntries.stories.tsx
@@ -1,0 +1,26 @@
+// PoleEntries.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { PoleEntries } from '.'
+
+const meta = {
+  title: 'Poles/PoleEntries',
+  component: PoleEntries,
+} satisfies Meta<typeof PoleEntries>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Les quatre portes d'entrée de l'accueil.
+ *
+ * Le composant ne prend aucune prop : il lit `POLES_NAV` et range les plaques par
+ * **place** — le tronc d'abord, socle puis passage, et les deux suites ensuite, côte à
+ * côte. C'est la mise en page qui porte le modèle, et c'est elle qu'on vient vérifier
+ * ici : deux plaques alignées à la même hauteur disent « parallèles » là où une colonne
+ * de quatre aurait dit « dans cet ordre ».
+ *
+ * Chaque plaque pose son propre `data-pole` : le contrôle « Pôle » de la barre d'outils
+ * n'a donc aucun effet sur cette story, et c'est normal.
+ */
+export const Defaut: Story = {}

--- a/src/components/PoleGlyph/PoleGlyph.stories.tsx
+++ b/src/components/PoleGlyph/PoleGlyph.stories.tsx
@@ -1,0 +1,54 @@
+// PoleGlyph.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import type { PoleId } from '@/interfaces/types'
+import { PoleGlyph } from '.'
+
+const POLES: readonly PoleId[] = ['ingenierie-web', 'data', 'ia', 'sea-ux']
+
+const meta = {
+  title: 'Poles/PoleGlyph',
+  component: PoleGlyph,
+  args: { pole: 'data' },
+  argTypes: {
+    pole: { control: 'inline-radio', options: POLES },
+    taille: { control: { type: 'range', max: 96, min: 16, step: 4 } },
+  },
+} satisfies Meta<typeof PoleGlyph>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Une marque isolée. Sa couleur vient de `--accent`, donc du contrôle « Pôle ». */
+export const Seule: Story = {}
+
+/**
+ * Les quatre marques, chacune sous son propre `data-pole`.
+ *
+ * C'est l'état qu'on ne peut voir nulle part sur le site : les quatre pôles n'y sont
+ * jamais côte à côte à la même taille. Les traits doivent se lire comme quatre
+ * structures distinctes, et les quatre teintes se distinguer sans lire les noms.
+ */
+export const LesQuatre: Story = {
+  render: () => (
+    <div style={{ alignItems: 'center', display: 'flex', gap: '2.5rem' }}>
+      {POLES.map((pole) => (
+        <div data-pole={pole} key={pole} style={{ textAlign: 'center' }}>
+          <PoleGlyph pole={pole} taille={64} />
+          <p style={{ color: 'var(--encre-douce)', fontSize: '0.8rem' }}>{pole}</p>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+/** L'échelle réelle des usages : de l'étiquette de carte au titre de page de pôle. */
+export const Echelles: Story = {
+  render: () => (
+    <div style={{ alignItems: 'center', display: 'flex', gap: '1.5rem' }}>
+      {[20, 28, 40, 64, 96].map((taille) => (
+        <PoleGlyph key={taille} pole="ia" taille={taille} />
+      ))}
+    </div>
+  ),
+}

--- a/src/components/PoleHero/PoleHero.stories.tsx
+++ b/src/components/PoleHero/PoleHero.stories.tsx
@@ -1,0 +1,45 @@
+// PoleHero.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import type { PoleId } from '@/interfaces/types'
+import { findPole } from '@/services/find-pole'
+import { PoleHero } from '.'
+
+/** Chaque story part du contenu réel du pôle, jointures comprises. */
+function ouverture(id: PoleId) {
+  const { pole, suites } = findPole(id)
+  return { pole, suites }
+}
+
+const meta = {
+  title: 'Poles/PoleHero',
+  component: PoleHero,
+  args: ouverture('data'),
+} satisfies Meta<typeof PoleHero>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le socle : aucune arête entrante, donc pas de bloc de jointure sous l'accroche.
+ *
+ * C'est le seul des quatre dans ce cas, et le rendu doit tenir sans ce paragraphe.
+ */
+export const Socle: Story = {
+  args: ouverture('ingenierie-web'),
+  globals: { pole: 'ingenierie-web' },
+}
+
+/**
+ * Le passage obligé, et le seul qui ouvre sur **deux** suites.
+ *
+ * C'est l'état qui compte : les deux sorties doivent se lire comme parallèles, sans
+ * qu'aucun ordre, numéro ou position ne laisse croire que l'une précède l'autre.
+ */
+export const Passage: Story = { args: ouverture('data'), globals: { pole: 'data' } }
+
+/** Une suite : arête entrante présente, aucune sortie. */
+export const SuiteIA: Story = { args: ouverture('ia'), globals: { pole: 'ia' } }
+
+/** L'autre suite, à la même place dans la chaîne et au même temps. */
+export const SuiteSeaUx: Story = { args: ouverture('sea-ux'), globals: { pole: 'sea-ux' } }

--- a/src/components/PoleStickyBar/PoleStickyBar.stories.tsx
+++ b/src/components/PoleStickyBar/PoleStickyBar.stories.tsx
@@ -1,0 +1,37 @@
+// PoleStickyBar.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { findPole } from '@/services/find-pole'
+import { PoleStickyBar } from '.'
+
+const meta = {
+  title: 'Poles/PoleStickyBar',
+  component: PoleStickyBar,
+  args: { pole: findPole('data').pole },
+} satisfies Meta<typeof PoleStickyBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** La barre du pôle data, teinte comprise. */
+export const Data: Story = { globals: { pole: 'data' } }
+
+/**
+ * Les deux suites côte à côte, chacune sous sa teinte.
+ *
+ * Elles affichent le **même** temps, et c'est voulu : le site ne compte pas ses pôles,
+ * il dit à quel moment de la chaîne ils interviennent. Deux barres portant « 3 » est le
+ * seul endroit où l'on peut vérifier que ce parti pris tient visuellement.
+ */
+export const LesDeuxSuites: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      <div data-pole="ia">
+        <PoleStickyBar pole={findPole('ia').pole} />
+      </div>
+      <div data-pole="sea-ux">
+        <PoleStickyBar pole={findPole('sea-ux').pole} />
+      </div>
+    </div>
+  ),
+}

--- a/src/components/PoleTagList/PoleTagList.stories.tsx
+++ b/src/components/PoleTagList/PoleTagList.stories.tsx
@@ -1,0 +1,46 @@
+// PoleTagList.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { PoleTagList } from '.'
+
+const meta = {
+  title: 'Poles/PoleTagList',
+  component: PoleTagList,
+  args: { legende: 'Pôles concernés', poles: ['data'] },
+} satisfies Meta<typeof PoleTagList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Le cas le plus fréquent sur une fiche de réalisation : un seul pôle. */
+export const UnPole: Story = {}
+
+/**
+ * Deux pôles, dont les deux suites parallèles de la donnée.
+ *
+ * L'ordre d'affichage suit celui de la chaîne, jamais celui du tableau reçu : c'est
+ * `listPoles` qui le tient. Rien ici ne doit laisser lire que l'IA vient après le SEA.
+ */
+export const DeuxPoles: Story = { args: { poles: ['sea-ux', 'ia'] } }
+
+/** Trois pôles : le cas où la ligne d'étiquettes commence à devoir se replier. */
+export const TroisPoles: Story = { args: { poles: ['ingenierie-web', 'data', 'ia'] } }
+
+/**
+ * Les quatre pôles à la fois.
+ *
+ * Aucune fiche n'en porte quatre aujourd'hui, et c'est précisément pourquoi la story
+ * existe : c'est le seul endroit où l'on vérifie que les quatre teintes se distinguent
+ * les unes des autres à cette taille, y compris en thème sombre.
+ */
+export const LesQuatre: Story = {
+  args: { poles: ['ingenierie-web', 'data', 'ia', 'sea-ux'] },
+}
+
+/**
+ * Aucun pôle : le composant ne rend rien du tout, pas même une liste vide.
+ *
+ * Une `<nav>` vide serait annoncée par un lecteur d'écran comme un point de repère sans
+ * contenu. L'aperçu est donc légitimement vide.
+ */
+export const Aucun: Story = { args: { poles: [] } }

--- a/src/components/ProofWall/ProofWall.stories.tsx
+++ b/src/components/ProofWall/ProofWall.stories.tsx
@@ -1,0 +1,37 @@
+// ProofWall.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { PREUVES } from '@/contenu/preuves'
+import { ProofWall } from '.'
+
+const meta = {
+  title: 'Editorial/ProofWall',
+  component: ProofWall,
+  args: { preuves: PREUVES },
+} satisfies Meta<typeof ProofWall>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le mur de preuves au complet, tel qu'il paraît sur l'accueil.
+ *
+ * Les chiffres viennent de `src/contenu/preuves.ts` : aucun n'est écrit ici, et c'est la
+ * règle. Un nombre recopié dans une story finirait par contredire la page.
+ */
+export const Defaut: Story = {}
+
+/**
+ * Une seule tuile, celle qui renvoie vers sa fiche.
+ *
+ * Toutes les preuves n'ont pas de fiche à déplier : le renvoi est optionnel, et la tuile
+ * doit tenir sa hauteur avec comme sans.
+ */
+export const AvecRenvoi: Story = {
+  args: { preuves: PREUVES.filter((preuve) => preuve.fiche !== undefined).slice(0, 1) },
+}
+
+/** Une tuile sans fiche : le cas le plus fréquent. */
+export const SansRenvoi: Story = {
+  args: { preuves: PREUVES.filter((preuve) => preuve.fiche === undefined).slice(0, 1) },
+}

--- a/src/components/RealisationCard/RealisationCard.stories.tsx
+++ b/src/components/RealisationCard/RealisationCard.stories.tsx
@@ -1,0 +1,37 @@
+// RealisationCard.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { listRealisations } from '@/services/find-realisation'
+import { exiger } from '../../../.storybook/jeux-de-donnees'
+import { RealisationCard } from '.'
+
+const AVEC_CHIFFRE = listRealisations().filter((r) => r.chiffre !== undefined)
+const SANS_CHIFFRE = listRealisations().filter((r) => r.chiffre === undefined)
+
+const meta = {
+  title: 'Realisations/RealisationCard',
+  component: RealisationCard,
+  args: { realisation: exiger(listRealisations(), 'réalisation') },
+} satisfies Meta<typeof RealisationCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** La carte telle qu'elle paraît sur l'index des réalisations. */
+export const Defaut: Story = {}
+
+/**
+ * Une fiche qui porte un chiffre.
+ *
+ * Trois fiches seulement sont dans ce cas, et l'accroche de l'accueil se garde bien de
+ * laisser croire le contraire. La carte doit rendre le chiffre lisible sans le
+ * transformer en promesse générale.
+ */
+export const AvecChiffre: Story = {
+  args: { realisation: exiger(AVEC_CHIFFRE, 'réalisation chiffrée') },
+}
+
+/** Une fiche sans chiffre : le cas majoritaire, et il ne doit pas paraître amputé. */
+export const SansChiffre: Story = {
+  args: { realisation: exiger(SANS_CHIFFRE, 'réalisation sans chiffre') },
+}

--- a/src/components/Reveal/Reveal.stories.tsx
+++ b/src/components/Reveal/Reveal.stories.tsx
@@ -1,0 +1,70 @@
+// Reveal.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { Reveal } from '.'
+
+const meta = {
+  title: 'Mouvement/Reveal',
+  component: Reveal,
+  args: {
+    children: (
+      <p style={{ color: 'var(--encre)', fontSize: '1.1rem', maxWidth: '46ch' }}>
+        Le contenu révélé n’est jamais amputé quand l’animation ne joue pas : la révélation porte
+        l’apparition, pas la présence.
+      </p>
+    ),
+  },
+} satisfies Meta<typeof Reveal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le bloc déjà dans le champ de vision au premier rendu.
+ *
+ * Il ne s'anime pas, et c'est la règle : on n'anime que ce qui entre. Un contenu déjà
+ * visible qui se met à bouger au chargement se lit comme un défaut, pas comme une
+ * intention.
+ */
+export const DansLeChamp: Story = {}
+
+/**
+ * Le bloc qui entre par le bas, l'état pour lequel le composant existe.
+ *
+ * Une hauteur est poussée au-dessus de lui pour qu'il commence hors champ : il faut
+ * faire défiler l'aperçu pour voir la révélation, exactement comme sur le site.
+ */
+export const ALEntree: Story = {
+  decorators: [
+    (Story) => (
+      <div>
+        <div style={{ color: 'var(--encre-douce)', height: '110vh' }}>
+          Faire défiler vers le bas.
+        </div>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Le rendu en balise `section`, réservé aux charnières et au fil.
+ *
+ * Ce n'est pas un détail de balisage : le filet qui se trace est un `::before` de la
+ * section, donc ces blocs *sont* leur propre révélation. Le nom accessible passe par
+ * `ariaLabelledBy`, sans quoi la section serait un point de repère anonyme.
+ */
+export const EnSection: Story = {
+  args: {
+    as: 'section',
+    ariaLabelledBy: 'reveal-titre',
+    children: (
+      <>
+        <h2 id="reveal-titre" style={{ color: 'var(--encre)' }}>
+          Une charnière
+        </h2>
+        <p style={{ color: 'var(--encre-douce)' }}>Ce qui passe la main à la suite.</p>
+      </>
+    ),
+  },
+}

--- a/src/components/SiteFooter/SiteFooter.stories.tsx
+++ b/src/components/SiteFooter/SiteFooter.stories.tsx
@@ -1,0 +1,21 @@
+// SiteFooter.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SiteFooter } from '.'
+
+const meta = {
+  title: 'Socle/SiteFooter',
+  component: SiteFooter,
+} satisfies Meta<typeof SiteFooter>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le pied de page, identique sur toutes les pages.
+ *
+ * Il porte le second exemplaire du bouton de mise en pause des animations : c'est le
+ * point d'accès garanti au réglage, celui qu'on atteint sans avoir à remonter en haut de
+ * page. Le vérifier ici évite de le perdre lors d'un remaniement du pied.
+ */
+export const Defaut: Story = {}

--- a/src/components/SiteHeader/SiteHeader.stories.tsx
+++ b/src/components/SiteHeader/SiteHeader.stories.tsx
@@ -1,0 +1,22 @@
+// SiteHeader.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SiteHeader } from '.'
+
+const meta = {
+  title: 'Socle/SiteHeader',
+  component: SiteHeader,
+} satisfies Meta<typeof SiteHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * L'en-tête du site, identique sur toutes les pages.
+ *
+ * Il est rendu hors de tout `data-pole` sur le site : sa couleur est celle de la maison,
+ * le cuivre, quelle que soit la page. Basculer le contrôle « Pôle » le teinte quand
+ * même ici, ce qui n'arrive jamais en production — l'écart est le prix à payer pour
+ * qu'une seule enveloppe serve tout le catalogue.
+ */
+export const Defaut: Story = {}

--- a/src/components/SkipLink/SkipLink.stories.tsx
+++ b/src/components/SkipLink/SkipLink.stories.tsx
@@ -1,0 +1,34 @@
+// SkipLink.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SkipLink } from '.'
+
+const meta = {
+  title: 'Socle/SkipLink',
+  component: SkipLink,
+} satisfies Meta<typeof SkipLink>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le lien d'évitement au repos : hors flux visuel, présent dans le document.
+ *
+ * L'aperçu paraît vide, et c'est l'état correct. Le composant ne se voit qu'au clavier.
+ */
+export const AuRepos: Story = {}
+
+/**
+ * Le même lien, une fois reçu le focus.
+ *
+ * C'est l'état qui compte, et il est presque impossible à observer sur le site : il faut
+ * charger une page et appuyer sur Tab avant tout autre geste. Ici il est simplement posé
+ * à l'écran, ce qui permet de juger son contraste et sa lisibilité dans les deux thèmes.
+ * Le focus est donné après la peinture, sans quoi le navigateur n'a rien à cibler.
+ */
+export const AuClavier: Story = {
+  play: async ({ canvas }) => {
+    const lien = canvas.getByRole('link', { name: 'Aller au contenu' })
+    lien.focus()
+  },
+}

--- a/src/components/SpaceEntries/SpaceEntries.stories.tsx
+++ b/src/components/SpaceEntries/SpaceEntries.stories.tsx
@@ -1,0 +1,21 @@
+// SpaceEntries.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SpaceEntries } from '.'
+
+const meta = {
+  title: 'Editorial/SpaceEntries',
+  component: SpaceEntries,
+} satisfies Meta<typeof SpaceEntries>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Les deux espaces éditoriaux, réalisations et blog.
+ *
+ * Les volumes annoncés sont **dérivés** des listes sources, jamais recopiés : la story
+ * montre donc le compte réel du jour. Si le chiffre affiché ici cesse de correspondre au
+ * nombre de fiches, c'est la dérivation qui est cassée, pas la story.
+ */
+export const Defaut: Story = {}

--- a/src/components/ThreadSection/ThreadSection.stories.tsx
+++ b/src/components/ThreadSection/ThreadSection.stories.tsx
@@ -1,0 +1,24 @@
+// ThreadSection.stories.tsx — jeromemarichez-fr
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SECTION_FIL } from '../../../.storybook/jeux-de-donnees'
+import { ThreadSection } from '.'
+
+const meta = {
+  title: 'Editorial/ThreadSection',
+  component: ThreadSection,
+  args: { section: SECTION_FIL },
+} satisfies Meta<typeof ThreadSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Le fil de la page IA : un axe de méthode qui traverse les pôles.
+ *
+ * Un fil ne reçoit jamais le verre — le vitrer en ferait une offre de plus, alors qu'il
+ * décrit la façon de tenir les autres. Les rangs affichés en tête d'étape sont
+ * décoratifs : la numérotation appartient au `<ol>`, et l'annoncer deux fois ferait
+ * entendre « un un » à un lecteur d'écran.
+ */
+export const Defaut: Story = {}


### PR DESCRIPTION
Storybook était annoncé par le dépôt et installé nulle part : `make storybook` échouait
sur un script npm inexistant, `docs/storybook.md` portait encore son `TODO`, et aucun
fichier `*.stories.tsx` n'existait. Cette PR l'installe réellement et le relie aux
composants. Refs #140.

## Ce qui est installé

| Paquet | Version | Rôle |
|--------|---------|------|
| `storybook` | ^10.5.10 | le noyau et la ligne de commande |
| `@storybook/nextjs-vite` | ^10.5.10 | le framework, seul à résoudre `next/font`, `next/image` et `next/link` hors d'un serveur Next |
| `vite` | ^8.2.2 | le bundler dont dépend le framework |

Les trois sont en **`devDependencies`**. `package.json` ne gagne **aucune** dépendance de
production : le bloc `dependencies` reste `next`, `react`, `react-dom`, `zod`.

Scripts npm ajoutés : `storybook` et `build-storybook`. Les deux cibles `make` existaient
déjà et fonctionnent enfin.

## Comment les jetons, les thèmes et les quatre teintes sont chargés

**Les jetons.** Aucun composant du dépôt ne porte de couleur en dur : ils consomment des
jetons déclarés dans quatre feuilles globales. `.storybook/preview.tsx` importe
`globals.css`, `poles.css`, `verre.css` puis `lavis.css` **dans l'ordre exact de
`src/app/layout.tsx`**, pose `FONT_VARIABLES` sur l'enveloppe, et rend le fond d'atelier
et le filtre de réfraction comme la mise en page racine les rend.

L'enveloppe ne peint **aucun fond**, et c'est le détail qui décide du résultat :
`.fond-atelier` porte `z-index: -1`, donc un fond posé sur l'enveloppe passerait
par-dessus lui, et le verre n'aurait plus aucune trame à laisser voir. Le fond vient de
`globals.css`, qui le pose sur le `<body>` d'où il se propage au canevas, exactement
comme sur le site.

**Les thèmes.** Le site n'a pas de bascule : son thème sombre tient dans quatre règles
`@media (prefers-color-scheme: dark)`. Un contrôle de barre d'outils réécrit au runtime
le `mediaText` de ces règles via le CSSOM (`.storybook/theme-media.ts`) : `all` pour
forcer le sombre, `not all` pour forcer le clair, la valeur d'origine pour « auto ».
Aucun jeton dupliqué, aucun fichier du site modifié.

**Les quatre teintes.** Un second contrôle pose `data-pole` sur l'enveloppe, `poles.css`
faisant le reste, comme une section de pôle sur le site.

Mesuré au navigateur sur une même story, quinze combinaisons :

| Thème | Fond mesuré | `--accent` par pôle |
|-------|-------------|---------------------|
| clair | `rgb(242, 239, 232)` | cuivre `#8f4520`, data `#00697b`, ia `#674d91`, sea-ux `#48691d` |
| sombre | `rgb(14, 17, 20)` | cuivre `#e08b4c`, data `#01b6d4`, ia `#af8fe8`, sea-ux `#87b357` |
| auto | suit le système | idem |

Les 79 stories ont été passées en revue au navigateur : **aucune erreur de page**, et
toutes rendent avec la palette du site, aucune en gris.

## Les stories

**31 composants sur 34** ont une story, colocalisée avec eux. 79 stories au total. Elles
sont alimentées par le contenu réel du site (`src/contenu/`), jamais par des données
inventées.

| Groupe | Composants |
|--------|------------|
| Socle | `SiteHeader`, `SiteFooter`, `SkipLink`, `Breadcrumb` |
| Verre | `GlassSurface` |
| Mouvement | `MotionToggle`, `Reveal` |
| Pôles | `PoleGlyph`, `PoleHero`, `PoleTagList`, `PoleStickyBar`, `PoleEntries`, `ChainDiagram` |
| Éditorial | `EditorialSection`, `HingeSection`, `ThreadSection`, `HingeNote`, `ExpertiseBlock`, `BoundaryList`, `ProofWall`, `CertificationList`, `SpaceEntries` |
| Accueil | `HomeHero`, `ChainCanvas` |
| Blog | `ArticleCard`, `ArticleFigure`, `ArticleSource` |
| Réalisations | `RealisationCard`, `EmploymentFrame` |
| Contact | `ContactField`, `ContactForm` |

La priorité est allée aux états qu'on ne peut pas atteindre en naviguant : les trois
refus du formulaire de contact (envoi vide, saisie trop courte, URL `mailto:` trop
longue), chacun joué par un `play` ; le lien d'évitement au focus ; les cinq figures
d'article et les quatre marques de pôle côte à côte ; le verre en clair et en sombre.

### Les trois exclusions, et leur raison

| Composant | Pourquoi pas de story |
|-----------|-----------------------|
| `StructuredData` | N'émet que du JSON-LD dans un `<script>`. Aucun rendu visuel : une story vide vaudrait moins que la raison écrite de son absence. |
| `MotionState` | Rend `null`. Son seul effet est un attribut posé sur `<html>`, que le CSS lit. Rien à montrer. |
| `GlassRefraction` | Filtre SVG inerte, invisible par lui-même. L'enveloppe des stories le rend déjà partout, et c'est dans `GlassSurface` que son effet se juge. |

`MagneticAction` n'apparaît nulle part : il a été supprimé du dépôt.

## Le coût, mesuré

Poids du JavaScript envoyé au navigateur, mesuré sur l'export statique avant et après
l'installation, scripts du HTML dédupliqués, compression brotli :

| Page | Avant | Après |
|------|-------|-------|
| accueil `/` | 10 scripts, 603,0 Kio brut, **161,7 Kio brotli** | 10 scripts, 603,0 Kio brut, **161,7 Kio brotli** |
| `/services/ia/` | 9 scripts, 563,4 Kio brut, **150,4 Kio brotli** | 9 scripts, 563,4 Kio brut, **150,4 Kio brotli** |

Identique au trait près, ce qui est attendu : rien de Storybook n'entre dans
`next build`. L'export statique est intact (`output: 'export'`, 7 pages plus les fiches
générées).

### Budgets

`node scripts/budgets.mjs`, 7 pages, 4 catégories :

| Page | Perf | A11y | Bonnes prat. | SEO |
|------|------|------|--------------|-----|
| accueil | 95 | 100 | 100 | 100 |
| pole-ingenierie-web | 96 | 100 | 100 | 100 |
| blog | 97 | 100 | 100 | 100 |
| article | 97 | 100 | 100 | 100 |
| article-avec-source | 97 | 100 | 100 | 100 |
| realisations | 97 | 100 | 100 | 100 |
| realisation | 97 | 100 | 100 | 100 |

Toutes >= 95. axe-core : 0 violation sur les 7 pages.

## Contrôles

- `make lint` vert, `make test` vert, `make type-check` vert, `npm run build` vert.
- `make storybook` démarre le catalogue sur le port 6006, `make storybook-build` produit
  le build statique, tous deux sans erreur.
- La limite de 300 lignes s'applique aux stories : aucune ne la dépasse.
- `storybook-static/` était déjà dans `.gitignore` ; il rejoint les sorties de build
  écartées de Biome et de `check-max-lines.sh`. **Ce sont des fichiers générés, pas du
  code du dépôt : aucun contrôle sur le code n'est assoupli.**

### Un job de CI en plus

`ci-dev-storybook` construit le catalogue à chaque PR vers `dev`. C'est un **ajout**, et
il a une raison datée : le dépôt a annoncé Storybook pendant des mois sans l'avoir
installé, parce que rien ne le construisait. Une story qui référencera demain un
composant supprimé ou une prop renommée fera échouer la PR, au lieu d'attendre qu'un
développeur ouvre le catalogue.

## Documentation

- `docs/storybook.md` : le `TODO` disparaît. Le fichier décrit l'installation réelle, la
  mécanique des jetons, des thèmes et des teintes, les conventions, la liste des
  composants couverts et les trois exclusions motivées.
- `README.md` : une section « Catalogue de composants » avec les deux commandes.
- `docs/tooling.md` : Storybook décrit comme installé et en service.
- `docs/ci-cd.md` : le nouveau job listé et motivé.

Textes relus par un second agent sans contexte de rédaction, comme le prescrit le
`CLAUDE.md`.

## Note

`Closes #140` n'est pas écrit : cette PR vise `dev`, la branche par défaut est `main`,
et la fermeture automatique ne fonctionnerait pas. L'issue se ferme à la main.
